### PR TITLE
:memo: Versionner la stack IA — context-packs BR + config ai-env

### DIFF
--- a/.ai-env/config.yaml
+++ b/.ai-env/config.yaml
@@ -1,0 +1,76 @@
+# .ai-env/config.yaml — configuration RUNTIME du Layer A (plugin ai-env).
+# Généré par /ai-env:setup pour MyTimeline.
+
+# --- Identité ---
+project_name: "MyTimeline"
+github_org: "LeenVandelied"
+github_repo: "MyTimeline"
+
+# --- Architecture backend ---
+architecture: "hexagonal"
+backend_language: "java"
+backend_package_root: "com.matimeline.eventmanager"
+
+# Imports INTERDITS dans domain/ (Spring Boot)
+domain_forbidden_import_prefixes: "org.springframework., jakarta.persistence., javax."
+# Exceptions tolérées dans domain/ (validation annotations)
+domain_allowed_import_prefixes: "jakarta.validation"
+# Imports INTERDITS dans application/
+application_forbidden_import_prefixes: "io.micrometer."
+
+# --- Modèles : ALIAS uniquement, jamais de version figée ---
+model_lead: "opus"
+model_worker: "sonnet"
+model_lightweight: "haiku"
+
+# --- Locale ---
+locale_code: "fr"
+
+# --- Logs PII (hook check-pii-logs) ---
+pii_scope_path_globs: "/infrastructure/security/, /application/, /domain/models/"
+pii_field_names: "userId, email, password"
+pii_substring_patterns: "user.getId(), .getMessage()"
+pii_masking_markers: "maskId(, maskEmail("
+
+# --- Frontend / lint ---
+frontend_dir: "frontend"
+frontend_src: "frontend/src"
+format_command: "npx eslint --fix"
+format_extensions: ".ts, .tsx, .js, .jsx"
+
+# --- Moteur JIT : domaines ---
+domains: "events, auth, products, categories"
+domain_events_keywords: "event|calendar|timeline|schedule|date|jalons"
+domain_events_paths: "/events?/|/calendar/|/event"
+domain_events_labels: "epic:events"
+domain_auth_keywords: "auth|login|register|jwt|token|password|user|role|security"
+domain_auth_paths: "/auth/|/security/|/user/|/register|/login"
+domain_auth_labels: "epic:auth"
+domain_products_keywords: "product|produit|catalogue|catalog|item|price|prix"
+domain_products_paths: "/products?/|/catalogue/"
+domain_products_labels: "epic:products"
+domain_categories_keywords: "categor|tag|label|classification"
+domain_categories_paths: "/categor/"
+domain_categories_labels: "epic:categories"
+
+# Répertoires Layer B
+packs_dir: ".ai-env/context-packs"
+rules_jit_dir: ".ai-env/rules-jit"
+
+# Mapping stack -> packs/règles
+stack_packs_backend: "cp-hexagonal, cp-backend"
+stack_packs_frontend: "cp-frontend"
+stack_rules_backend: "backend"
+stack_rules_frontend: "frontend"
+
+# --- Review d'intention ---
+tracker_provider: "github"
+intent_exploration_agent: "domain-researcher"
+intent_rule_notation: ""
+
+# --- Hooks de protection ---
+protected_tables: ""
+migrations_dir: ""
+schemas_dir: ""
+backend_src: "backend/src"
+heavy_test_commands: "mvn test, mvn verify, npx playwright test"

--- a/.ai-env/context-packs/br-auth.md
+++ b/.ai-env/context-packs/br-auth.md
@@ -1,0 +1,156 @@
+# Context-pack domaine : `auth`
+
+> Domaine : `auth` — inscription, authentification JWT (cookie HttpOnly + Bearer), session courante et refresh de token pour les utilisateurs MyTimeline.
+> Acteurs principaux : `anonymous` (visiteur non authentifié), `ROLE_USER` (utilisateur authentifié), `ROLE_ADMIN` (déclaré mais inutilisé), `system` (filtre JWT, refresh périodique frontend).
+
+---
+
+## 1. Lifecycles (machines à états)
+
+### Entité `User`
+
+CRUD simple côté persistance — **pas de lifecycle d'état métier** sur `User` (aucun champ `status`/`state`, pas de soft-delete, pas d'activation/désactivation). Le seul cycle réel est celui de la **session JWT**, porté par le cookie `jwt`, non par l'entité.
+
+### Session JWT (état dérivé du token, non persisté)
+
+| Etat | Description | Transitions sortantes |
+|------|-------------|-----------------------|
+| `ANONYME` | Aucun cookie `jwt` / pas de Bearer | → `AUTHENTIFIÉ` via `POST /login` (succès) ou `POST /register` puis login |
+| `AUTHENTIFIÉ` | Token valide présent (cookie ou header), `validateToken` OK | → `EXPIRÉ` après MaxAge (2 jours) ; → `ANONYME` via `POST /logout` ; → `AUTHENTIFIÉ` (renouvelé) via `POST /refresh` |
+| `EXPIRÉ` | `ExpiredJwtException` levée à l'extraction | → devrait forcer `ANONYME` ; ⚠️ `POST /refresh` ré-émet un token sans bloquer l'expiré (voir BR-AUT-009) |
+
+> ⚠️ `CustomUserDetails.isAccountNonExpired / isAccountNonLocked / isCredentialsNonExpired / isEnabled` renvoient tous `true` en dur (commentaire `need to implement logic`). Aucun verrouillage / désactivation de compte n'existe.
+
+---
+
+## 2. Actions x Acteurs
+
+| Action | anonymous | ROLE_USER | ROLE_ADMIN | system | Notes |
+|--------|:--------:|:---------:|:----------:|:------:|-------|
+| `POST /api/auth/register` | ✅ | ✅ | ✅ | — | `permitAll`, rôle forcé `ROLE_USER` (BR-AUT-006) |
+| `POST /api/auth/login` | ✅ | ✅ | ✅ | — | `permitAll`, pose cookie + renvoie JWT brut en body (BR-AUT-007) |
+| `POST /api/auth/logout` | ✅ | ✅ | ✅ | — | `permitAll`, efface cookie (MaxAge=0) |
+| `POST /api/auth/refresh` | ⚠️ | ✅ | ✅ | ✅ (toutes les 6h frontend) | `permitAll`, ne vérifie pas l'expiration (BR-AUT-009) |
+| `GET /api/auth/me` | ❌ | ✅ | ✅ | — | `permitAll` mais exige cookie `jwt` ; ⚠️ renvoie l'objet `User` domaine avec mot de passe hashé (BR-AUT-008) |
+| Accès `/api/users/**`, `/api/products/**`, `/api/events/**` | ❌ | ✅ | ✅ | — | exige token valide (JwtFilter) |
+| Endpoints `hasAuthority('ROLE_ADMIN')` | ❌ | ❌ | ❌ | — | ⚠️ rôle ADMIN mort, aucun endpoint ne l'utilise |
+
+---
+
+## 3. Business Rules atomiques
+
+### BR-AUT-001 — Unicité du username à l'inscription
+**Règle** : Le `system` MUST refuser un `register` quand un `User` avec le même `username` existe déjà (réponse `409 CONFLICT`).
+**Pourquoi** : Le username est l'identifiant de connexion ; un doublon rendrait l'authentification ambiguë.
+**Implémentation** : `AuthController.register` (l.106-110) via `userService.findDomainUserByUsername`.
+**Test attendu** : `AuthControllerTest#register_shouldReturn409_whenUsernameAlreadyExists`.
+> ⚠️ **NON IMPLÉMENTÉ au niveau DB** : `UserEntity` n'a pas de `@Column(unique=true)` sur `username` → doublon possible en cas de course concurrente (check applicatif seul, non atomique). `email` n'a aucun contrôle d'unicité ni applicatif ni DB.
+
+### BR-AUT-002 — Hachage du mot de passe avant persistance
+**Règle** : Le `system` MUST hacher le mot de passe (BCrypt) avant de construire et persister le `User`.
+**Pourquoi** : Aucun mot de passe en clair ne doit être stocké.
+**Implémentation** : `AuthController.register` (l.112) `passwordEncoder.encode(...)`.
+**Test attendu** : `AuthControllerTest#register_shouldStoreBcryptHash_notPlaintext`.
+
+### BR-AUT-003 — Validation des champs d'inscription
+**Règle** : Le `system` MUST rejeter un `register` dont `name`/`username` ne font pas 3..20 caractères, `email` non valide, ou `password` < 6 caractères.
+**Pourquoi** : Garantir des credentials exploitables et un email correct.
+**Implémentation** : annotations Bean Validation sur `RegisterRequest` (`@NotBlank`, `@Size(min=3,max=20)`, `@Email`, `@Size(min=6)`).
+**Test attendu** : `AuthControllerTest#register_shouldReturn400_whenPasswordTooShort`.
+> ⚠️ **NON IMPLÉMENTÉ (code mort)** : `@Valid` ABSENT sur `@RequestBody RegisterRequest` (`AuthController.register` l.104). Toutes les annotations de `RegisterRequest` ne sont JAMAIS déclenchées → aucune validation serveur. Côté frontend, `RegisterData` n'a pas de schéma Zod → aucune validation client non plus. **Fix attendu : ajouter `@Valid`.**
+
+### BR-AUT-004 — Validation des credentials de login
+**Règle** : Le `system` MUST rejeter un `login` dont `username` < 3 ou `password` < 6 caractères.
+**Pourquoi** : Cohérence avec les contraintes d'inscription, éviter des requêtes d'auth triviales.
+**Implémentation** : `AuthRequest` côté backend ; `LoginSchema` Zod côté frontend (`username z.string().min(3)`, `password z.string().min(6)`).
+**Test attendu** : `AuthControllerTest#login_shouldReject_whenUsernameTooShort`.
+> ⚠️ **NON IMPLÉMENTÉ côté backend** : `AuthRequest` ne porte AUCUNE annotation de validation et `@Valid` est absent. Seul le frontend (Zod) contraint ces champs.
+
+### BR-AUT-005 — Échec d'authentification → 401, jamais de fuite interne
+**Règle** : Le `system` MUST renvoyer `401 UNAUTHORIZED` (`"Invalid username or password"`) sur mauvais credentials et NE MUST PAS exposer de détail interne d'exception.
+**Pourquoi** : Ne pas divulguer si l'utilisateur existe ; éviter la fuite de stack trace.
+**Implémentation** : `AuthController.login` (l.68-72), délégation à `AuthenticationManager`, catch `BadCredentialsException`.
+**Test attendu** : `AuthControllerTest#login_shouldReturn401_onBadCredentials`.
+> ⚠️ **VIOLATION** : le `catch (Exception e)` (l.71) renvoie `ResponseEntity.status(500).body(e)` — l'objet exception est sérialisé dans le body → fuite potentielle d'informations internes. **À corriger.**
+
+### BR-AUT-006 — Rôle forcé à `ROLE_USER` à l'inscription
+**Règle** : Le `system` MUST assigner `ROLE_USER` à tout nouvel utilisateur ; un `anonymous` NE MUST PAS pouvoir choisir son rôle.
+**Pourquoi** : Empêcher l'auto-élévation de privilèges (ex. s'inscrire en ADMIN).
+**Implémentation** : `AuthController.register` (l.119) — littéral String `"ROLE_USER"`.
+**Test attendu** : `AuthControllerTest#register_shouldAlwaysAssignRoleUser`.
+> ⚠️ Le rôle est un `String` brut (pas l'enum `Role`). L'enum `Role(USER, ADMIN)` existe mais n'est jamais utilisée pour la persistance ni le typage → pas de type safety, pas de contrainte DB.
+
+### BR-AUT-007 — Émission du token et cookie HttpOnly au login
+**Règle** : Au login réussi, le `system` MUST poser un cookie `jwt` HttpOnly, `Path=/`, `SameSite=Lax`, MaxAge 2 jours, contenant les authorities en claim `role`.
+**Pourquoi** : Session navigateur protégée contre l'accès JS (XSS).
+**Implémentation** : `AuthController.login` (l.56-66) ; `JwtService.generateToken(Authentication)` embarque les authorities.
+**Test attendu** : `AuthControllerTest#login_shouldSetHttpOnlyJwtCookie`.
+> ⚠️ **VIOLATIONS** : (a) le JWT brut est aussi renvoyé dans le body (l.67) → double exposition du token, annule l'intérêt du HttpOnly ; (b) `Secure=false` en dur (l.60) → token transmis en clair hors HTTPS ; (c) `domain="localhost"` en dur (l.63) → casse tout déploiement non-localhost.
+
+### BR-AUT-008 — `/me` retourne l'utilisateur courant sans secret
+**Règle** : `GET /me` MUST renvoyer les données de l'utilisateur identifié par le token et NE MUST PAS exposer le mot de passe (même hashé).
+**Pourquoi** : Un hash ne doit jamais transiter par l'API (risque de cassage offline, surface inutile).
+**Implémentation** : `AuthController.getUserDetails` (l.75-101) — extrait username, `validateToken`, renvoie l'utilisateur.
+**Test attendu** : `AuthControllerTest#me_shouldNotExposePasswordHash`.
+> ⚠️ **VIOLATION CRITIQUE** : l.93 renvoie directement l'objet domaine `User.get()` → le champ `password` (hash) est sérialisé dans la réponse HTTP. **Fix attendu : projection / DTO sans password.**
+
+### BR-AUT-009 — Refresh exige un token encore valide
+**Règle** : `POST /refresh` MUST vérifier que le token courant est valide (non expiré) avant d'émettre un nouveau token, sinon `401`.
+**Pourquoi** : Un token expiré ne doit pas pouvoir prolonger indéfiniment une session.
+**Implémentation** : `AuthController.refreshToken` (l.147-185).
+**Test attendu** : `AuthControllerTest#refresh_shouldReturn401_whenTokenExpired`.
+> ⚠️ **NON IMPLÉMENTÉ** : aucune vérification de validité/expiration avant `generateToken` (l.168). `ExpiredJwtException` n'est attrapée que si `extractUsername` échoue ; un token techniquement parsable mais expiré peut être renouvelé silencieusement. **À corriger.**
+
+### BR-AUT-010 — Logout invalide la session navigateur
+**Règle** : `POST /logout` MUST effacer le cookie `jwt` (MaxAge=0) pour terminer la session côté navigateur.
+**Pourquoi** : Permettre la déconnexion explicite.
+**Implémentation** : `AuthController.logout` (l.131-145).
+**Test attendu** : `AuthControllerTest#logout_shouldExpireJwtCookie`.
+> ⚠️ Incohérence de config : le cookie de logout est `Secure=true` (l.136) alors que login/refresh posent `Secure=false` (l.60/172) → attributs asymétriques, l'effacement peut ne pas matcher le cookie posé selon le navigateur. JWT non révoqué côté serveur (stateless) : le token reste valide jusqu'à expiration si déjà capturé.
+
+### BR-AUT-011 — JwtFilter accepte cookie OU Bearer et bypass /api/auth/**
+**Règle** : Le `system` (JwtFilter) MUST authentifier les requêtes via le cookie `jwt` OU l'en-tête `Authorization: Bearer`, et NE MUST PAS filtrer les routes `/api/auth/**`.
+**Pourquoi** : Permettre login/register sans token tout en protégeant le reste de l'API.
+**Implémentation** : `JwtFilter.shouldNotFilter` (bypass `/api/auth/**`) + lecture cookie/Bearer.
+**Test attendu** : `JwtFilterTest#shouldAuthenticate_fromCookieOrBearer` / `shouldSkip_authPaths`.
+
+---
+
+## 4. Dépendances inter-domaines
+
+- **Aucune relation JPA** : `UserEntity` est une table `users` autonome (pas de `@OneToMany`/`@ManyToOne`).
+- **Dépendances logiques sortantes** : `users`, `products`, `events` exigent un `User` authentifié (`ROLE_USER`) via JwtFilter — le domaine `auth` est producteur de l'identité consommée par ces domaines (notamment `userId` dans `/api/users/{userId}/products/**`).
+- **Couplage infrastructure (à surveiller)** : `AuthController` importe et injecte des classes infra (`UserServiceImpl` concret, `JwtService`, `CustomUserDetailsService`, `CustomUserDetails`) — voir anti-patterns.
+- **Frontend** : `useAuth` (state d'auth, localStorage) et `apiClient` (intercepteur axios 401/403 → redirect `/login`, refresh périodique) dépendent des contrats de ce domaine.
+
+---
+
+## 5. Anti-patterns documentés
+
+| # | Anti-pattern | Localisation | Gravité |
+|---|--------------|--------------|:-------:|
+| A1 | `/me` renvoie l'objet domaine `User` → hash de mot de passe exposé en HTTP | `AuthController` l.93 | CRITIQUE |
+| A2 | `@Valid` absent sur `@RequestBody RegisterRequest` → toutes les Bean Validations sont du code mort | `AuthController` l.104 | CRITIQUE |
+| A3 | JWT brut renvoyé dans le body du login en plus du cookie HttpOnly → double exposition | `AuthController` l.67 | HAUTE |
+| A4 | `catch (Exception)` renvoie l'objet exception dans le body (500) → fuite d'internes | `AuthController` l.71 | HAUTE |
+| A5 | `refresh` n'invalide pas un token expiré avant ré-émission | `AuthController` l.148-185 | HAUTE |
+| A6 | `Secure=false` en dur au login/refresh, `Secure=true` au logout → config asymétrique, token en clair hors HTTPS | l.60 / 172 / 136 | HAUTE |
+| A7 | `domain="localhost"` en dur → casse tout déploiement non-localhost | l.63 / 175 | HAUTE |
+| A8 | `AuthController` injecte `UserServiceImpl` concret + importe classes infra → viole hexagonal/DIP | l.24-28, 38 | MOYENNE |
+| A9 | `role` stocké en `String` (domaine + entité) ; enum `Role` inutilisée → pas de type safety ni contrainte DB | `UserEntity`, `User` | MOYENNE |
+| A10 | `UserEntity` sans `@Column(unique=true)` ni contraintes (nullable, length) → doublons username/email possibles, VARCHAR(255) nullable par défaut | `UserEntity` | MOYENNE |
+| A11 | `useAuth.register` passe `username` comme `name` ET premier argument → le champ `name` vaut toujours `username`, l'input `name` réel est ignoré | `useAuth.ts` l.54 | MOYENNE |
+| A12 | `RegisterData` sans schéma Zod → aucune validation client à l'inscription | frontend register flow | MOYENNE |
+| A13 | Refresh périodique via `setInterval` (6h) au chargement du module, sans cleanup ni vérif d'auth réelle | `apiClient.ts` l.22 | BASSE |
+| A14 | `CustomUserDetails` : `isAccountNonExpired/NonLocked/CredentialsNonExpired/isEnabled` renvoient `true` en dur (`need to implement logic`) | `CustomUserDetails` | BASSE |
+| A15 | `UserServiceImpl.updateUser` sans `@Transactional` (alors que `createUser` l'a) | `UserServiceImpl` | BASSE |
+| A16 | Enum `Role.ADMIN` jamais référencée par un `hasAuthority` → rôle ADMIN mort | sécurité globale | BASSE |
+| A17 | `useAuth` lit l'utilisateur depuis `localStorage` au montage sans vérification serveur | `useAuth.ts` | BASSE |
+
+---
+
+## Référence
+
+- Coverage actuelle : `coverage-auth.md`
+- Backend : `backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/AuthController.java` (+ `application/dtos/RegisterRequest.java`, `AuthRequest.java`, `infrastructure/entities/UserEntity.java`, `infrastructure/security/{JwtService,JwtFilter,CustomUserDetails,CustomUserDetailsService}.java`, `domain/models/User.java`, `domain/models/Role.java`)
+- Frontend : `frontend/src/hooks/useAuth.ts`, `frontend/src/services/apiClient.ts` (+ schémas Zod `LoginSchema`, `UserSchema`)

--- a/.ai-env/context-packs/br-categories.md
+++ b/.ai-env/context-packs/br-categories.md
@@ -1,0 +1,107 @@
+# Context-pack domaine : `categories`
+
+> Domaine : `categories` — référentiel de classification des produits (value object `id` + `name`), exposé en CRUD REST sans logique d'état métier.
+> Acteurs principaux : `user` (tout utilisateur authentifié ROLE_USER). Aucun `admin` distinct n'existe pour ce domaine.
+
+---
+
+## 1. Lifecycles (machines à états)
+
+### Entité : `Category`
+
+CRUD simple — pas de lifecycle d'état.
+
+`Category` est un value object pur (`id: UUID`, `name: String`, cf. `domain/models/Category.java`). Aucun champ de statut, pas de soft delete : `deleteCategory` appelle `deleteById` (suppression physique, cf. `CategoryServiceImpl:65`). Pas de transition d'état à modéliser.
+
+---
+
+## 2. Actions x Acteurs
+
+| Action | `user` (ROLE_USER) | `admin` | `system` | Notes |
+|---|---|---|---|---|
+| Créer une catégorie (`POST /api/categories`) | ✅ | n/a | ❌ | Aucun garde admin — fallthrough `.anyRequest().authenticated()` (`SecurityConfig`) |
+| Lister les catégories (`GET /api/categories`) | ✅ | n/a | ❌ | Retourne `List<Category>` brut |
+| Lire une catégorie (`GET /api/categories/{id}`) | ✅ | n/a | ❌ | 404 si absente |
+| Supprimer une catégorie (`DELETE /api/categories/{id}`) | ✅ | n/a | ❌ | Suppression physique, pas de soft delete |
+| Modifier une catégorie (`PUT/PATCH`) | ❌ | ❌ | ❌ | ⚠️ Aucun endpoint exposé — `updateCategory` implémenté mais mort (cf. BR-CAT-006) |
+| Utilisateur anonyme | ❌ | ❌ | ❌ | Bloqué par `.anyRequest().authenticated()` |
+
+> Aucune distinction `ROLE_ADMIN` dans `SecurityConfig` pour `/api/categories/**` : tout utilisateur authentifié est l'unique acteur. Colonne `admin` = n/a.
+
+---
+
+## 3. Business Rules atomiques
+
+### BR-CAT-001 — Nom de catégorie obligatoire (⚠️ NON IMPLÉMENTÉ)
+**Règle** : Le `name` d'une `Category` MUST NOT être null ou vide à la création.
+**Pourquoi** : Une catégorie sans nom est inexploitable côté UI et côté classification produit.
+**Implémentation** : ⚠️ NON IMPLÉMENTÉ. Aucune annotation Bean Validation sur `Category.java` ni `CategoryEntity.java` (`name` sans `@NotBlank`, `@Column(nullable=false)`). La colonne `name` est nullable au niveau JPA. Aucun `@Valid` sur le `@RequestBody` du `CategoryController`.
+**Test attendu** : `CategoryControllerTest` — `POST /api/categories` avec `name` vide/null doit renvoyer 400 (après ajout de `@NotBlank` + `@Valid`).
+
+### BR-CAT-002 — Suppression d'une catégorie inexistante rejetée
+**Règle** : Supprimer une catégorie dont l'`id` n'existe pas MUST lever `CategoryNotFoundException`.
+**Pourquoi** : Éviter une suppression silencieuse no-op et signaler 404 au client.
+**Implémentation** : `CategoryServiceImpl.deleteCategory:62` — `if (!existsById(id)) throw new CategoryNotFoundException(id)`. Le contrôleur double-check également (`CategoryController:48`), voir AP-CAT-04.
+**Test attendu** : `CategoryServiceImplTest` — `deleteCategory(unknownId)` lève `CategoryNotFoundException` ; `CategoryControllerTest` — `DELETE /{id}` inconnu renvoie 404.
+
+### BR-CAT-003 — Mise à jour d'une catégorie inexistante rejetée
+**Règle** : Mettre à jour une catégorie dont l'`id` n'existe pas MUST lever `CategoryNotFoundException`.
+**Pourquoi** : Empêcher un `save` de créer accidentellement une entité via un upsert sur un id fourni.
+**Implémentation** : `CategoryServiceImpl.updateCategory:35` — `if (!existsById(category.getId())) throw`. ⚠️ Règle non atteignable via l'API : aucun endpoint n'expose `updateCategory` (cf. BR-CAT-006).
+**Test attendu** : `CategoryServiceImplTest` — `updateCategory(categoryWithUnknownId)` lève `CategoryNotFoundException`.
+
+### BR-CAT-004 — Unicité du nom de catégorie (⚠️ NON IMPLÉMENTÉ)
+**Règle** : Deux catégories MUST NOT partager le même `name`.
+**Pourquoi** : `findDomainCategoryByName` ne renvoie que le premier résultat ; des doublons rendent la résolution par nom non déterministe.
+**Implémentation** : ⚠️ NON IMPLÉMENTÉ. Pas de `@Column(unique=true)` sur `name` (`CategoryEntity:13`), pas de check d'unicité dans `CategoryServiceImpl.createCategory:28-29` avant `save`. `CategoryRepositoryJpaImpl.findDomainCategoryByName:40-52` fait `getResultList()` et retourne `results.get(0)` silencieusement si plusieurs lignes partagent le nom.
+**Test attendu** : `CategoryServiceImplTest` — créer deux catégories de même nom doit lever une exception métier (après ajout du check + contrainte UNIQUE).
+
+### BR-CAT-005 — Catégorie requise et référençable côté produit
+**Règle** : Un `Product` MUST référencer une `Category` existante via un `id` UUID valide ; la FK `category_id` est NOT NULL en base.
+**Pourquoi** : `ProductEntity.category` est `@ManyToOne @JoinColumn(name='category_id', nullable=false)` — un produit sans catégorie est invalide au niveau DB.
+**Implémentation** : Côté écriture, `productCreateSchema` (`frontend/src/types/product.ts:18`) valide `category: z.string().uuid('La catégorie est requise')` (format UUID uniquement, pas d'existence). Côté lecture, `productSchema` (`product.ts:7-10`) attend `category: { id, name }` sans `.uuid()`. ⚠️ Aucune validation backend que l'UUID correspond à une catégorie réelle au moment de la création produit.
+**Test attendu** : test d'intégration produit — créer un produit avec `category` UUID inconnu doit échouer proprement (404/400), pas une violation FK brute.
+
+### BR-CAT-006 — Endpoint de mise à jour absent (⚠️ NON IMPLÉMENTÉ)
+**Règle** : La modification d'une catégorie via l'API MUST être possible (`PUT`/`PATCH /api/categories/{id}`).
+**Pourquoi** : `CategoryServiceImpl.updateCategory:34-39` est entièrement implémenté mais aucun handler du `CategoryController` ne l'expose — méthode de service morte, mise à jour impossible via API.
+**Implémentation** : ⚠️ NON IMPLÉMENTÉ côté contrôleur. `CategoryController` n'a que `POST`, `GET`, `GET/{id}`, `DELETE/{id}`.
+**Test attendu** : `CategoryControllerTest` — `PUT /api/categories/{id}` met à jour le `name` et renvoie 200 (après exposition de l'endpoint avec request/response DTO).
+
+### BR-CAT-007 — Chargement dynamique des catégories côté UI (⚠️ NON IMPLÉMENTÉ)
+**Règle** : Le formulaire de création produit MUST charger les catégories depuis `GET /api/categories`, pas via des valeurs codées en dur.
+**Pourquoi** : `AddProducts.tsx:172-184` contient 4 UUID de catégorie littéraux dans le JSX ; le formulaire casse dès que la base est seedée différemment selon l'environnement.
+**Implémentation** : ⚠️ NON IMPLÉMENTÉ. `AddProducts.tsx` court-circuite `GET /api/categories`.
+**Test attendu** : test de composant `AddProducts` — le select de catégorie est peuplé depuis un fetch mocké de `GET /api/categories`, sans UUID en dur.
+
+---
+
+## 4. Dépendances inter-domaines
+
+- **`products` dépend de `categories`** : `CategoryEntity -> ProductEntity` en `OneToMany` (côté inverse), `ProductEntity.category` en `@ManyToOne @JoinColumn(name='category_id', nullable=false)`. FK requise en base, mais **aucun cascade** côté `Category` : supprimer une catégorie référencée par des produits provoque une violation de contrainte FK (suppression physique non protégée — voir AP-CAT-05).
+- **`categories` dépend de `auth`** : tout accès passe par le fallthrough `.anyRequest().authenticated()` (JWT ROLE_USER). Pas de notion de propriétaire (`ownerId`) sur `Category` — c'est un référentiel partagé.
+- **`Category` (domain model)** : value object pur `id` + `name`, sans champ de relation. Le lien vers les produits n'existe qu'au niveau infrastructure (`CategoryEntity`/`ProductEntity`).
+
+---
+
+## 5. Anti-patterns documentés
+
+- **AP-CAT-01 — Injection de l'implémentation concrète** : `CategoryController:8,20` importe et injecte `CategoryServiceImpl` (couche application) au lieu du port `CategoryService` (domaine). Brise la règle hexagonale ; le contrôleur est couplé à l'implémentation.
+- **AP-CAT-02 — Double injection du même champ** : `CategoryController:19-25` déclare `@Autowired` sur le champ ET un constructeur `@Autowired` pour `categoryService`. Comportement indéfini, Spring peut injecter deux fois. Garder une seule injection par constructeur.
+- **AP-CAT-03 — Domaine exposé en couche HTTP** : `CategoryController:28` désérialise le `@RequestBody` directement vers `Category` (domain model) et `CategoryController:34` retourne `List<Category>` brut. Aucun request/response DTO — le modèle de domaine fuit vers les consommateurs de l'API. Introduire un `CategoryRequest`/`CategoryResponse`.
+- **AP-CAT-04 — Double `existsById` (fenêtre de race + double requête)** : `CategoryController:48` vérifie `existsById` puis `CategoryServiceImpl.deleteCategory:62` re-vérifie. Double requête + fenêtre de race entre les deux checks. Laisser la décision 404 au service / `@ExceptionHandler` sur `CategoryNotFoundException`.
+- **AP-CAT-05 — Suppression physique sans soft delete ni protection FK** : `deleteCategory` fait un `deleteById` physique (`CategoryServiceImpl:65`). Aucun soft delete, aucune vérification de produits référents — risque de violation FK ou d'orphelins. Contraire à la règle soft-delete du projet.
+- **AP-CAT-06 — Champ `name` sans contrainte** : `CategoryEntity:13` n'a ni `@Column(nullable=false)`, ni `@Column(unique=true)`, ni `@NotBlank`. Colonne nullable et dupliquable malgré une sémantique « requis et unique ».
+- **AP-CAT-07 — Création sans check de doublon** : `CategoryServiceImpl.createCategory:28-29` `save` sans vérifier l'existence d'un même nom — doublons silencieux (cf. BR-CAT-004).
+- **AP-CAT-08 — Résolution par nom non déterministe** : `CategoryRepositoryJpaImpl.findDomainCategoryByName:40-52` renvoie `results.get(0)` parmi plusieurs lignes possibles, sans contrainte UNIQUE garantissant l'unicité.
+- **AP-CAT-09 — Absence de garde admin** : `SecurityConfig` ne liste pas `/api/categories/**` explicitement ; tout ROLE_USER peut créer/supprimer des catégories (référentiel global) via le fallthrough `.anyRequest().authenticated()`.
+- **AP-CAT-10 — Code mort** : `CategoryNotFoundException(String name):10` n'est jamais utilisé ; `CategoryServiceImpl.updateCategory` est implémenté mais non exposé par un endpoint (cf. BR-CAT-006).
+- **AP-CAT-11 — UUID de catégories codés en dur dans le JSX** : `AddProducts.tsx:172-184` (4 UUID littéraux) court-circuite `GET /api/categories` (cf. BR-CAT-007).
+
+---
+
+## Référence
+
+- Coverage actuelle : `coverage-categories.md`
+- Backend : `backend/src/main/java/com/matimeline/eventmanager/` (`infrastructure/adapters/controllers/CategoryController.java`, `application/services/CategoryServiceImpl.java`, `infrastructure/adapters/repositories/jpa/CategoryRepositoryJpaImpl.java`, `infrastructure/entities/CategoryEntity.java`, `domain/models/Category.java`, `domain/exceptions/CategoryNotFoundException.java`)
+- Frontend : `frontend/src/types/product.ts` (schémas Zod), `frontend/src/components/.../AddProducts.tsx` (formulaire de création produit)

--- a/.ai-env/context-packs/br-events.md
+++ b/.ai-env/context-packs/br-events.md
@@ -1,0 +1,151 @@
+# Context-pack domaine : `events`
+
+> Domaine : `events` — gestion des événements d'une timeline (création, mise à jour partielle, suppression, listing par produit), chaque événement étant rattaché à un `Product` et porteur de dates calculées (durée ou date unique).
+> Acteurs principaux : `ROLE_USER` (utilisateur authentifié via cookie JWT), `Anonymous` (bloqué), `system` (mappers / `Utils.calculateEndDate` qui calculent dates et valeurs par défaut).
+
+---
+
+## 1. Lifecycles (machines à états)
+
+**EventEntity** — CRUD simple, **pas de lifecycle d'état métier** (aucun champ `status`/`state`, pas de soft-delete : la suppression est physique via `deleteById`).
+
+Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une nature figée à la création :
+
+| `type`     | Description                                              | Conséquence métier                                                                 |
+|------------|----------------------------------------------------------|------------------------------------------------------------------------------------|
+| `duration` | Événement avec durée → `endDate` = `startDate` + `durationValue` × `durationUnit` | `Utils.calculateEndDate` applique `plusDays/Weeks/Months/Years`                     |
+| `single`   | Événement ponctuel → `endDate` = `startDate`             | `calculateEndDate` retourne `startDate` inchangée (branche `if` non prise)          |
+
+⚠️ Aucune contrainte d'enum sur `type` côté backend : toute chaîne hors `duration`/`single` est acceptée et traitée comme `single` (branche `if` non prise → `endDate = startDate`).
+
+---
+
+## 2. Actions x Acteurs
+
+| Action                                                        | ROLE_USER | Anonymous | system | Notes                                                                                  |
+|--------------------------------------------------------------|:---------:|:---------:|:------:|----------------------------------------------------------------------------------------|
+| `POST /api/events` (créer)                                    | ✅        | ❌        | —      | Bloqué anonyme via `SecurityConfig`. ⚠️ `@Valid` absent → DTO non validé.              |
+| `PATCH /api/events/{id}` (maj partielle)                      | ⚠️        | ❌        | —      | ⚠️ IDOR : aucun contrôle d'ownership, tout `ROLE_USER` modifie n'importe quel event.   |
+| `DELETE /api/events/{id}` (supprimer)                         | ⚠️        | ❌        | —      | ⚠️ IDOR : aucun contrôle d'ownership, suppression physique.                            |
+| `GET /api/users/{userId}/products/{productId}/events` (lister)| ✅        | ❌        | —      | Endpoint porté par `ProductController`. `userId` vérifié vs JWT via `JwtService`.      |
+| Calcul `endDate`                                             | —         | —         | ✅     | `Utils.calculateEndDate` à la création uniquement (pas recalculé au PATCH).            |
+| Défaut `startDate = LocalDate.now()`                          | —         | —         | ✅     | Appliqué dans `EventServiceImpl.createEvent` si `date` null.                            |
+
+---
+
+## 3. Business Rules atomiques
+
+### BR-EVE-001 — Nom d'événement requis et borné
+**Règle** : un `ROLE_USER` MUST fournir un `name` non vide (1–100 caractères) à la création.
+**Pourquoi** : intégrité des données, le `name` est mappé vers `Event.title` (champ d'affichage).
+**Implémentation** : `EventCreationRequest.name` (`@NotBlank` + `@Size(min=1, max=100)`).
+**⚠️ NON IMPLÉMENTÉ EFFECTIVEMENT** : `@Valid` absent sur `EventController.createEvent(@RequestBody ...)` → la contrainte n'est **jamais déclenchée** côté backend. Seul le frontend (`eventCreationSchema.name.min(3)`) filtre, avec un seuil divergent (3 vs 1).
+**Test attendu** : `EventControllerTest.shouldReject400WhenNameBlankOrTooLong` (à créer — échouera tant que `@Valid` absent).
+
+### BR-EVE-002 — Produit cible obligatoire et existant
+**Règle** : un `ROLE_USER` MUST fournir un `productId` non null référençant un `Product` existant, sinon la création échoue.
+**Pourquoi** : `EventEntity.product` est `@JoinColumn(nullable=false)` ; un event orphelin est interdit.
+**Implémentation** : `EventCreationRequest.productId` (`@NotNull`) + `EventServiceImpl.createEvent` → `productRepository.findDomainProductById(...).orElseThrow(ProductNotFoundException)`.
+**Test attendu** : `EventServiceImplTest.shouldThrowProductNotFoundWhenProductIdUnknown`.
+
+### BR-EVE-003 — endDate calculée selon le type
+**Règle** : le `system` MUST calculer `endDate` = `startDate` + (`durationValue` × `durationUnit`) quand `type='duration'`, et `endDate = startDate` quand `type='single'`.
+**Pourquoi** : cohérence temporelle de l'affichage timeline ; un event `single` ne dure qu'un jour.
+**Implémentation** : `Utils.calculateEndDate(EventCreationRequest, startDate)` (switch sur `durationUnit` : `days/weeks/months/years`).
+**Test attendu** : `UtilsTest.shouldComputeEndDatePerDurationUnit` + `shouldReturnStartDateForSingleType`.
+
+### BR-EVE-004 — durationUnit valide quand type=duration
+**Règle** : quand `type='duration'`, `durationUnit` MUST être l'une de `days/weeks/months/years`, sinon `IllegalArgumentException`.
+**Pourquoi** : éviter un calcul de date silencieusement faux.
+**Implémentation** : `Utils.calculateEndDate` branche `default` → `throw new IllegalArgumentException`.
+**⚠️ FAILLE NPE** : si `type='duration'`, `durationValue != null` et `durationUnit == null`, `switch(null)` lève une `NullPointerException` (aucun null-guard avant le switch). `durationUnit` n'est pas garanti non-null à la création (`@NotBlank` jamais déclenché faute de `@Valid`).
+**Test attendu** : `UtilsTest.shouldThrowOnUnknownDurationUnit` + `shouldNotNpeWhenDurationUnitNull` (à créer).
+
+### BR-EVE-005 — startDate par défaut = aujourd'hui
+**Règle** : si `date` est null à la création, le `system` MUST utiliser `LocalDate.now()` comme `startDate`.
+**Pourquoi** : un event sans date de début n'a pas de sens sur la timeline.
+**Implémentation** : `EventServiceImpl.createEvent` → `startDate = (date != null) ? date : LocalDate.now()`.
+**Test attendu** : `EventServiceImplTest.shouldDefaultStartDateToTodayWhenDateNull`.
+
+### BR-EVE-006 — recurrenceUnit requis quand isRecurring=true
+**Règle** : quand `isRecurring=true`, `recurrenceUnit` DEVRAIT être obligatoire (`weeks/months/years`).
+**Pourquoi** : une récurrence sans unité est inexploitable.
+**⚠️ NON IMPLÉMENTÉ** : aucune contrainte ni backend (`EventCreationRequest.recurrenceUnit` sans `@NotBlank` ni validation conditionnelle) ni frontend (`eventCreationSchema` ne refine pas `recurrenceUnit`). `recurrenceUnit` reste librement null même avec `isRecurring=true`.
+**Test attendu** : `EventCreationRequestValidationTest.shouldRequireRecurrenceUnitWhenRecurring` (à créer après ajout de la règle).
+
+### BR-EVE-007 — isRecurring obligatoire à la création
+**Règle** : un `ROLE_USER` MUST fournir `isRecurring` (non null) à la création.
+**Pourquoi** : le flag pilote la logique de récurrence côté affichage.
+**Implémentation** : `EventCreationRequest.isRecurring` (`@NotNull`).
+**⚠️ NON IMPLÉMENTÉ EFFECTIVEMENT** : `@Valid` absent → contrainte jamais déclenchée (voir BR-EVE-001).
+**Test attendu** : `EventControllerTest.shouldReject400WhenIsRecurringNull`.
+
+### BR-EVE-008 — Ownership requis sur PATCH / DELETE
+**Règle** : un `ROLE_USER` MUST NOT modifier ou supprimer un event qui n'appartient pas à l'un de ses produits.
+**Pourquoi** : isolation des données entre utilisateurs (confidentialité, intégrité).
+**⚠️ NON IMPLÉMENTÉ (IDOR critique)** : `EventController.updateEvent` et `deleteEvent` n'effectuent aucun contrôle d'ownership ; tout `ROLE_USER` agit sur n'importe quel `id`. Contraste avec le GET liste qui, lui, vérifie `userId` vs JWT.
+**Test attendu** : `EventControllerSecurityTest.shouldReturn403WhenPatchingForeignEvent` + `shouldReturn403WhenDeletingForeignEvent`.
+
+### BR-EVE-009 — Couleurs cohérentes sur le formulaire d'édition
+**Règle** : sur l'édition, `backgroundColor`/`borderColor`/`textColor` DOIVENT être traités de façon cohérente (un seul schéma source de vérité).
+**Pourquoi** : éviter des erreurs de validation/runtime divergentes pour le même formulaire.
+**⚠️ NON IMPLÉMENTÉ (schéma dupliqué)** : deux `eventEditSchema` divergents — `types/event.ts` (couleurs `optional`, seul `backgroundColor` présent) vs `EventEditForm.tsx` (3 couleurs `z.string()` requises). Aucune validation de format hex côté backend (`backgroundColor/borderColor/textColor` String libres, nullable).
+**Test attendu** : `eventEditSchema.test.ts.shouldValidateColorsConsistently` (après consolidation en un schéma unique).
+
+### BR-EVE-010 — Champ allDay : nom de sérialisation
+**Règle** : le frontend MUST lire le champ booléen "journée entière" sous la clé sérialisée par le backend.
+**Pourquoi** : éviter un `undefined` silencieux à la désérialisation.
+**⚠️ INCOHÉRENCE** : backend sérialise `isAllDay` (getter `getIsAllDay` → préfixe Jackson `isAllDay`), tandis que `eventSchema` (`types/event.ts`) attend `allDay`. Le mapping `mapToFullCalendarEvent` lit `event.allDay` → risque de `undefined`.
+**Test attendu** : `eventSerialization.test.ts.shouldDeserializeIsAllDayField` (après alignement des noms).
+
+### BR-EVE-011 — Quota d'événements actifs selon le tier (anticipation monétisation)
+**Règle** : le nombre d'événements **actifs (non archivés)** d'un utilisateur DOIT être plafonné selon son `tier` (`FREE`=20, `PLUS`=200, `PRO`=illimité). Un événement **récurrent compte pour 1** (la récurrence est une propriété, pas un multiplicateur). Les produits et catégories restent **gratuits et illimités** — l'unité facturable est l'événement.
+**Pourquoi** : modèle de monétisation par abonnement pas cher débloquant plus d'événements. Compter par lane/produit serait contournable (1 catégorie = 300 events).
+**⚠️ NON IMPLÉMENTÉ / ANTICIPATION (issue #88)** : couture `PlanPolicy.canCreateEvent(user)` posée mais **no-op** (renvoie toujours `true`, plafonds en mode illimité) tant que la monétisation n'est pas lancée. Champ `User.tier` (défaut `FREE`). Le paiement réel (Stripe, paywall, webhooks) = epic « Monétisation » **post-MVP, hors périmètre**.
+**Lien** : « actif » = non archivé (dépend du soft-delete événement, cf. modèle v3 #44) ; comptage à garder atomique en cas de création concurrente / offline (#76).
+**Test attendu** : `PlanPolicyTest.shouldCountActiveNonArchivedEvents` + `shouldCountRecurringAsOne` + `EventControllerQuotaTest.shouldReturn402WhenTierLimitReached` (quand l'enforcement sera activé).
+
+---
+
+## 4. Dépendances inter-domaines
+
+- **events → products (fort)** : `EventEntity` `@ManyToOne ProductEntity` (`@JoinColumn product_id, nullable=false`, `@JsonBackReference`). Côté `Product`, `@OneToMany(mappedBy="product", cascade=ALL, orphanRemoval=true, @JsonManagedReference)` → la suppression d'un produit **cascade** sur ses events.
+- **Modèle domaine** : `Event` porte `productId: UUID` (pas l'entité) → isolation hexagonale correcte au niveau domaine.
+- **Listing des events** : porté par `ProductController` (`GET /api/users/{userId}/products/{productId}/events`), pas par `EventController` → le domaine `events` dépend de l'auth produit/user.
+- ⚠️ **Couplage infra-infra** : `EventRepositoryJpaImpl` injecte `ProductRepositoryJpaImpl` (classe concrète) au lieu du port `ProductRepository` → viole l'inversion de dépendance hexagonale.
+- ⚠️ **Fuite DTO dans le port domaine** : `EventService` (port domaine) référence `EventCreationRequest` (couche application) dans `createEvent(...)` → le DTO applicatif pollue la définition du port.
+
+---
+
+## 5. Anti-patterns documentés
+
+- **IDOR (PATCH & DELETE)** : aucun contrôle d'ownership sur `EventController.updateEvent` / `deleteEvent` → modification/suppression de l'event d'autrui. (cf. BR-EVE-008)
+- **`@Valid` manquant** sur `POST /api/events` `@RequestBody` → toutes les annotations Bean Validation de `EventCreationRequest` silencieusement ignorées. (cf. BR-EVE-001/007)
+- **Fuite du modèle domaine en réponse REST** : `Event` (domaine) renvoyé directement par POST/PATCH et par le GET liste — aucun response DTO.
+- **Logique métier dans le controller** : `EventController.updateEvent` contient la boucle de mise à jour champ-par-champ avec `instanceof` (parsing `durationValue`/`isRecurring`) — devrait être en couche service.
+- **Mismatch sémantique name↔title** : `EventCreationRequest.name` mappé vers `Event.title`.
+- **Exception avalée** : `EventServiceImpl.findEventById` fait `e.printStackTrace()` puis retourne `Optional.empty()` → masque les vraies erreurs.
+- **Double round-trip DB** : `deleteById` fait `existsById` puis `deleteById` (2 requêtes) ; `findEventById` fait `existsById` puis `findEventById` (2 requêtes).
+- **Check vide dupliqué** : `EventServiceImpl.findDomainEventByProductId` lève `EventNotFoundException` sur liste vide, puis `ProductController` re-teste `isEmpty()` après coup.
+- **NPE potentielle** : `Utils.calculateEndDate` `switch(durationUnit)` sans null-guard quand `type='duration'`. (cf. BR-EVE-004)
+- **Suppression physique** : `deleteById` supprime réellement la ligne — pas de soft-delete (divergence avec la convention soft-delete du projet).
+- **`@CrossOrigin(origins="*")`** sur `EventController` en conflit avec `SecurityConfig` (CORS `allowCredentials=true` + `allowedOrigins localhost:3000`) — wildcard + credentials invalide selon la spec CORS.
+- **Schémas Zod dupliqués/divergents** : `eventEditSchema` défini deux fois (cf. BR-EVE-009) ; champ `allDay` vs `isAllDay` (cf. BR-EVE-010) ; `name.min(3)` front vs `@Size(min=1)` back ; `type` enum strict front vs `@NotBlank` libre back.
+
+---
+
+## Référence
+
+- Coverage actuelle : `coverage-events.md`
+- Backend :
+  - Controller : `backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventController.java`
+  - Service : `backend/src/main/java/com/matimeline/eventmanager/application/services/EventServiceImpl.java`
+  - DTO : `backend/src/main/java/com/matimeline/eventmanager/application/dtos/EventCreationRequest.java`
+  - Calcul dates : `backend/src/main/java/com/matimeline/eventmanager/utils/Utils.java`
+  - Entité : `backend/src/main/java/com/matimeline/eventmanager/infrastructure/entities/EventEntity.java`
+  - Port service : `backend/src/main/java/com/matimeline/eventmanager/domain/ports/services/EventService.java`
+  - Listing : `backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/ProductController.java`
+- Frontend :
+  - Schémas/types : `frontend/src/types/event.ts`
+  - Formulaire édition : `frontend/src/components/EventEditForm.tsx`
+  - Service API : `frontend/src/services/eventService.ts`

--- a/.ai-env/context-packs/br-products.md
+++ b/.ai-env/context-packs/br-products.md
@@ -1,0 +1,129 @@
+# Context-pack domaine : `products`
+
+> Domaine : `products` — gestion des produits possédés par un utilisateur, chacun rattaché à une catégorie et agrégeant une liste d'événements (création groupée produit + événements).
+> Acteurs principaux : Utilisateur authentifié (self-service uniquement, JWT cookie). Système (résolution Category/User, calcul des dates d'événements). Aucun rôle Admin n'existe dans le code.
+
+---
+
+## 1. Lifecycles (machines à états)
+
+**Product** — CRUD simple, pas de lifecycle d'état métier (aucun champ `status`/`active`/`ARCHIVED` sur `ProductEntity`).
+
+| Etat | Description | Transitions sortantes |
+| --- | --- | --- |
+| (Created) | Produit créé via `POST`, événements créés en cascade | -> (Deleted) via `DELETE` |
+| (Deleted) | Suppression PHYSIQUE (`existsById` puis delete) | aucune |
+
+⚠️ Suppression PHYSIQUE observée (`deleteById` après `existsById`) — **pas de soft delete**, contraire à la convention projet. Aucun champ `deletedAt`/`active` sur `ProductEntity`.
+
+**Event** (entité agrégée) — pas de lifecycle propre côté `products` ; cycle de vie piloté par le produit (`cascade=ALL`, `orphanRemoval=true`).
+
+---
+
+## 2. Actions x Acteurs
+
+| Action | user (authentifié) | admin | system | Notes |
+| --- | --- | --- | --- | --- |
+| `POST` créer produit + events | ✅ self uniquement | ❌ inexistant | ⚠️ résout Category & User, calcule end dates | userId du body ignoré, écrasé par path `{userId}` |
+| `GET` lister produits (avec events) | ✅ self uniquement | ❌ | ⚠️ full table scan + filtre in-memory | accepte cookie JWT **OU** header Bearer (incohérent) |
+| `GET` produit par id | ✅ self uniquement | ❌ | — | 404 si absent |
+| `DELETE` produit | ✅ self uniquement | ❌ | — | retourne 200 (devrait être 204) |
+| `GET` events d'un produit | ✅ self uniquement | ❌ | — | ⚠️ 404 si liste vide (sémantique erronée) |
+
+⚠️ Contrôle d'ownership fait **manuellement** dans le controller (extraction username depuis JWT cookie -> load User -> compare `user.getId()` au path `{userId}`), sans `@PreAuthorize` ni Spring Security method security.
+
+---
+
+## 3. Business Rules atomiques
+
+### BR-PRO-001 — Nom de produit obligatoire et borné
+**Règle** : un utilisateur MUST fournir un `name` non vide, longueur 1..100, à la création d'un produit.
+**Pourquoi** : intégrité des données, un produit anonyme n'a pas de sens métier.
+**Implémentation** : `ProductCreationRequest.name` — `@NotBlank` + `@Size(min=1, max=100)`. Front : `productCreateSchema.name = z.string().min(3)`.
+**Test attendu** : `ProductControllerTest#createProduct_rejectsBlankName`, `#createProduct_rejectsNameOver100`.
+**⚠️ DESYNC** : Zod impose `min(3)`, backend impose `min(1)` — noms de 1-2 caractères acceptés backend mais refusés front. Voir `.claude/rules-jit/zod-dto-sync.md`.
+**⚠️ Entité non protégée** : `ProductEntity.name` sans `@Column(nullable=false)` ni Bean Validation — un nom NULL peut être persisté si le DTO est contourné.
+
+### BR-PRO-002 — Catégorie obligatoire et existante
+**Règle** : un utilisateur MUST fournir un `category` (UUID) correspondant à une catégorie existante.
+**Pourquoi** : tout produit appartient à une catégorie (FK `category_id NOT NULL`).
+**Implémentation** : `ProductCreationRequest.category` — `@NotNull`. `createProduct` résout la catégorie et lève `CategoryNotFoundException` si absente. Entité : `@ManyToOne @JoinColumn(name='category_id', nullable=false)`. Front : `z.string().uuid()`.
+**Test attendu** : `ProductServiceImplTest#createProduct_throwsWhenCategoryMissing`, `ProductControllerTest#createProduct_rejectsNullCategory`.
+
+### BR-PRO-003 — Utilisateur cible obligatoire et existant
+**Règle** : la création MUST cibler un User existant ; `createProduct` lève `UserNotFoundException` si absent.
+**Pourquoi** : un produit appartient à un utilisateur.
+**Implémentation** : `ProductCreationRequest.userId` — `@NotNull` ; `createProduct` résout le User.
+**Test attendu** : `ProductServiceImplTest#createProduct_throwsWhenUserMissing`.
+**⚠️ Contrainte DB manquante** : `ProductEntity.user` -> `@JoinColumn(name='user_id')` SANS `nullable=false` — `user_id` peut être NULL en base, produit orphelin possible.
+**⚠️ Front incomplet** : `productSchema` (lecture) n'expose PAS le champ `user` (seulement `id, name, category, events`).
+
+### BR-PRO-004 — Le userId du path fait autorité (anti-IDOR partiel)
+**Règle** : l'`userId` du body MUST être ignoré ; le `{userId}` du path écrase le body et MUST correspondre au subject du JWT.
+**Pourquoi** : empêcher un utilisateur de créer un produit pour le compte d'un autre via le body.
+**Implémentation** : `ProductController.createProduct` écrase `request.userId` avec le path variable, puis compare `user.getId()` (extrait du cookie JWT) au `{userId}`.
+**Test attendu** : `ProductControllerTest#createProduct_ignoresBodyUserId`, `#createProduct_rejectsMismatchedPathUser`.
+**⚠️ Sécurité manuelle** : pas de `@PreAuthorize` ni Spring Security ; autorisation dispersée dans le controller, fragile et non centralisée.
+
+### BR-PRO-005 — Liste d'événements à la création (NPE non gardé)
+**Règle** : un utilisateur PEUT fournir une liste d'`events` ; chaque event sans date reçoit `LocalDate.now()` comme `startDate`, et `endDate` est calculée via `Utils.calculateEndDate()`.
+**Pourquoi** : création groupée produit + événements en une transaction.
+**Implémentation** : `ProductServiceImpl.createProduct` itère `request.getEvents().forEach(...)`.
+**Test attendu** : `ProductServiceImplTest#createProduct_defaultsEventStartDateToToday`, `#createProduct_handlesNullEventsList`.
+**⚠️ NON GARDÉ (bug)** : `getEvents()` peut être `null` (`@NotNull`/`@NotEmpty` absents sur le DTO ; Zod `z.array(...)` sans `.min(1)`). Le `forEach` lève un `NullPointerException` si la liste est nulle. -> ajouter null guard ou `@NotNull` sur le DTO.
+
+### BR-PRO-006 — Listing des produits filtré par utilisateur
+**Règle** : `GET /products` MUST ne retourner que les produits de l'utilisateur du path possédant au moins un event.
+**Pourquoi** : isolation des données par utilisateur.
+**Implémentation** : `ProductServiceImpl.getProductsWithEvents` charge `findAllProducts()` puis filtre en mémoire par `userId` et `hasEvents()`.
+**Test attendu** : `ProductServiceImplTest#getProductsWithEvents_filtersByUserAndHasEvents`.
+**⚠️ PERF (anti-pattern)** : aucun filtre SQL `WHERE user_id = ?` — scan complet de la table puis filtre Java (O(N)). Ne passe pas à l'échelle. -> requête JPQL/Panache avec filtre DB.
+
+### BR-PRO-007 — Suppression conditionnée à l'existence
+**Règle** : `DELETE` MUST vérifier l'existence (`existsById`) avant suppression ; lève `ProductNotFoundException` sinon.
+**Pourquoi** : retour d'erreur explicite plutôt que delete silencieux.
+**Implémentation** : `ProductServiceImpl.deleteById`.
+**Test attendu** : `ProductServiceImplTest#deleteById_throwsWhenMissing`.
+**⚠️ Soft delete NON IMPLÉMENTÉ** : suppression physique alors que la convention impose le soft delete. **⚠️ Code HTTP** : retourne 200 au lieu de 204.
+
+### BR-PRO-008 — Sémantique 404 sur collection d'events vide (NON CONFORME)
+**Règle attendue** : `GET /products/{productId}/events` DEVRAIT retourner `200` avec une liste (éventuellement vide).
+**Implémentation actuelle** : retourne `404` quand la liste d'events est vide — confond "ressource introuvable" et "collection vide".
+**Pourquoi** : un produit existant sans event est un état valide, pas une absence de ressource.
+**Test attendu** : `ProductControllerTest#getEvents_returns200EmptyListWhenNoEvents` (rouge tant que le bug n'est pas corrigé).
+**Statut** : ⚠️ NON CONFORME — à corriger.
+
+---
+
+## 4. Dépendances inter-domaines
+
+- **`products` -> `categories`** : `Product` `@ManyToOne Category`, FK `category_id NOT NULL`. Création échoue (`CategoryNotFoundException`) si la catégorie n'existe pas.
+- **`products` -> `users`** : `Product` `@ManyToOne User`, FK `user_id` nullable (⚠️ pas de `nullable=false`). Ownership et autorisation reposent sur `User`.
+- **`products` -> `events`** : `Product` `@OneToMany Event` (`cascade=ALL`, `orphanRemoval=true`, `mappedBy='product'`). Le domaine `products` crée/supprime les events en cascade ; leur cycle de vie est piloté par le produit.
+- **Couplage hexagonal inversé (anti-pattern)** : `domain/ports/services/ProductService` importe le DTO applicatif `ProductCreationRequest` — le domaine dépend de la couche application (cf. §5).
+
+---
+
+## 5. Anti-patterns documentés
+
+1. **Fuite du modèle de domaine** : `ResponseEntity<Product>`, `ResponseEntity<List<Product>>`, `ResponseEntity<List<Event>>` renvoyés directement — aucun DTO de réponse, expose la structure interne y compris l'objet `User`. -> introduire des response DTO.
+2. **Dépendance hexagonale inversée** : `ProductService` (port domaine) importe `ProductCreationRequest` (DTO application).
+3. **Annotation infra dans le domaine** : `ProductRepository` (port domaine) annoté `@Repository` (Spring).
+4. **Couplage aux implémentations** : `ProductController` injecte `ProductServiceImpl`, `EventServiceImpl`, `UserServiceImpl` au lieu des interfaces de port.
+5. **Full table scan** : `getProductsWithEvents` charge toute la table puis filtre par `userId` en Java (cf. BR-PRO-006).
+6. **NPE non gardé** : `createProduct` appelle `request.getEvents().forEach()` sans null check (cf. BR-PRO-005).
+7. **UUID hard-codés au front** : le sélecteur de catégorie embarque des UUID en dur (`7446a49c...`, `dbc134fb...`) — casse à tout changement DB. -> charger les catégories via API.
+8. **Desync Zod/DTO** : `name` Zod `min(3)` vs backend `@Size(min=1)` (cf. BR-PRO-001).
+9. **Codes HTTP incorrects** : `DELETE` renvoie 200 au lieu de 204 ; events vides renvoient 404 (cf. BR-PRO-008).
+10. **Annotation Jackson sur entité de persistance** : `@JsonManagedReference` sur `ProductEntity.events` — concern présentation sur entité infra.
+11. **`@Valid` manquant** : pas de `@Valid` visible sur le `@RequestBody` de `ProductController` — la Bean Validation de `ProductCreationRequest` peut ne pas être déclenchée.
+12. **Authentification incohérente** : `getProducts` accepte cookie JWT **ou** header Bearer ; les autres endpoints sont cookie-only.
+13. **Autorisation manuelle** : extraction/validation JWT et comparaison d'ownership codées à la main dans le controller, sans `@PreAuthorize`.
+
+---
+
+## Référence
+
+- Coverage actuelle : `coverage-products.md`
+- Backend : `backend/src/main/java/com/matimeline/eventmanager/` — `domain/ports/services/ProductService.java`, `domain/ports/repositories/ProductRepository.java`, `application/.../ProductServiceImpl.java`, `infrastructure/.../ProductEntity.java`, `infrastructure/.../ProductController.java`, DTO `ProductCreationRequest`
+- Frontend : `frontend/src/components/products/` — sélecteur de catégorie + schémas Zod `productCreateSchema` / `productSchema` (`eventCreationSchema` réutilisé)

--- a/.ai-env/context-packs/coverage-auth.md
+++ b/.ai-env/context-packs/coverage-auth.md
@@ -1,0 +1,42 @@
+# Coverage : `auth`
+
+> État de couverture du domaine `auth` au 2026-06-25.
+
+---
+
+## 1. Matrice de couverture par action
+
+| Action | `user` | `system` | Notes |
+|---|---|---|---|
+| S'inscrire | ⚠️ | n/a | Controller implémenté, pas de test dédié |
+| Se connecter | ⚠️ | n/a | Controller implémenté, pas de test dédié |
+| Valider token JWT | n/a | ⚠️ | JwtFilter implémenté, pas de test d'intégration |
+| Rafraîchir token | ❌ | n/a | Non implémenté |
+
+---
+
+## 2. Gaps prioritisés
+
+### P0 — Aucun test auth
+- **Symptôme** : Zéro test sur la chaîne register/login/JWT
+- **Cause** : Tests non écrits en phase initiale
+- **BR concernée** : BR-AUTH-001, BR-AUTH-002, BR-AUTH-003
+- **Action** : Écrire `AuthControllerTest` + `JwtServiceTest`
+
+### P1 — Pas de refresh token
+- **Symptôme** : Token expiré = reconnexion manuelle
+- **Action** : Implémenter endpoint `/auth/refresh`
+
+---
+
+## 3. Coverage E2E
+
+| Scénario | Fichier test | Statut |
+|---|---|---|
+| Inscription → connexion → accès protégé | `e2e/auth/login.spec.ts` | ❌ non créé |
+
+---
+
+## Référence
+
+- Pack métier stable : `br-auth.md`

--- a/.ai-env/context-packs/coverage-categories.md
+++ b/.ai-env/context-packs/coverage-categories.md
@@ -1,0 +1,40 @@
+# Coverage : `categories`
+
+> État de couverture du domaine `categories` au 2026-06-25.
+
+---
+
+## 1. Matrice de couverture par action
+
+| Action | `user` | `admin` | Notes |
+|---|---|---|---|
+| Créer une catégorie | ⚠️ | n/a | Backend implémenté, pas de test |
+| Lister les catégories | ⚠️ | n/a | Backend implémenté, pas de test |
+| Modifier une catégorie | ⚠️ | n/a | Backend implémenté, pas de test |
+| Supprimer une catégorie | ⚠️ | n/a | Backend implémenté, pas de test |
+
+---
+
+## 2. Gaps prioritisés
+
+### P0 — Zéro test backend categories
+- **BR concernée** : BR-CAT-001, BR-CAT-002
+- **Action** : `CategoryServiceImplTest`
+
+### P1 — Contrainte suppression non vérifiée
+- **BR concernée** : BR-CAT-002
+- **Action** : Vérifier que `CategoryServiceImpl.delete()` rejette si catégorie utilisée
+
+---
+
+## 3. Coverage E2E
+
+| Scénario | Fichier test | Statut |
+|---|---|---|
+| Créer une catégorie, l'assigner à un événement | `e2e/categories/assign.spec.ts` | ❌ non créé |
+
+---
+
+## Référence
+
+- Pack métier stable : `br-categories.md`

--- a/.ai-env/context-packs/coverage-events.md
+++ b/.ai-env/context-packs/coverage-events.md
@@ -1,0 +1,43 @@
+# Coverage : `events`
+
+> État de couverture du domaine `events` au 2026-06-25.
+
+---
+
+## 1. Matrice de couverture par action
+
+| Action | `user` | `admin` | Notes |
+|---|---|---|---|
+| Créer un événement | ⚠️ | n/a | Backend implémenté, pas de test |
+| Lister ses événements | ⚠️ | n/a | Backend implémenté, pas de test |
+| Modifier un événement | ⚠️ | n/a | Backend implémenté, pas de test |
+| Supprimer un événement | ⚠️ | n/a | Backend implémenté, pas de test |
+| Afficher sur calendrier | ⚠️ | n/a | Frontend FullCalendar intégré, pas d'E2E |
+
+---
+
+## 2. Gaps prioritisés
+
+### P0 — Zéro test backend events
+- **Symptôme** : EventServiceImpl non testée
+- **BR concernée** : BR-EVT-001, BR-EVT-002, BR-EVT-003
+- **Action** : `EventServiceImplTest` + `EventControllerIntegrationTest`
+
+### P1 — Pas d'E2E calendrier
+- **Symptôme** : Intégration FullCalendar non couverte
+- **Action** : `e2e/events/calendar.spec.ts`
+
+---
+
+## 3. Coverage E2E
+
+| Scénario | Fichier test | Statut |
+|---|---|---|
+| Créer un événement, voir sur calendrier | `e2e/events/create.spec.ts` | ❌ non créé |
+| Modifier un événement depuis le calendrier | `e2e/events/edit.spec.ts` | ❌ non créé |
+
+---
+
+## Référence
+
+- Pack métier stable : `br-events.md`

--- a/.ai-env/context-packs/coverage-products.md
+++ b/.ai-env/context-packs/coverage-products.md
@@ -1,0 +1,39 @@
+# Coverage : `products`
+
+> État de couverture du domaine `products` au 2026-06-25.
+
+---
+
+## 1. Matrice de couverture par action
+
+| Action | `user` | `admin` | Notes |
+|---|---|---|---|
+| Créer un produit | ⚠️ | n/a | Backend implémenté, pas de test |
+| Lister les produits | ⚠️ | n/a | Backend implémenté, pas de test |
+| Modifier un produit | ⚠️ | n/a | Backend implémenté, pas de test |
+| Supprimer un produit | ⚠️ | n/a | Backend implémenté, pas de test |
+
+---
+
+## 2. Gaps prioritisés
+
+### P0 — Zéro test backend products
+- **BR concernée** : BR-PROD-001, BR-PROD-002
+- **Action** : `ProductServiceImplTest`
+
+### P2 — Pas d'E2E produits
+- **Action** : `e2e/products/create.spec.ts`
+
+---
+
+## 3. Coverage E2E
+
+| Scénario | Fichier test | Statut |
+|---|---|---|
+| Créer un produit, voir dans la liste | `e2e/products/create.spec.ts` | ❌ non créé |
+
+---
+
+## Référence
+
+- Pack métier stable : `br-products.md`

--- a/.ai-env/context-packs/cp-backend.md
+++ b/.ai-env/context-packs/cp-backend.md
@@ -1,0 +1,80 @@
+# Context-pack : Backend le langage backend / Quarkus
+
+> ⚠️ EXEMPLE Layer B (instance EdelWheels / Quarkus-Next). À RÉGÉNÉRER par /ai-env:setup pour ta stack. Voir REBUILD-PLAN.md §2.2.
+
+> Reference maitre : `.claude/rules-jit/backend.md`
+> A charger pour TOUTE tache backend
+
+## Stack
+
+le langage backend + le framework backend + l'ORM + l'outil de migration + le provider d'identité + la base de données
+
+## Conventions le langage backend
+
+- **Records** pour DTOs (request/response immuables)
+- **Sealed Classes** pour etats metier
+- **Pattern Matching**, Streams
+- **Validation** : `@Valid` + Bean Validation sur tous les `@RequestBody`
+- **Reponses** : `Response.ok(dto).build()` ou `Response.created(uri).build()`
+- **Erreurs** : le format d'erreur
+- **Logging** : le logger injecte — jamais `System.out`
+- **Config** : `@ConfigProperty` pour valeurs externalisees
+- **JPA constructeurs** : `public Entity() {}` (pas protected)
+
+## Regles transversales entites
+
+- **Soft delete** (règle métier suppression) : champ `deleted_at` obligatoire, JAMAIS de DELETE physique
+- **UUID v7** (règle métier clés primaires) sur toutes les cles primaires
+- **Ownership** (règle métier ownership) : verifier l'identifiant propriétaire sur chaque endpoint GET/PUT/DELETE securise, admins bypassent via `isAdmin`
+
+## Securite
+
+- `@RolesAllowed` sur chaque endpoint protege
+- Aucune donnee sensible dans les logs
+- Aucune concatenation SQL
+- `l'identité de sécurité` (pas `JsonWebToken`) avec le provider d'identite
+
+## Migrations l'outil de migration
+
+- `db/migration/V{n}__{description}.sql`
+- Rollback commente dans chaque fichier
+- JAMAIS modifier une migration deja appliquee
+- Derniere migration : `ls {{MIGRATIONS_DIR}}/V*.sql | sort -V | tail -1` (hook `check-stack-drift.sh` avertit en cas de drift)
+
+## l'ORM
+
+- `persist()` = INSERT only. Pour upsert → `getEntityManager().merge()`
+- `TranslationRepository` implemente directement par `l'ORMRepository`
+
+## Null safety
+
+- `orElseThrow()` quand l'entite DOIT exister — jamais `orElse(null)` + null checks downstream
+- Fallback explicite obligatoire pour les valeurs nullable externes (locale, enum)
+
+## Tests `@QuarkusTest`
+
+- **`@TestTransaction`** (pas `@Transactional`) pour rollback automatique — `@Transactional` commit et pollue les tests suivants. **PIT recurrent**.
+- Test data : valeurs uniques par test (generateur AtomicInteger ou UUID), jamais de constantes partagees entre tests
+
+## Qualite du code
+
+- Methodes > 20 lignes → decomposer
+- Complexite cyclomatique > 5 → refactorer
+- Pas de magic numbers/strings
+- Nommage explicite
+- **Risque N+1** : `fetch join` ou `@BatchSize`
+- Toute liste paginee
+- Index DB prevus pour colonnes filtrees/triees
+
+## Pitfalls backend frequents
+
+- `@Transactional` dans tests → pollue tests suivants. Toujours `@TestTransaction`.
+- `orElse(null)` + null check downstream → NPE cache. `orElseThrow()`.
+- `persist()` pour update → INSERT duplique. `getEntityManager().merge()`.
+- Concatenation SQL → injection. Query params obligatoires.
+- Migration modifiee apres deploiement → cluster inconsistant. Creer V{n+1}.
+
+## Reference pour approfondir
+
+`.claude/rules-jit/backend.md` (rule versionnee)
+`docs/memory/pitfalls.md` (filtre par PIT-XX backend)

--- a/.ai-env/context-packs/cp-frontend.md
+++ b/.ai-env/context-packs/cp-frontend.md
@@ -1,0 +1,88 @@
+# Context-pack : Frontend Next.js 16 / TypeScript
+
+> ⚠️ EXEMPLE Layer B (instance EdelWheels / Quarkus-Next). À RÉGÉNÉRER par /ai-env:setup pour ta stack. Voir REBUILD-PLAN.md §2.2.
+
+> Reference maitre : `.claude/rules-jit/frontend.md`
+> A charger pour TOUTE tache frontend
+
+## Stack
+
+le framework frontend + TypeScript strict + le framework CSS + la gestion d'état
+
+## Conventions TypeScript
+
+- **TypeScript strict** : zero `any`, zero `as` cast non justifie
+- **Server Components** par defaut, `"use client"` uniquement si necessaire
+- `"use client"` inutile sur fichiers type-only (pas de hooks React)
+- **TanStack Query** cote client, `fetch` natif dans Server Components
+- **Forms** : React Hook Form + Zod
+- **Style** : Tailwind CSS + shadcn/ui UNIQUEMENT
+
+## i18n (règle métier i18n) — langues configurées du projet
+
+- TOUJOURS `useTranslations("namespace")` — jamais de strings FR hardcodees
+- `useTranslations("ns")` separe par namespace (next-intl ne supporte pas `t("key", { ns })`)
+- Zod schemas : factory function `createSchema(messages)` avec `useMemo`
+- Module-level i18n : separer styles statiques + `buildConfig(t)` function
+
+## Formatage locale (règle métier locale/devise)
+
+- TOUJOURS `{{LOCALE_CONSTANT}}` de `@/lib/utils` — jamais `"{{LOCALE_CODE}}"` hardcode
+- SSR : utiliser le helper de formatage locale du projet (deterministe) — jamais `Intl.NumberFormat` inline (hydration mismatch)
+- `Intl.DateTimeFormat({{LOCALE_CONSTANT}}, ...)` pour dates
+
+## Montants (règle métier devise)
+
+- Tout montant avec code devise ISO 4217
+- Utiliser `currency` du type response, JAMAIS hardcoder la devise du projet
+
+## Accessibilite
+
+- **Spinners** : `role="status"` + `aria-label` + `<span class="sr-only">`
+- **Tables** : `aria-label` sur `<table>`, `scope="col"` sur `<th>`
+- **Barres progression** : `role="progressbar"` + `aria-valuenow/min/max`
+- **Boutons** : `focus:ring-2 focus:ring-accent`
+- **Elements interactifs custom** : `role="button"` + `tabIndex={0}` + `onKeyDown` (Enter/Space) + `focus:ring-2`
+
+## Charts Recharts
+
+- TOUJOURS `useChartTheme()` — JAMAIS de hex inline
+- Importer couleurs depuis `tokens.ts` ou `useChartTheme()`
+- `Number(value)` pour Tooltip formatter
+
+## Zod / DTO Synchronisation
+
+Voir `.claude/rules-jit/zod-dto-sync.md` (ou Phase 2 : `cp-zod-dto-sync.md`).
+Resume :
+- `.nullable()` pour nullable backend
+- `.optional()` pour absent
+- JAMAIS `.nullish()` en code manuel (accepte dans code genere)
+- Endpoint pagine : TOUJOURS `paginatedSchema(itemSchema)`, jamais `schema.array()`
+
+## Design
+
+- Consulter `la charte de design` et `les design tokens`
+- **Theme-aware** : chaque composant fonctionne en clair ET sombre
+- Mock data : format machine-readable, jamais strings FR hardcodees
+- Animations : `duration-300` standard
+
+## Tests — zero warning stderr (MEMO-007)
+
+Tout test livre doit produire un run vitest sans aucune ligne stderr.
+- **MockImage** : exclure `priority`, `fill`, `quality`, `placeholder`, `blurDataURL`, `loader`, `unoptimized` du spread `...rest` vers `<img>`
+- **`act()` warning** : render avec effets async → test `async` + `await waitFor(() => stableCondition)`
+- **Logs d'erreur intentionnels** : `vi.spyOn(console, "error").mockImplementation(() => {})` + `mockRestore()`
+
+## Pitfalls frontend frequents
+
+- `.nullish()` dans schema manuel → ZodError runtime (PIT-174)
+- `validated()` avec schema genere sans overlay nullable → strip silencieusement (PIT-180)
+- `Intl.NumberFormat('{{LOCALE_CODE}}')` inline → hydration mismatch SSR vs client (PIT-185)
+- `validated()` en `select:` sur fallback non-conforme (PIT-186)
+- `schema.array()` au lieu de `paginatedSchema()` → `.filter()` crash sur `{items, total, page, size}`
+
+## Reference pour approfondir
+
+`.claude/rules-jit/frontend.md` (rule versionnee)
+`.claude/rules-jit/zod-dto-sync.md` (checklist DTO/Zod)
+`docs/memory/pitfalls.md` (filtre par PIT-XX frontend)

--- a/.ai-env/context-packs/cp-hexagonal.md
+++ b/.ai-env/context-packs/cp-hexagonal.md
@@ -1,0 +1,58 @@
+# Context-pack : Architecture hexagonale
+
+> ⚠️ EXEMPLE Layer B (instance EdelWheels / Quarkus-Next). À RÉGÉNÉRER par /ai-env:setup pour ta stack. Voir REBUILD-PLAN.md §2.2.
+
+> Reference maitre : `.claude/rules/hexagonal.md`
+> A charger pour TOUTE tache backend touchant `{{JAVA_PACKAGE}}.*`
+
+## Structure obligatoire
+
+```
+{{JAVA_PACKAGE}}/
+├── domain/            # Couche metier pure (Java pur, 0 framework)
+├── application/       # Ports (interfaces) et use cases
+└── infrastructure/    # Adapters techniques (JPA, REST, Quarkus)
+```
+
+## Imports interdits — AUDIT AUTOMATIQUE par hook `check-hexagonal.sh`
+
+### `domain/` NE DOIT JAMAIS importer :
+- `jakarta.*` (sauf annotations validation : `@NotNull`, `@Valid`, `@Size`)
+- `io.quarkus.*`
+- `javax.*`
+- `{{JAVA_PACKAGE}}.infrastructure.*`
+- `{{JAVA_PACKAGE}}.application.*` (sauf interfaces de ports)
+
+### `application/` NE DOIT JAMAIS importer :
+- `{{JAVA_PACKAGE}}.infrastructure.*`
+- `io.quarkus.*` (sauf annotations CDI basiques : `@ApplicationScoped`, `@Inject`)
+
+### `infrastructure/` peut importer tout :
+- `{{JAVA_PACKAGE}}.domain.*`
+- `{{JAVA_PACKAGE}}.application.*`
+- Tous les frameworks necessaires
+
+## DEC-009 — Ports obligatoires
+
+- `application/` ne touche JAMAIS `infrastructure/` directement
+- Les ports (interfaces) sont definis dans `application/`
+- Les implementations (adapters) sont dans `infrastructure/`
+
+## Anti-patterns a proscrire
+
+- Entite JPA dans `domain/` → deplacer vers `infrastructure/persistence/`
+- `@Path`, `@GET`, `@POST` dans `domain/` ou `application/`
+- `l'ORMRepository` dans `application/` → port + adapter infra
+- Static method call vers `application` depuis `domain`
+
+## Checklist implementation
+
+- [ ] La logique metier est dans `domain/` (pure)
+- [ ] Les use cases sont dans `application/` via ports
+- [ ] Les adapters (REST, JPA, HTTP client) sont dans `infrastructure/`
+- [ ] Le hook `check-hexagonal.sh` passe sans erreur
+
+## Reference pour approfondir
+
+`.claude/rules/hexagonal.md` (rule versionnee)
+`docs/memory/decisions.md#DEC-009`

--- a/.ai-env/setup-state.yaml
+++ b/.ai-env/setup-state.yaml
@@ -1,0 +1,9 @@
+# .ai-env/setup-state.yaml — état du tunnel /ai-env:setup (resumable).
+# Géré par lib/setup-state.sh, lu par le Stop hook check-setup-complete.sh.
+sentinel: done
+phase_detect_stack: done
+phase_detect_tools: done
+phase_confirm: done
+phase_write_config: pending
+phase_domains: done
+phase_report: done


### PR DESCRIPTION
## Contexte
Versionne le plugin ai-env (config-driven) pour MyTimeline : context-packs des business rules canoniques (BR-AUT / BR-EVE / BR-PRO / BR-CAT), coverage par domaine, context-packs techniques (cp-*), et config runtime JIT.

Ces fichiers vivaient uniquement dans le working dir local (untracked). Les versionner sur dev permet aux agents de sprint (fullstack-dev) de disposer des BR canoniques dans tous les worktrees, et fait de dev la base propre pour le plan d'intégration design (61 issues #28-#88).

Inclut **BR-EVE-011** (quota d'événements par tier — anticipation monétisation, issue #88).

## Contenu
- `.ai-env/context-packs/br-{auth,events,products,categories}.md`
- `.ai-env/context-packs/coverage-*.md`, `cp-*.md`
- `.ai-env/config.yaml`, `setup-state.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)