### PR TITLE
Sprint 1 — Sécurité backend P0 (IDOR, validation, DTO)

### DIFF
--- a/.ai-env/context-packs/br-events.md
+++ b/.ai-env/context-packs/br-events.md
@@ -24,9 +24,9 @@ Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une n
 
 | Action                                                        | ROLE_USER | Anonymous | system | Notes                                                                                  |
 |--------------------------------------------------------------|:---------:|:---------:|:------:|----------------------------------------------------------------------------------------|
-| `POST /api/events` (créer)                                    | ✅        | ❌        | —      | Bloqué anonyme via `SecurityConfig`. ⚠️ `@Valid` absent → DTO non validé.              |
-| `PATCH /api/events/{id}` (maj partielle)                      | ⚠️        | ❌        | —      | ⚠️ IDOR : aucun contrôle d'ownership, tout `ROLE_USER` modifie n'importe quel event.   |
-| `DELETE /api/events/{id}` (supprimer)                         | ⚠️        | ❌        | —      | ⚠️ IDOR : aucun contrôle d'ownership, suppression physique.                            |
+| `POST /api/events` (créer)                                    | ✅        | ❌        | —      | Bloqué anonyme via `SecurityConfig`. ✅ `@Valid` + ownership productId (Sprint 1 #31/#91). |
+| `PATCH /api/events/{id}` (maj partielle)                      | ✅        | ❌        | —      | ✅ Ownership event→product→user (403) + DTO typé `@Valid` (Sprint 1 #28/#30).           |
+| `DELETE /api/events/{id}` (supprimer)                         | ✅        | ❌        | —      | ✅ Ownership (403 si event d'autrui) implémenté Sprint 1 #30. Suppression physique.     |
 | `GET /api/users/{userId}/products/{productId}/events` (lister)| ✅        | ❌        | —      | Endpoint porté par `ProductController`. `userId` vérifié vs JWT via `JwtService`.      |
 | Calcul `endDate`                                             | —         | —         | ✅     | `Utils.calculateEndDate` à la création uniquement (pas recalculé au PATCH).            |
 | Défaut `startDate = LocalDate.now()`                          | —         | —         | ✅     | Appliqué dans `EventServiceImpl.createEvent` si `date` null.                            |
@@ -39,7 +39,7 @@ Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une n
 **Règle** : un `ROLE_USER` MUST fournir un `name` non vide (1–100 caractères) à la création.
 **Pourquoi** : intégrité des données, le `name` est mappé vers `Event.title` (champ d'affichage).
 **Implémentation** : `EventCreationRequest.name` (`@NotBlank` + `@Size(min=1, max=100)`).
-**⚠️ NON IMPLÉMENTÉ EFFECTIVEMENT** : `@Valid` absent sur `EventController.createEvent(@RequestBody ...)` → la contrainte n'est **jamais déclenchée** côté backend. Seul le frontend (`eventCreationSchema.name.min(3)`) filtre, avec un seuil divergent (3 vs 1).
+**✅ IMPLÉMENTÉ Sprint 1 (#31/#91)** : `@Valid` ajouté sur `EventController.createEvent(@RequestBody ...)` → la contrainte `@Size(min=1,max=100)` est désormais déclenchée (titre vide → 400). Reste un seuil divergent avec le frontend (`eventCreationSchema.name.min(3)` vs back min=1) à harmoniser.
 **Test attendu** : `EventControllerTest.shouldReject400WhenNameBlankOrTooLong` (à créer — échouera tant que `@Valid` absent).
 
 ### BR-EVE-002 — Produit cible obligatoire et existant
@@ -77,13 +77,13 @@ Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une n
 **Règle** : un `ROLE_USER` MUST fournir `isRecurring` (non null) à la création.
 **Pourquoi** : le flag pilote la logique de récurrence côté affichage.
 **Implémentation** : `EventCreationRequest.isRecurring` (`@NotNull`).
-**⚠️ NON IMPLÉMENTÉ EFFECTIVEMENT** : `@Valid` absent → contrainte jamais déclenchée (voir BR-EVE-001).
+**✅ IMPLÉMENTÉ Sprint 1 (#31)** : `@Valid` présent → `@NotNull` sur `isRecurring` désormais déclenché (voir BR-EVE-001).
 **Test attendu** : `EventControllerTest.shouldReject400WhenIsRecurringNull`.
 
 ### BR-EVE-008 — Ownership requis sur PATCH / DELETE
 **Règle** : un `ROLE_USER` MUST NOT modifier ou supprimer un event qui n'appartient pas à l'un de ses produits.
 **Pourquoi** : isolation des données entre utilisateurs (confidentialité, intégrité).
-**⚠️ NON IMPLÉMENTÉ (IDOR critique)** : `EventController.updateEvent` et `deleteEvent` n'effectuent aucun contrôle d'ownership ; tout `ROLE_USER` agit sur n'importe quel `id`. Contraste avec le GET liste qui, lui, vérifie `userId` vs JWT.
+**✅ IMPLÉMENTÉ Sprint 1 (#30/#91)** : `EventController` vérifie l'ownership sur `createEvent` (productId du caller), `updateEvent` et `deleteEvent` via le helper `checkEventOwnership` (`event → productId → product.getUser().getId() == caller.getId()`, sinon 403). Identité dérivée du JWT (`resolveCaller`), jamais d'un path param. `JwtException` → 401 (pas 500).
 **Test attendu** : `EventControllerSecurityTest.shouldReturn403WhenPatchingForeignEvent` + `shouldReturn403WhenDeletingForeignEvent`.
 
 ### BR-EVE-009 — Couleurs cohérentes sur le formulaire d'édition
@@ -119,8 +119,8 @@ Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une n
 
 ## 5. Anti-patterns documentés
 
-- **IDOR (PATCH & DELETE)** : aucun contrôle d'ownership sur `EventController.updateEvent` / `deleteEvent` → modification/suppression de l'event d'autrui. (cf. BR-EVE-008)
-- **`@Valid` manquant** sur `POST /api/events` `@RequestBody` → toutes les annotations Bean Validation de `EventCreationRequest` silencieusement ignorées. (cf. BR-EVE-001/007)
+- ~~**IDOR (PATCH & DELETE)**~~ : ✅ RÉSOLU Sprint 1 #30/#91 — ownership sur create/update/delete (cf. BR-EVE-008).
+- ~~**`@Valid` manquant** sur `POST /api/events`~~ : ✅ RÉSOLU Sprint 1 #31 — `@Valid` posé sur tous les `@RequestBody` + `@EnableMethodSecurity` + session STATELESS (cf. BR-EVE-001/007).
 - **Fuite du modèle domaine en réponse REST** : `Event` (domaine) renvoyé directement par POST/PATCH et par le GET liste — aucun response DTO.
 - **Logique métier dans le controller** : `EventController.updateEvent` contient la boucle de mise à jour champ-par-champ avec `instanceof` (parsing `durationValue`/`isRecurring`) — devrait être en couche service.
 - **Mismatch sémantique name↔title** : `EventCreationRequest.name` mappé vers `Event.title`.
@@ -129,7 +129,7 @@ Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une n
 - **Check vide dupliqué** : `EventServiceImpl.findDomainEventByProductId` lève `EventNotFoundException` sur liste vide, puis `ProductController` re-teste `isEmpty()` après coup.
 - **NPE potentielle** : `Utils.calculateEndDate` `switch(durationUnit)` sans null-guard quand `type='duration'`. (cf. BR-EVE-004)
 - **Suppression physique** : `deleteById` supprime réellement la ligne — pas de soft-delete (divergence avec la convention soft-delete du projet).
-- **`@CrossOrigin(origins="*")`** sur `EventController` en conflit avec `SecurityConfig` (CORS `allowCredentials=true` + `allowedOrigins localhost:3000`) — wildcard + credentials invalide selon la spec CORS.
+- ~~**`@CrossOrigin(origins="*")`** sur `EventController`~~ : ✅ RETIRÉ Sprint 1 #30 — CORS gérée uniquement par `SecurityConfig` (`allowCredentials=true` + `allowedOrigins localhost:3000`).
 - **Schémas Zod dupliqués/divergents** : `eventEditSchema` défini deux fois (cf. BR-EVE-009) ; champ `allDay` vs `isAllDay` (cf. BR-EVE-010) ; `name.min(3)` front vs `@Size(min=1)` back ; `type` enum strict front vs `@NotBlank` libre back.
 
 ---

--- a/backend/src/main/java/com/matimeline/eventmanager/application/dtos/AuthRequest.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/application/dtos/AuthRequest.java
@@ -1,7 +1,15 @@
 package com.matimeline.eventmanager.application.dtos;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public class AuthRequest {
+    @NotBlank(message = "Username is required")
+    @Size(max = 100, message = "Username must be at most 100 characters")
     private String username;
+
+    @NotBlank(message = "Password is required")
+    @Size(max = 100, message = "Password must be at most 100 characters")
     private String password;
 
     public String getUsername() {

--- a/backend/src/main/java/com/matimeline/eventmanager/application/dtos/EventUpdateRequest.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/application/dtos/EventUpdateRequest.java
@@ -1,0 +1,111 @@
+package com.matimeline.eventmanager.application.dtos;
+
+import jakarta.validation.constraints.Size;
+
+/**
+ * DTO de mise à jour partielle (PATCH /api/events/{id}).
+ *
+ * Sémantique PATCH partielle : chaque champ est optionnel (wrapper types nullable).
+ * Un champ {@code null} signifie "non fourni" et n'est PAS appliqué côté service.
+ *
+ * Validation conditionnelle "si présent alors valide" :
+ * - {@code title} utilise {@code @Size(min = 1)} (et non {@code @NotBlank}) pour
+ *   rejeter une chaîne vide ("" -> HTTP 400) tout en autorisant l'absence (null),
+ *   indispensable car certains PATCH (mise à jour des couleurs seules via
+ *   {@code updateEventColor}) n'envoient pas de title.
+ *
+ * Le contrat JSON sur le wire est inchangé (mêmes noms de champs que le Map précédent).
+ */
+public class EventUpdateRequest {
+
+    @Size(min = 1, max = 100, message = "Title must be between 1 and 100 characters")
+    private String title;
+
+    private String type;
+
+    private Integer durationValue;
+
+    private String durationUnit;
+
+    private Boolean isRecurring;
+
+    private String recurrenceUnit;
+
+    private String backgroundColor;
+
+    private String borderColor;
+
+    private String textColor;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Integer getDurationValue() {
+        return durationValue;
+    }
+
+    public void setDurationValue(Integer durationValue) {
+        this.durationValue = durationValue;
+    }
+
+    public String getDurationUnit() {
+        return durationUnit;
+    }
+
+    public void setDurationUnit(String durationUnit) {
+        this.durationUnit = durationUnit;
+    }
+
+    public Boolean getIsRecurring() {
+        return isRecurring;
+    }
+
+    public void setIsRecurring(Boolean isRecurring) {
+        this.isRecurring = isRecurring;
+    }
+
+    public String getRecurrenceUnit() {
+        return recurrenceUnit;
+    }
+
+    public void setRecurrenceUnit(String recurrenceUnit) {
+        this.recurrenceUnit = recurrenceUnit;
+    }
+
+    public String getBackgroundColor() {
+        return backgroundColor;
+    }
+
+    public void setBackgroundColor(String backgroundColor) {
+        this.backgroundColor = backgroundColor;
+    }
+
+    public String getBorderColor() {
+        return borderColor;
+    }
+
+    public void setBorderColor(String borderColor) {
+        this.borderColor = borderColor;
+    }
+
+    public String getTextColor() {
+        return textColor;
+    }
+
+    public void setTextColor(String textColor) {
+        this.textColor = textColor;
+    }
+}

--- a/backend/src/main/java/com/matimeline/eventmanager/application/services/EventServiceImpl.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/application/services/EventServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.matimeline.eventmanager.application.dtos.EventCreationRequest;
+import com.matimeline.eventmanager.application.dtos.EventUpdateRequest;
 import com.matimeline.eventmanager.domain.exceptions.EventNotFoundException;
 import com.matimeline.eventmanager.domain.exceptions.ProductNotFoundException;
 import com.matimeline.eventmanager.domain.models.Event;
@@ -53,6 +54,49 @@ public class EventServiceImpl implements EventService {
                 product.getId(),
                 eventCreationRequest.getIsAllDay()
         );
+        return eventRepository.save(event);
+    }
+
+    @Override
+    @Transactional
+    public Event updateEvent(UUID id, EventUpdateRequest updateRequest) {
+        Event event = findEventById(id)
+            .orElseThrow(() -> new EventNotFoundException(id));
+
+        // Préserve le lien produit existant (le DTO ne porte pas productId).
+        UUID originalProductId = event.getProductId();
+
+        // PATCH partiel : chaque champ n'est appliqué que s'il est fourni (non null).
+        if (updateRequest.getTitle() != null) {
+            event.setTitle(updateRequest.getTitle());
+        }
+        if (updateRequest.getType() != null) {
+            event.setType(updateRequest.getType());
+        }
+        if (updateRequest.getDurationValue() != null) {
+            event.setDurationValue(updateRequest.getDurationValue());
+        }
+        if (updateRequest.getDurationUnit() != null) {
+            event.setDurationUnit(updateRequest.getDurationUnit());
+        }
+        if (updateRequest.getIsRecurring() != null) {
+            event.setIsRecurring(updateRequest.getIsRecurring());
+        }
+        if (updateRequest.getRecurrenceUnit() != null) {
+            event.setRecurrenceUnit(updateRequest.getRecurrenceUnit());
+        }
+        if (updateRequest.getBackgroundColor() != null) {
+            event.setBackgroundColor(updateRequest.getBackgroundColor());
+        }
+        if (updateRequest.getBorderColor() != null) {
+            event.setBorderColor(updateRequest.getBorderColor());
+        }
+        if (updateRequest.getTextColor() != null) {
+            event.setTextColor(updateRequest.getTextColor());
+        }
+
+        event.setProduct(originalProductId);
+
         return eventRepository.save(event);
     }
 

--- a/backend/src/main/java/com/matimeline/eventmanager/domain/ports/services/EventService.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/domain/ports/services/EventService.java
@@ -5,10 +5,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 import com.matimeline.eventmanager.application.dtos.EventCreationRequest;
+import com.matimeline.eventmanager.application.dtos.EventUpdateRequest;
 import com.matimeline.eventmanager.domain.models.Event;
 
 public interface EventService {
     Event createEvent(EventCreationRequest eventCreationRequest);
+    Event updateEvent(UUID id, EventUpdateRequest updateRequest);
     Event save(Event event);
     
     List<Event> findDomainEventByProductId(UUID productId);

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/AuthController.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/AuthController.java
@@ -69,7 +69,7 @@ public class AuthController {
         } catch (BadCredentialsException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid username or password");
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Authentication failed");
         }
     }
 

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/AuthController.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/AuthController.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.MalformedJwtException;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 
 import java.util.List;
 import java.util.Optional;
@@ -47,7 +48,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody AuthRequest authRequest, HttpServletResponse response) {
+    public ResponseEntity<?> login(@Valid @RequestBody AuthRequest authRequest, HttpServletResponse response) {
         try {
             Authentication authentication = authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(authRequest.getUsername(), authRequest.getPassword()));
@@ -101,7 +102,7 @@ public class AuthController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<?> register(@RequestBody RegisterRequest registerRequest) {
+    public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest registerRequest) {
         try {
             Optional<User> existingUser = userService.findDomainUserByUsername(registerRequest.getUsername());
 

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/CategoryController.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/CategoryController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.*;
 import com.matimeline.eventmanager.application.services.CategoryServiceImpl;
 import com.matimeline.eventmanager.domain.models.Category;
 
+import jakarta.validation.Valid;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -25,7 +27,7 @@ public class CategoryController {
     }
 
     @PostMapping
-    public ResponseEntity<Category> createCategory(@RequestBody Category category) {
+    public ResponseEntity<Category> createCategory(@Valid @RequestBody Category category) {
         Category savedCategory = categoryService.createCategory(category);
         return new ResponseEntity<>(savedCategory, HttpStatus.CREATED);
     }

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventController.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventController.java
@@ -1,15 +1,17 @@
 package com.matimeline.eventmanager.infrastructure.adapters.controllers;
 
 import java.util.UUID;
-import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.matimeline.eventmanager.application.dtos.EventCreationRequest;
+import com.matimeline.eventmanager.application.dtos.EventUpdateRequest;
 import com.matimeline.eventmanager.domain.models.Event;
 import com.matimeline.eventmanager.domain.ports.services.EventService;
+
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/events")
@@ -30,77 +32,8 @@ public class EventController {
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<Event> updateEvent(@PathVariable UUID id, @RequestBody Map<String, Object> updates) {
-        Event event = eventService.findEventById(id)
-            .orElseThrow(() -> new RuntimeException("Event not found"));
-            
-        UUID originalProductId = event.getProductId();
-        
-        if (updates.containsKey("title")) {
-            String title = (String) updates.get("title");
-            event.setTitle(title);
-        }
-        
-        if (updates.containsKey("type")) {
-            String type = (String) updates.get("type");
-            event.setType(type);
-        }
-        
-        if (updates.containsKey("durationValue")) {
-            Integer durationValue = null;
-            if (updates.get("durationValue") instanceof Integer) {
-                durationValue = (Integer) updates.get("durationValue");
-            } else if (updates.get("durationValue") instanceof String) {
-                try {
-                    durationValue = Integer.parseInt((String) updates.get("durationValue"));
-                } catch (NumberFormatException e) {
-                }
-            }
-            if (durationValue != null) {
-                event.setDurationValue(durationValue);
-            }
-        }
-        
-        if (updates.containsKey("durationUnit")) {
-            String durationUnit = (String) updates.get("durationUnit");
-            event.setDurationUnit(durationUnit);
-        }
-        
-        if (updates.containsKey("isRecurring")) {
-            Boolean isRecurring = null;
-            if (updates.get("isRecurring") instanceof Boolean) {
-                isRecurring = (Boolean) updates.get("isRecurring");
-            } else if (updates.get("isRecurring") instanceof String) {
-                isRecurring = Boolean.parseBoolean((String) updates.get("isRecurring"));
-            }
-            if (isRecurring != null) {
-                event.setIsRecurring(isRecurring);
-            }
-        }
-        
-        if (updates.containsKey("recurrenceUnit")) {
-            String recurrenceUnit = (String) updates.get("recurrenceUnit");
-            event.setRecurrenceUnit(recurrenceUnit);
-        }
-        
-        if (updates.containsKey("backgroundColor")) {
-            String backgroundColor = (String) updates.get("backgroundColor");
-            event.setBackgroundColor(backgroundColor);
-        }
-        
-        if (updates.containsKey("borderColor")) {
-            String borderColor = (String) updates.get("borderColor");
-            event.setBorderColor(borderColor);
-        }
-        
-        if (updates.containsKey("textColor")) {
-            String textColor = (String) updates.get("textColor");
-            event.setTextColor(textColor);
-        }
-        
-        event.setProduct(originalProductId);
-        
-        Event updatedEvent = eventService.save(event);
+    public ResponseEntity<Event> updateEvent(@PathVariable UUID id, @Valid @RequestBody EventUpdateRequest request) {
+        Event updatedEvent = eventService.updateEvent(id, request);
         return ResponseEntity.ok(updatedEvent);
     }
 

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventController.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventController.java
@@ -18,6 +18,7 @@ import com.matimeline.eventmanager.domain.ports.services.ProductService;
 import com.matimeline.eventmanager.domain.ports.services.UserService;
 import com.matimeline.eventmanager.infrastructure.security.JwtService;
 
+import io.jsonwebtoken.JwtException;
 import jakarta.validation.Valid;
 
 @RestController
@@ -41,7 +42,26 @@ public class EventController {
     }
 
     @PostMapping
-    public ResponseEntity<Event> createEvent(@Valid @RequestBody EventCreationRequest request) {
+    public ResponseEntity<Event> createEvent(@Valid @RequestBody EventCreationRequest request,
+                                             @CookieValue(value = "jwt", required = false) String token) {
+        if (token == null || token.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        User caller = resolveCaller(token);
+        if (caller == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        Optional<Product> product = productService.findDomainProductById(request.getProductId());
+        if (product.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        if (product.get().getUser() == null
+                || !product.get().getUser().getId().equals(caller.getId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
         Event event = eventService.createEvent(request);
         return ResponseEntity.ok(event);
     }
@@ -79,9 +99,8 @@ public class EventController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        String username = jwtService.extractUsername(token);
-        Optional<User> user = userService.findDomainUserByUsername(username);
-        if (user.isEmpty()) {
+        User caller = resolveCaller(token);
+        if (caller == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
@@ -96,10 +115,24 @@ public class EventController {
         }
 
         if (product.get().getUser() == null
-                || !product.get().getUser().getId().equals(user.get().getId())) {
+                || !product.get().getUser().getId().equals(caller.getId())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
         return null;
+    }
+
+    /**
+     * Resolves the authenticated User from the JWT, or null when the token is
+     * malformed/expired/invalid (JwtException) or the user is unknown.
+     * Identity is derived from the JWT, never from a path or body param.
+     */
+    private User resolveCaller(String token) {
+        try {
+            String username = jwtService.extractUsername(token);
+            return userService.findDomainUserByUsername(username).orElse(null);
+        } catch (JwtException e) {
+            return null;
+        }
     }
 }

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventController.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventController.java
@@ -41,7 +41,7 @@ public class EventController {
     }
 
     @PostMapping
-    public ResponseEntity<Event> createEvent(@RequestBody EventCreationRequest request) {
+    public ResponseEntity<Event> createEvent(@Valid @RequestBody EventCreationRequest request) {
         Event event = eventService.createEvent(request);
         return ResponseEntity.ok(event);
     }

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventController.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventController.java
@@ -1,28 +1,43 @@
 package com.matimeline.eventmanager.infrastructure.adapters.controllers;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.matimeline.eventmanager.application.dtos.EventCreationRequest;
 import com.matimeline.eventmanager.application.dtos.EventUpdateRequest;
 import com.matimeline.eventmanager.domain.models.Event;
+import com.matimeline.eventmanager.domain.models.Product;
+import com.matimeline.eventmanager.domain.models.User;
 import com.matimeline.eventmanager.domain.ports.services.EventService;
+import com.matimeline.eventmanager.domain.ports.services.ProductService;
+import com.matimeline.eventmanager.domain.ports.services.UserService;
+import com.matimeline.eventmanager.infrastructure.security.JwtService;
 
 import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/events")
-@CrossOrigin(origins = "*")
 public class EventController {
 
     private final EventService eventService;
+    private final ProductService productService;
+    private final UserService userService;
+    private final JwtService jwtService;
 
     @Autowired
-    public EventController(EventService eventService) {
+    public EventController(EventService eventService,
+                           ProductService productService,
+                           UserService userService,
+                           JwtService jwtService) {
         this.eventService = eventService;
+        this.productService = productService;
+        this.userService = userService;
+        this.jwtService = jwtService;
     }
 
     @PostMapping
@@ -32,14 +47,59 @@ public class EventController {
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<Event> updateEvent(@PathVariable UUID id, @Valid @RequestBody EventUpdateRequest request) {
+    public ResponseEntity<Event> updateEvent(@PathVariable UUID id,
+                                             @Valid @RequestBody EventUpdateRequest request,
+                                             @CookieValue(value = "jwt", required = false) String token) {
+        ResponseEntity<Event> denied = checkEventOwnership(id, token);
+        if (denied != null) {
+            return denied;
+        }
         Event updatedEvent = eventService.updateEvent(id, request);
         return ResponseEntity.ok(updatedEvent);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteEvent(@PathVariable UUID id) {
+    public ResponseEntity<Void> deleteEvent(@PathVariable UUID id,
+                                            @CookieValue(value = "jwt", required = false) String token) {
+        ResponseEntity<Event> denied = checkEventOwnership(id, token);
+        if (denied != null) {
+            return ResponseEntity.status(denied.getStatusCode()).build();
+        }
         eventService.deleteById(id);
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Verifies the authenticated user owns the event (event -> product -> product.user).
+     * Returns a non-null ResponseEntity carrying the error status when access must be denied,
+     * or null when ownership is confirmed. Identity is derived from the JWT, never from a path param.
+     */
+    private ResponseEntity<Event> checkEventOwnership(UUID eventId, String token) {
+        if (token == null || token.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String username = jwtService.extractUsername(token);
+        Optional<User> user = userService.findDomainUserByUsername(username);
+        if (user.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        Optional<Event> event = eventService.findEventById(eventId);
+        if (event.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        Optional<Product> product = productService.findDomainProductById(event.get().getProductId());
+        if (product.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        if (product.get().getUser() == null
+                || !product.get().getUser().getId().equals(user.get().getId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        return null;
     }
 }

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.matimeline.eventmanager.infrastructure.adapters.controllers;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.matimeline.eventmanager.domain.exceptions.CategoryNotFoundException;
+import com.matimeline.eventmanager.domain.exceptions.EventNotFoundException;
+import com.matimeline.eventmanager.domain.exceptions.ProductNotFoundException;
+import com.matimeline.eventmanager.domain.exceptions.UserNotFoundException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({
+            EventNotFoundException.class,
+            ProductNotFoundException.class,
+            CategoryNotFoundException.class,
+            UserNotFoundException.class
+    })
+    public ResponseEntity<Map<String, Object>> handleNotFound(RuntimeException ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(buildBody(HttpStatus.NOT_FOUND, "Resource not found"));
+    }
+
+    private Map<String, Object> buildBody(HttpStatus status, String message) {
+        return Map.of(
+                "timestamp", Instant.now().toString(),
+                "status", status.value(),
+                "error", status.getReasonPhrase(),
+                "message", message
+        );
+    }
+}

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -26,6 +27,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
                 .body(buildBody(HttpStatus.NOT_FOUND, "Resource not found"));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidation(MethodArgumentNotValidException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(buildBody(HttpStatus.BAD_REQUEST, "Validation failed"));
     }
 
     private Map<String, Object> buildBody(HttpStatus status, String message) {

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/ProductController.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/ProductController.java
@@ -110,8 +110,13 @@ public class ProductController {
         }
 
         Optional<Product> product = productService.findDomainProductById(productId);
-        return product.map(ResponseEntity::ok)
-                      .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+        if (product.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        if (!productBelongsToUser(product.get(), userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        return ResponseEntity.ok(product.get());
     }
 
     @DeleteMapping("/users/{userId}/products/{productId}")
@@ -127,6 +132,14 @@ public class ProductController {
         Optional<User> user = userService.findDomainUserByUsername(username);
 
         if (user.isEmpty() || !user.get().getId().equals(userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        Optional<Product> product = productService.findDomainProductById(productId);
+        if (product.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        if (!productBelongsToUser(product.get(), userId)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -150,10 +163,28 @@ public class ProductController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
+        Optional<Product> product = productService.findDomainProductById(productId);
+        if (product.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        if (!productBelongsToUser(product.get(), userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
         List<Event> events = eventService.findDomainEventByProductId(productId);
         if (events.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
         return ResponseEntity.ok(events);
+    }
+
+    /**
+     * Verifies the product is owned by the given user (product.user.id == userId).
+     * Guards against IDOR where a valid userId==jwt holder accesses another user's product.
+     */
+    private boolean productBelongsToUser(Product product, UUID userId) {
+        return product.getUser() != null
+                && product.getUser().getId() != null
+                && product.getUser().getId().equals(userId);
     }
 }

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/ProductController.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/ProductController.java
@@ -14,6 +14,8 @@ import com.matimeline.eventmanager.domain.models.Product;
 import com.matimeline.eventmanager.domain.models.User;
 import com.matimeline.eventmanager.infrastructure.security.JwtService;
 
+import jakarta.validation.Valid;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -41,7 +43,7 @@ public class ProductController {
     @PostMapping("/users/{userId}/products")
     public ResponseEntity<Product> createProduct(
             @PathVariable UUID userId,
-            @RequestBody ProductCreationRequest request, 
+            @Valid @RequestBody ProductCreationRequest request,
             @CookieValue(value = "jwt", required = false) String token) {
         if (token == null || token.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/ProductController.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/ProductController.java
@@ -14,6 +14,7 @@ import com.matimeline.eventmanager.domain.models.Product;
 import com.matimeline.eventmanager.domain.models.User;
 import com.matimeline.eventmanager.infrastructure.security.JwtService;
 
+import io.jsonwebtoken.JwtException;
 import jakarta.validation.Valid;
 
 import java.util.List;
@@ -48,14 +49,19 @@ public class ProductController {
         if (token == null || token.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
-    
-        String username = jwtService.extractUsername(token);
+
+        String username;
+        try {
+            username = jwtService.extractUsername(token);
+        } catch (JwtException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         Optional<User> user = userService.findDomainUserByUsername(username);
-    
+
         if (user.isEmpty() || !user.get().getId().equals(userId)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
-    
+
         request.setUserId(userId);
         Product product = productService.createProduct(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(product);
@@ -104,7 +110,12 @@ public class ProductController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        String username = jwtService.extractUsername(token);
+        String username;
+        try {
+            username = jwtService.extractUsername(token);
+        } catch (JwtException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         Optional<User> user = userService.findDomainUserByUsername(username);
 
         if (user.isEmpty() || !user.get().getId().equals(userId)) {
@@ -130,7 +141,12 @@ public class ProductController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        String username = jwtService.extractUsername(token);
+        String username;
+        try {
+            username = jwtService.extractUsername(token);
+        } catch (JwtException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         Optional<User> user = userService.findDomainUserByUsername(username);
 
         if (user.isEmpty() || !user.get().getId().equals(userId)) {
@@ -158,7 +174,12 @@ public class ProductController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        String username = jwtService.extractUsername(token);
+        String username;
+        try {
+            username = jwtService.extractUsername(token);
+        } catch (JwtException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         Optional<User> user = userService.findDomainUserByUsername(username);
 
         if (user.isEmpty() || !user.get().getId().equals(userId)) {

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/security/SecurityConfig.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -25,6 +27,7 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
     private final JwtFilter jwtFilter;
 
@@ -51,6 +54,7 @@ public class SecurityConfig {
         http
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers("/api/users/{userId}/products/**").hasAuthority("ROLE_USER")

--- a/backend/src/test/java/com/matimeline/eventmanager/application/services/EventServiceImplTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/application/services/EventServiceImplTest.java
@@ -1,0 +1,145 @@
+package com.matimeline.eventmanager.application.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.matimeline.eventmanager.application.dtos.EventUpdateRequest;
+import com.matimeline.eventmanager.domain.exceptions.EventNotFoundException;
+import com.matimeline.eventmanager.domain.models.Event;
+import com.matimeline.eventmanager.domain.ports.repositories.EventRepository;
+import com.matimeline.eventmanager.domain.ports.repositories.ProductRepository;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceImplTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private EventServiceImpl eventService;
+
+    private UUID eventId;
+    private UUID productId;
+    private Event existingEvent;
+
+    @BeforeEach
+    void setUp() {
+        eventId = UUID.randomUUID();
+        productId = UUID.randomUUID();
+        existingEvent = new Event(
+                eventId, "Original title", "duration", 5, "days",
+                false, null, LocalDate.now(), LocalDate.now().plusDays(5),
+                productId, false, "#000000", "#111111", "#ffffff");
+    }
+
+    @Test
+    void updateEvent_appliesOnlyProvidedFields_partialPatch() {
+        EventUpdateRequest request = new EventUpdateRequest();
+        request.setTitle("New title");
+        // type, durationValue, etc. left null -> must NOT change existing values
+
+        when(eventRepository.existsById(eventId)).thenReturn(true);
+        when(eventRepository.findEventById(eventId)).thenReturn(Optional.of(existingEvent));
+        when(eventRepository.save(any(Event.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Event result = eventService.updateEvent(eventId, request);
+
+        assertThat(result.getTitle()).isEqualTo("New title");
+        assertThat(result.getType()).isEqualTo("duration");
+        assertThat(result.getDurationValue()).isEqualTo(5);
+        assertThat(result.getDurationUnit()).isEqualTo("days");
+    }
+
+    @Test
+    void updateEvent_preservesProductLink() {
+        EventUpdateRequest request = new EventUpdateRequest();
+        request.setTitle("Whatever");
+
+        when(eventRepository.existsById(eventId)).thenReturn(true);
+        when(eventRepository.findEventById(eventId)).thenReturn(Optional.of(existingEvent));
+        when(eventRepository.save(any(Event.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+        eventService.updateEvent(eventId, request);
+
+        verify(eventRepository).save(captor.capture());
+        assertThat(captor.getValue().getProductId()).isEqualTo(productId);
+    }
+
+    @Test
+    void updateEvent_appliesAllProvidedFields() {
+        EventUpdateRequest request = new EventUpdateRequest();
+        request.setTitle("Updated");
+        request.setType("single");
+        request.setDurationValue(10);
+        request.setDurationUnit("weeks");
+        request.setIsRecurring(true);
+        request.setRecurrenceUnit("months");
+        request.setBackgroundColor("#aaaaaa");
+        request.setBorderColor("#bbbbbb");
+        request.setTextColor("#cccccc");
+
+        when(eventRepository.existsById(eventId)).thenReturn(true);
+        when(eventRepository.findEventById(eventId)).thenReturn(Optional.of(existingEvent));
+        when(eventRepository.save(any(Event.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Event result = eventService.updateEvent(eventId, request);
+
+        assertThat(result.getTitle()).isEqualTo("Updated");
+        assertThat(result.getType()).isEqualTo("single");
+        assertThat(result.getDurationValue()).isEqualTo(10);
+        assertThat(result.getDurationUnit()).isEqualTo("weeks");
+        assertThat(result.getIsRecurring()).isTrue();
+        assertThat(result.getRecurrenceUnit()).isEqualTo("months");
+        assertThat(result.getBackgroundColor()).isEqualTo("#aaaaaa");
+        assertThat(result.getBorderColor()).isEqualTo("#bbbbbb");
+        assertThat(result.getTextColor()).isEqualTo("#cccccc");
+    }
+
+    @Test
+    void updateEvent_colorOnlyPatch_doesNotTouchTitle() {
+        EventUpdateRequest request = new EventUpdateRequest();
+        request.setBackgroundColor("#123456");
+
+        when(eventRepository.existsById(eventId)).thenReturn(true);
+        when(eventRepository.findEventById(eventId)).thenReturn(Optional.of(existingEvent));
+        when(eventRepository.save(any(Event.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Event result = eventService.updateEvent(eventId, request);
+
+        assertThat(result.getBackgroundColor()).isEqualTo("#123456");
+        assertThat(result.getTitle()).isEqualTo("Original title");
+    }
+
+    @Test
+    void updateEvent_notFound_throwsEventNotFoundException() {
+        EventUpdateRequest request = new EventUpdateRequest();
+        request.setTitle("New");
+
+        when(eventRepository.existsById(eventId)).thenReturn(false);
+
+        assertThatThrownBy(() -> eventService.updateEvent(eventId, request))
+                .isInstanceOf(EventNotFoundException.class);
+
+        verify(eventRepository, never()).save(any(Event.class));
+    }
+}

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/AuthControllerValidationTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/AuthControllerValidationTest.java
@@ -67,4 +67,14 @@ class AuthControllerValidationTest {
                         .content(body))
                 .andExpect(status().isBadRequest());
     }
+
+    @Test
+    void login_blankUsernameAndPassword_returns400() throws Exception {
+        String body = "{\"username\":\"\",\"password\":\"\"}";
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/AuthControllerValidationTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/AuthControllerValidationTest.java
@@ -1,0 +1,70 @@
+package com.matimeline.eventmanager.infrastructure.adapters.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.matimeline.eventmanager.application.services.UserServiceImpl;
+import com.matimeline.eventmanager.infrastructure.security.CustomUserDetailsService;
+import com.matimeline.eventmanager.infrastructure.security.JwtService;
+
+/**
+ * Validates that @Valid on @RequestBody rejects malformed payloads with 400
+ * before any business logic runs (issue #31). The controller body is never
+ * reached, so collaborators need no stubbing.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthControllerValidationTest {
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock
+    private JwtService jwtService;
+    @Mock
+    private CustomUserDetailsService userDetailsService;
+    @Mock
+    private UserServiceImpl userService;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        AuthController controller = new AuthController(
+                authenticationManager, jwtService, userDetailsService, userService, passwordEncoder);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void register_invalidEmail_returns400() throws Exception {
+        String body = "{\"name\":\"validName\",\"username\":\"validUser\","
+                + "\"email\":\"not-an-email\",\"password\":\"secret6\"}";
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void register_blankPassword_returns400() throws Exception {
+        String body = "{\"name\":\"validName\",\"username\":\"validUser\","
+                + "\"email\":\"valid@example.com\",\"password\":\"\"}";
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventControllerOwnershipTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventControllerOwnershipTest.java
@@ -3,7 +3,9 @@ package com.matimeline.eventmanager.infrastructure.adapters.controllers;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Optional;
@@ -14,8 +16,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.matimeline.eventmanager.application.dtos.EventUpdateRequest;
 
 import com.matimeline.eventmanager.domain.models.Event;
 import com.matimeline.eventmanager.domain.models.Product;
@@ -74,6 +79,28 @@ class EventControllerOwnershipTest {
                 .andExpect(status().isForbidden());
 
         verify(eventService, never()).deleteById(eventId);
+    }
+
+    @Test
+    void patchEvent_crossUser_returns403_andDoesNotUpdate() throws Exception {
+        User attacker = new User(attackerId, "Attacker", "attacker", "pwd", "ROLE_USER", "a@a.com");
+        User owner = new User(ownerId, "Owner", "owner", "pwd", "ROLE_USER", "o@o.com");
+
+        Event event = new Event(eventId, "title", "type", 1, "DAY", false, null, null, null, productId, false);
+        Product product = new Product(productId, "prod", null, owner, java.util.List.of());
+
+        when(jwtService.extractUsername("attacker-token")).thenReturn("attacker");
+        when(userService.findDomainUserByUsername("attacker")).thenReturn(Optional.of(attacker));
+        when(eventService.findEventById(eventId)).thenReturn(Optional.of(event));
+        when(productService.findDomainProductById(productId)).thenReturn(Optional.of(product));
+
+        mockMvc.perform(patch("/api/events/" + eventId)
+                        .cookie(new Cookie("jwt", "attacker-token"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\":\"hacked\"}"))
+                .andExpect(status().isForbidden());
+
+        verify(eventService, never()).updateEvent(any(UUID.class), any(EventUpdateRequest.class));
     }
 
     @Test

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventControllerOwnershipTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventControllerOwnershipTest.java
@@ -1,0 +1,95 @@
+package com.matimeline.eventmanager.infrastructure.adapters.controllers;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.matimeline.eventmanager.domain.models.Event;
+import com.matimeline.eventmanager.domain.models.Product;
+import com.matimeline.eventmanager.domain.models.User;
+import com.matimeline.eventmanager.domain.ports.services.EventService;
+import com.matimeline.eventmanager.domain.ports.services.ProductService;
+import com.matimeline.eventmanager.domain.ports.services.UserService;
+import com.matimeline.eventmanager.infrastructure.security.JwtService;
+
+import jakarta.servlet.http.Cookie;
+
+@ExtendWith(MockitoExtension.class)
+class EventControllerOwnershipTest {
+
+    @Mock
+    private EventService eventService;
+    @Mock
+    private ProductService productService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private JwtService jwtService;
+
+    private MockMvc mockMvc;
+
+    private UUID eventId;
+    private UUID productId;
+    private UUID ownerId;
+    private UUID attackerId;
+
+    @BeforeEach
+    void setUp() {
+        EventController controller = new EventController(eventService, productService, userService, jwtService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+        eventId = UUID.randomUUID();
+        productId = UUID.randomUUID();
+        ownerId = UUID.randomUUID();
+        attackerId = UUID.randomUUID();
+    }
+
+    @Test
+    void deleteEvent_crossUser_returns403_andDoesNotDelete() throws Exception {
+        User attacker = new User(attackerId, "Attacker", "attacker", "pwd", "ROLE_USER", "a@a.com");
+        User owner = new User(ownerId, "Owner", "owner", "pwd", "ROLE_USER", "o@o.com");
+
+        Event event = new Event(eventId, "title", "type", 1, "DAY", false, null, null, null, productId, false);
+        Product product = new Product(productId, "prod", null, owner, java.util.List.of());
+
+        when(jwtService.extractUsername("attacker-token")).thenReturn("attacker");
+        when(userService.findDomainUserByUsername("attacker")).thenReturn(Optional.of(attacker));
+        when(eventService.findEventById(eventId)).thenReturn(Optional.of(event));
+        when(productService.findDomainProductById(productId)).thenReturn(Optional.of(product));
+
+        mockMvc.perform(delete("/api/events/" + eventId).cookie(new Cookie("jwt", "attacker-token")))
+                .andExpect(status().isForbidden());
+
+        verify(eventService, never()).deleteById(eventId);
+    }
+
+    @Test
+    void deleteEvent_owner_returns200_andDeletes() throws Exception {
+        User owner = new User(ownerId, "Owner", "owner", "pwd", "ROLE_USER", "o@o.com");
+        Event event = new Event(eventId, "title", "type", 1, "DAY", false, null, null, null, productId, false);
+        Product product = new Product(productId, "prod", null, owner, java.util.List.of());
+
+        when(jwtService.extractUsername("owner-token")).thenReturn("owner");
+        when(userService.findDomainUserByUsername("owner")).thenReturn(Optional.of(owner));
+        when(eventService.findEventById(eventId)).thenReturn(Optional.of(event));
+        when(productService.findDomainProductById(productId)).thenReturn(Optional.of(product));
+
+        mockMvc.perform(delete("/api/events/" + eventId).cookie(new Cookie("jwt", "owner-token")))
+                .andExpect(status().isOk());
+
+        verify(eventService).deleteById(eventId);
+    }
+}

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventControllerValidationTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/EventControllerValidationTest.java
@@ -1,0 +1,60 @@
+package com.matimeline.eventmanager.infrastructure.adapters.controllers;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.matimeline.eventmanager.application.dtos.EventCreationRequest;
+import com.matimeline.eventmanager.domain.ports.services.EventService;
+import com.matimeline.eventmanager.domain.ports.services.ProductService;
+import com.matimeline.eventmanager.domain.ports.services.UserService;
+import com.matimeline.eventmanager.infrastructure.security.JwtService;
+
+/**
+ * Validates that @Valid rejects an event with a blank required field with 400
+ * before EventService is invoked (issue #31).
+ */
+@ExtendWith(MockitoExtension.class)
+class EventControllerValidationTest {
+
+    @Mock
+    private EventService eventService;
+    @Mock
+    private ProductService productService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private JwtService jwtService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        EventController controller = new EventController(eventService, productService, userService, jwtService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void createEvent_blankName_returns400_andServiceNotCalled() throws Exception {
+        String body = "{\"name\":\"\",\"type\":\"BIRTHDAY\",\"durationValue\":1,"
+                + "\"durationUnit\":\"DAY\",\"isRecurring\":false,"
+                + "\"productId\":\"" + java.util.UUID.randomUUID() + "\"}";
+
+        mockMvc.perform(post("/api/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+
+        verify(eventService, never()).createEvent(org.mockito.ArgumentMatchers.any(EventCreationRequest.class));
+    }
+}

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/GlobalExceptionHandlerValidationTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/GlobalExceptionHandlerValidationTest.java
@@ -1,0 +1,64 @@
+package com.matimeline.eventmanager.infrastructure.adapters.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.matimeline.eventmanager.domain.ports.services.EventService;
+import com.matimeline.eventmanager.domain.ports.services.ProductService;
+import com.matimeline.eventmanager.domain.ports.services.UserService;
+import com.matimeline.eventmanager.infrastructure.security.JwtService;
+
+/**
+ * Validates that MethodArgumentNotValidException (@Valid failures) is mapped by
+ * GlobalExceptionHandler to a 400 carrying the same structured body
+ * {timestamp,status,error,message} as the 404 handlers, with a generic message
+ * (no raw field-error list). Advice is wired explicitly via setControllerAdvice.
+ */
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerValidationTest {
+
+    @Mock
+    private EventService eventService;
+    @Mock
+    private ProductService productService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private JwtService jwtService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        EventController controller = new EventController(eventService, productService, userService, jwtService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void validationFailure_returns400_withStructuredBody() throws Exception {
+        String body = "{\"name\":\"\",\"type\":\"BIRTHDAY\",\"durationValue\":1,"
+                + "\"durationUnit\":\"DAY\",\"isRecurring\":false,"
+                + "\"productId\":\"" + java.util.UUID.randomUUID() + "\"}";
+
+        mockMvc.perform(post("/api/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("Validation failed"));
+    }
+}

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/ProductControllerOwnershipTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/ProductControllerOwnershipTest.java
@@ -1,0 +1,106 @@
+package com.matimeline.eventmanager.infrastructure.adapters.controllers;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.matimeline.eventmanager.application.services.EventServiceImpl;
+import com.matimeline.eventmanager.application.services.ProductServiceImpl;
+import com.matimeline.eventmanager.application.services.UserServiceImpl;
+import com.matimeline.eventmanager.domain.models.Product;
+import com.matimeline.eventmanager.domain.models.User;
+import com.matimeline.eventmanager.infrastructure.security.JwtService;
+
+import jakarta.servlet.http.Cookie;
+
+@ExtendWith(MockitoExtension.class)
+class ProductControllerOwnershipTest {
+
+    @Mock
+    private ProductServiceImpl productService;
+    @Mock
+    private EventServiceImpl eventService;
+    @Mock
+    private UserServiceImpl userService;
+    @Mock
+    private JwtService jwtService;
+
+    private MockMvc mockMvc;
+
+    private UUID callerId;
+    private UUID otherUserId;
+    private UUID productId;
+
+    @BeforeEach
+    void setUp() {
+        ProductController controller = new ProductController(productService, eventService, userService, jwtService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+        callerId = UUID.randomUUID();
+        otherUserId = UUID.randomUUID();
+        productId = UUID.randomUUID();
+    }
+
+    @Test
+    void getProductById_productOwnedByAnotherUser_returns403() throws Exception {
+        // Caller is authenticated and userId in path matches caller (passes the legacy check),
+        // but the product actually belongs to another user -> IDOR must be blocked.
+        User caller = new User(callerId, "Caller", "caller", "pwd", "ROLE_USER", "c@c.com");
+        User realOwner = new User(otherUserId, "Other", "other", "pwd", "ROLE_USER", "o@o.com");
+        Product foreignProduct = new Product(productId, "foreign", null, realOwner, List.of());
+
+        when(jwtService.extractUsername("caller-token")).thenReturn("caller");
+        when(userService.findDomainUserByUsername("caller")).thenReturn(Optional.of(caller));
+        when(productService.findDomainProductById(productId)).thenReturn(Optional.of(foreignProduct));
+
+        mockMvc.perform(get("/api/users/" + callerId + "/products/" + productId)
+                        .cookie(new Cookie("jwt", "caller-token")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deleteProduct_productOwnedByAnotherUser_returns403_andDoesNotDelete() throws Exception {
+        User caller = new User(callerId, "Caller", "caller", "pwd", "ROLE_USER", "c@c.com");
+        User realOwner = new User(otherUserId, "Other", "other", "pwd", "ROLE_USER", "o@o.com");
+        Product foreignProduct = new Product(productId, "foreign", null, realOwner, List.of());
+
+        when(jwtService.extractUsername("caller-token")).thenReturn("caller");
+        when(userService.findDomainUserByUsername("caller")).thenReturn(Optional.of(caller));
+        when(productService.findDomainProductById(productId)).thenReturn(Optional.of(foreignProduct));
+
+        mockMvc.perform(delete("/api/users/" + callerId + "/products/" + productId)
+                        .cookie(new Cookie("jwt", "caller-token")))
+                .andExpect(status().isForbidden());
+
+        verify(productService, never()).deleteById(productId);
+    }
+
+    @Test
+    void getProductById_ownProduct_returns200() throws Exception {
+        User caller = new User(callerId, "Caller", "caller", "pwd", "ROLE_USER", "c@c.com");
+        Product ownProduct = new Product(productId, "mine", null, caller, List.of());
+
+        when(jwtService.extractUsername("caller-token")).thenReturn("caller");
+        when(userService.findDomainUserByUsername("caller")).thenReturn(Optional.of(caller));
+        when(productService.findDomainProductById(productId)).thenReturn(Optional.of(ownProduct));
+
+        mockMvc.perform(get("/api/users/" + callerId + "/products/" + productId)
+                        .cookie(new Cookie("jwt", "caller-token")))
+                .andExpect(status().isOk());
+    }
+}

--- a/docs/memory/audits/sprint-1-test-coverage.md
+++ b/docs/memory/audits/sprint-1-test-coverage.md
@@ -1,6 +1,6 @@
 # Audit tests — Sprint 1
 
-> Généré en fin de Phase 6. Aucun `[MISSING]` → Phase 9 PR débloquée.
+> Généré en fin de Phase 6. Aucune couverture manquante → Phase 9 PR débloquée.
 > Sprint backend sécurité P0 (IDOR, validation, DTO). Aucun changement frontend.
 
 ## Couverture par BR
@@ -14,7 +14,7 @@
 | Auth validation | login payload vide → 400 (`@NotBlank`) | NON | ✅ | ✅ | ⚠ N/A | ⚠ N/A |
 | Sécurité config | STATELESS + @EnableMethodSecurity (pas de JSESSIONID) | NON | — | ✅ (boot contexte) | ⚠ N/A | ⚠ N/A |
 
-> Cross-system flow = NON pour tout le sprint : contrôle d'accès backend mono-système (REST + JWT), pas de flux multi-services/rôles. → Pas d'E2E métier obligatoire. Aucun `[MISSING]`.
+> Cross-system flow = NON pour tout le sprint : contrôle d'accès backend mono-système (REST + JWT), pas de flux multi-services/rôles. → Pas d'E2E métier obligatoire. Aucune couverture manquante.
 
 ## Tests créés / modifiés
 - `EventServiceImplTest` (#28, créé — 5 tests : PATCH partiel, all-fields, lien produit, color-only, not-found)

--- a/docs/memory/audits/sprint-1-test-coverage.md
+++ b/docs/memory/audits/sprint-1-test-coverage.md
@@ -1,0 +1,41 @@
+# Audit tests — Sprint 1
+
+> Généré en fin de Phase 6. Aucun `[MISSING]` → Phase 9 PR débloquée.
+> Sprint backend sécurité P0 (IDOR, validation, DTO). Aucun changement frontend.
+
+## Couverture par BR
+
+| BR | Description | Cross-system flow | Unit backend | Intégration | E2E parcours | E2E métier |
+|----|-------------|:---:|:---:|:---:|:---:|:---:|
+| BR-EVE-001 | Titre événement requis (validation) | NON | ✅ | ✅ (`@Valid`) | ⚠ N/A backend-only | ⚠ N/A |
+| BR-EVE-008 | Ownership PATCH/DELETE/CREATE event (IDOR) | NON | ✅ | ✅ | ⚠ N/A | ⚠ N/A |
+| BR-PRO-004 | Ownership produit↔user (IDOR) | NON | ✅ | ✅ | ⚠ N/A | ⚠ N/A |
+| BR-PROD-001 | Nom produit requis (`@Valid` createProduct) | NON | ⚠ annot. seule | ✅ (`@Valid`) | ⚠ N/A | ⚠ N/A |
+| Auth validation | login payload vide → 400 (`@NotBlank`) | NON | ✅ | ✅ | ⚠ N/A | ⚠ N/A |
+| Sécurité config | STATELESS + @EnableMethodSecurity (pas de JSESSIONID) | NON | — | ✅ (boot contexte) | ⚠ N/A | ⚠ N/A |
+
+> Cross-system flow = NON pour tout le sprint : contrôle d'accès backend mono-système (REST + JWT), pas de flux multi-services/rôles. → Pas d'E2E métier obligatoire. Aucun `[MISSING]`.
+
+## Tests créés / modifiés
+- `EventServiceImplTest` (#28, créé — 5 tests : PATCH partiel, all-fields, lien produit, color-only, not-found)
+- `EventControllerOwnershipTest` (#30 + correction — DELETE cross-user 403, PATCH cross-user 403, owner 200)
+- `ProductControllerOwnershipTest` (#30 — GET/DELETE cross-user 403, owner 200)
+- `AuthControllerValidationTest` (#31 + correction — email invalide 400, password vide 400, login blank 400)
+- `EventControllerValidationTest` (#31 — champ requis vide 400, service jamais appelé)
+
+## Résultats runs
+- Backend (suite complète) : **16 tests, 16 passed, 0 failed, 0 errors** — BUILD SUCCESS (`mvn -DskipTests=false test`).
+- Frontend : aucun changement → pas de run.
+- E2E : aucun (sprint backend).
+
+## Conclusion
+Prêt pour PR. Couverture sécurité : IDOR events (PATCH/DELETE/CREATE) + IDOR products + validation 400 + JwtException→401 testés. Pas de blocage.
+
+### Follow-ups identifiés (review) — à arbitrer en /sprint end Phase 4
+- Cookie `Secure=false` (conditionner à l'env)
+- `GET /auth/me` expose l'objet User complet → **déjà couvert par Sprint 2 #32 (fuite /me)**
+- ProductController injecte les `*Impl` au lieu des ports (violation hexagonale, refactor)
+- `EventServiceImpl.findEventById` double-hit DB + `printStackTrace` (pré-existant)
+- `getEventsByProductId` renvoie 404 sur liste vide (sémantique)
+- `hasAuthority("ROLE_USER")` → `hasRole("USER")` (lisibilité)
+- Identité via `SecurityContextHolder` plutôt que cookie brut (cohérence cookie/Bearer)

--- a/docs/memory/decisions.md
+++ b/docs/memory/decisions.md
@@ -1,0 +1,12 @@
+# Décisions — MyTimeline
+
+> Décisions d'architecture/implémentation consolidées en fin de sprint.
+
+## DEC-S1-001 — Logique de mise à jour event déplacée controller → service
+`EventController.updateEvent` contenait la boucle de mapping champ-par-champ (`containsKey`/`instanceof`/casts) sur un `Map<String,Object>`. Remplacée par un DTO typé `EventUpdateRequest` (`@Valid`) ; le mapping vit désormais dans `EventServiceImpl.updateEvent(UUID, EventUpdateRequest)`. Motif : respect hexagonal (controller mince), surface minimale avant les retouches #30/#31. (Sprint 1 #28)
+
+## DEC-S1-002 — @Size(min=1) plutôt que @NotBlank sur EventUpdateRequest.title
+Pour préserver la sémantique PATCH partielle (le front a un endpoint « couleurs seules » sans title). `@Size(min=1)` rejette "" (→400 « titre vide ») mais tolère l'absence (null). Voir [[pitfalls]] PIT-S1-001. (Sprint 1 #28)
+
+## DEC-S1-003 — Identité d'ownership via cookie JWT (pattern existant ProductController)
+Sprint 1 a réutilisé le pattern existant `@CookieValue("jwt")` + `jwtService` pour l'ownership, plutôt que `SecurityContextHolder`. Cohérence avec le code existant. Migration vers `SecurityContextHolder` (cohérence cookie/Bearer) actée en follow-up #93. (Sprint 1 #30)

--- a/docs/memory/patterns.md
+++ b/docs/memory/patterns.md
@@ -1,0 +1,9 @@
+# Patterns — MyTimeline
+
+> Patterns réutilisables consolidés en fin de sprint.
+
+## PAT-S1-001 — Ownership IDOR via helper d'identité
+Contrôle d'accès sur les endpoints de mutation : helper privé (`resolveCaller(token)` → User|null ; `checkEventOwnership` → ResponseEntity d'erreur non-null ou null si OK) factorisant 401/404/403. L'identité est dérivée du JWT authentifié, JAMAIS d'un path param contrôlable par le client. Pour un event : `event → productId → product.getUser().getId() == caller.getId()`. (Sprint 1 #30/#91)
+
+## PAT-S1-002 — resolveCaller centralise l'extraction JWT + le mapping d'erreur
+`resolveCaller(token)` enveloppe `jwtService.extractUsername` dans `try/catch (JwtException) → null`, réutilisé par tous les checks d'ownership (createEvent, PATCH, DELETE). Évite la duplication d'`extractUsername` nu et le risque 500. (Sprint 1 #91)

--- a/docs/memory/pitfalls.md
+++ b/docs/memory/pitfalls.md
@@ -1,0 +1,15 @@
+# Pitfalls — MyTimeline
+
+> Pièges récurrents consolidés en fin de sprint. 4 lignes max par entrée.
+
+## PIT-S1-001 — @NotBlank sur un DTO de PATCH casse les updates partiels
+Un PATCH partiel légitime peut omettre un champ (ex: endpoint « couleurs seules »). `@NotBlank` rejette null ET "" → casse l'omission. Utiliser `@Size(min=1)` (rejette "" mais tolère null) + application conditionnelle `if(!=null)` côté service. Vérifier TOUS les call-sites front avant de poser une contrainte de présence. (Sprint 1 #28)
+
+## PIT-S1-002 — @Valid inerte si le DTO ne porte aucune contrainte
+`@Valid` sur un `@RequestBody` ne fait rien si le DTO n'a aucune annotation Bean Validation (`AuthRequest` sans `@NotBlank` → login acceptait un payload vide). Toujours vérifier que le DTO porte des contraintes, sinon `@Valid` est cosmétique. (Sprint 1 #31)
+
+## PIT-S1-003 — jwtService.extractUsername non catché dans un controller → 500
+`extractUsername` lève `JwtException` (token malformé/expiré/signature) ; sans try/catch dans le controller → 500 + fuite stacktrace. Centraliser dans un helper `resolveCaller(token)` avec `try/catch (JwtException) → null` mappé en 401. (Sprint 1 #30/#91)
+
+## PIT-S1-004 — `git add -A` dans un worktree sprint capture les artefacts d'orchestration
+Le worktree sprint contient des fichiers untracked d'orchestration (`docs/memory/sprints/sprint-N/*` briefings/done.md). `git add -A` les capture par erreur. Stager explicitement les fichiers source/test (`git add <paths>` ciblés). (Sprint 1 correction post-review)

--- a/docs/memory/sprint-history.md
+++ b/docs/memory/sprint-history.md
@@ -1,0 +1,31 @@
+# Sprint history — MyTimeline
+
+> Tracking des sprints. Source unique de vérité = milestones GitHub (MEMO-011).
+> Plan généré le 2026-06-25 (3 sprints séquentiels, harden-then-found).
+
+## Sprint 1 — 2026-06-25 (PLANIFIE — cohésion ~0.33, Sécurité backend : IDOR, validation, DTO)
+**Objectif :** Corriger les failles P0 backend (IDOR, validation silencieuse) + poser le DTO updateEvent.
+**Milestone GitHub :** #1
+**Issues :** #28, #30, #31
+**Vagues :** V1 = #28 | V2 = #30 | V3 = #31 (séquentiel — fichiers partagés EventController/SecurityConfig)
+**Migrations Flyway :** aucune
+**Dépend de :** aucune
+**Status :** Planifié
+
+## Sprint 2 — (PLANIFIE — cohésion ~1.0, Sécurité auth : fuite /me, rate-limit, 401/403)
+**Objectif :** Compléter le durcissement auth (fuite password, brute-force, codes HTTP).
+**Milestone GitHub :** #2
+**Issues :** #32, #33, #51
+**Vagues :** V1 = #32 + #51 (disjoints) | V2 = #33 (SecurityConfig après #32)
+**Migrations Flyway :** aucune (contrainte unique #32 posée en S3 via #42)
+**Dépend de :** Sprint 1 (#51 requiert le ControllerAdvice de #30)
+**Status :** Planifié
+
+## Sprint 3 — (PLANIFIE — cohésion ~0.4, Fondations infra & DB : secrets, Flyway, audit JPA)
+**Objectif :** Externaliser les secrets, versionner le schéma (Flyway), poser l'audit JPA (@Version/timestamps).
+**Milestone GitHub :** #3
+**Issues :** #34, #42, #43
+**Vagues :** V1 = #34 | V2 = #42 (absorbe contraintes uniques #32) | V3 = #43 (après migration #42)
+**Migrations Flyway :** V1__baseline.sql + V2 (version/timestamps + unique)
+**Dépend de :** Sprint 2 (coordination contraintes uniques)
+**Status :** Planifié

--- a/docs/memory/sprint-history.md
+++ b/docs/memory/sprint-history.md
@@ -10,7 +10,9 @@
 **Vagues :** V1 = #28 | V2 = #30 | V3 = #31 (séquentiel — fichiers partagés EventController/SecurityConfig)
 **Migrations Flyway :** aucune
 **Dépend de :** aucune
-**Status :** Planifié
+**Status :** En cours (implémenté, PR ouverte — V1/V2/V3 livrées + correction post-review)
+**Commits :** 1c308ba (#28) · b606af8 (#30) · de0c095 (#31) · ec1e399 (fix post-review IDOR createEvent + JwtException 401)
+**Tests :** Backend 16/16 verts (mvn test). Frontend : aucun changement.
 
 ## Sprint 2 — (PLANIFIE — cohésion ~1.0, Sécurité auth : fuite /me, rate-limit, 401/403)
 **Objectif :** Compléter le durcissement auth (fuite password, brute-force, codes HTTP).

--- a/docs/memory/sprint-history.md
+++ b/docs/memory/sprint-history.md
@@ -3,16 +3,28 @@
 > Tracking des sprints. Source unique de vérité = milestones GitHub (MEMO-011).
 > Plan généré le 2026-06-25 (3 sprints séquentiels, harden-then-found).
 
-## Sprint 1 — 2026-06-25 (PLANIFIE — cohésion ~0.33, Sécurité backend : IDOR, validation, DTO)
+## Sprint 1 — 2026-06-25 (Terminé — merge PR #91 dans dev — cohésion ~0.33, Sécurité backend : IDOR, validation, DTO)
 **Objectif :** Corriger les failles P0 backend (IDOR, validation silencieuse) + poser le DTO updateEvent.
-**Milestone GitHub :** #1
-**Issues :** #28, #30, #31
-**Vagues :** V1 = #28 | V2 = #30 | V3 = #31 (séquentiel — fichiers partagés EventController/SecurityConfig)
+**Milestone GitHub :** #1 (fermé après merge)
+**Issues livrées (3) :** #28, #30, #31
+**Vagues exécutées :** V1 = #28 | V2 = #30 | V3 = #31 (séquentiel — fichiers partagés EventController/SecurityConfig)
+**Cohésion score :** ~0.33
+**Commits :** 1c308ba (#28 DTO) · b606af8 (#30 ownership/ControllerAdvice) · de0c095 (#31 @Valid/STATELESS) · ec1e399 (fix post-review : IDOR createEvent + JwtException 401) · e542dc8 (handler 400 @Valid, review PR #91)
 **Migrations Flyway :** aucune
 **Dépend de :** aucune
-**Status :** En cours (implémenté, PR ouverte — V1/V2/V3 livrées + correction post-review)
-**Commits :** 1c308ba (#28) · b606af8 (#30) · de0c095 (#31) · ec1e399 (fix post-review IDOR createEvent + JwtException 401)
-**Tests :** Backend 16/16 verts (mvn test). Frontend : aucun changement.
+**BR impactées :** BR-EVE-001 (titre @Valid effectif), BR-EVE-007 (@NotNull isRecurring), BR-EVE-008 (ownership create/update/delete), BR-PRO-004 (ownership produit), BR-PROD-001 (@Valid nom produit).
+**Reviews :** review batch (Phase 7 + /review-pr #91) — 2 CRITIQUE (IDOR createEvent, JwtException→500) + 3 MAJEUR, tous RÉSOLUS (commits ec1e399, e542dc8).
+**Tests :** Backend 17/17 verts (mvn test). Frontend : aucun changement → pas d'E2E à compléter.
+**Nouveaux pitfalls/patterns/décisions :** voir docs/memory/{pitfalls,patterns,decisions}.md (PIT-S1-001..004, PAT-S1-001/002, DEC-S1-001..003).
+**Follow-ups arbitrés (triage Phase 4) :**
+  - getProducts catch(Exception) [S | auth] → issue #92 (backlog)
+  - Identité via SecurityContextHolder [M | auth] → issue #93 (backlog)
+  - Refactor Impl→ports hexagonal [M | transversal] → issue #94 (backlog)
+  - findEventById double-hit + printStackTrace [S | events] → issue #95 (backlog)
+  - hasRole + 404 liste vide [XS | events] → issue #96 (backlog)
+  - @Valid Category à vérifier [XS | categories] → issue #97 (backlog)
+  - Cookie Secure conditionné env [S | auth] → fusionné dans #32 (commentaire, évite doublon)
+  Bilan : 6 issues créées, 1 fusionné, 0 discardé, 0 absorbé (ratio discard 0%).
 
 ## Sprint 2 — (PLANIFIE — cohésion ~1.0, Sécurité auth : fuite /me, rate-limit, 401/403)
 **Objectif :** Compléter le durcissement auth (fuite password, brute-force, codes HTTP).

--- a/docs/memory/sprints/sprint-1/architect-plans.md
+++ b/docs/memory/sprints/sprint-1/architect-plans.md
@@ -1,0 +1,37 @@
+# Mini-plans architect — Sprint 1
+
+issue_28:
+  fichiers_cles:
+    - "backend/.../infrastructure/adapters/controllers/EventController.java"
+    - "backend/.../application/dtos/EventUpdateRequest.java (nouveau)"
+    - "frontend/src/services/eventService.ts (sync contrat)"
+  couches_touchees: ["application", "infrastructure", "frontend"]
+  strategie_test: "unit + integration"
+  risque_regression: "BR-EVE-003/008 — le contrat API updateEvent change (Map -> DTO), eventService front doit suivre"
+  ordre_ecriture: "dto -> controller -> front eventService/types"
+  zod_dto_sync: "OUI"
+  possibly_done: false
+
+issue_30:
+  fichiers_cles:
+    - "backend/.../infrastructure/adapters/controllers/EventController.java"
+    - "backend/.../infrastructure/adapters/controllers/ProductController.java"
+    - "backend/.../infrastructure/.../GlobalExceptionHandler.java (nouveau, @RestControllerAdvice)"
+  couches_touchees: ["infrastructure", "application"]
+  strategie_test: "unit + integration (cas 403 cross-user)"
+  risque_regression: "BR-EVE-008 / BR-PRO-004 ownership ; retirer @CrossOrigin(*) peut casser le CORS front si SecurityConfig pas aligné"
+  ordre_ecriture: "ControllerAdvice global -> ownership checks events -> ownership checks products"
+  zod_dto_sync: "NON"
+  possibly_done: false
+
+issue_31:
+  fichiers_cles:
+    - "backend/.../infrastructure/security/SecurityConfig.java"
+    - "tous les @RequestBody des controllers (@Valid)"
+  couches_touchees: ["infrastructure"]
+  strategie_test: "unit (400 validation) + integration"
+  risque_regression: "BR-EVE-001/007 — @Valid déclenche des validations jamais actives ; STATELESS peut casser des tests d'intégration session"
+  ordre_ecriture: "@EnableMethodSecurity + sessionCreationPolicy STATELESS -> @Valid sur les @RequestBody"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  depend_intra: "requiert #28 (DTO updateEvent) pour pouvoir annoter @Valid"

--- a/docs/memory/sprints/sprint-1/issue-28-done.md
+++ b/docs/memory/sprints/sprint-1/issue-28-done.md
@@ -1,0 +1,33 @@
+# Issue #28 — DONE
+
+**Titre :** [REFACTOR] Refondre EventController.updateEvent avec DTO typé
+**Vague :** V1 | **Modèle :** opus/high | **Commit :** 1c308ba
+
+## Résumé
+- Remplacé `Map<String,Object>` par DTO typé `EventUpdateRequest` (`@Valid`) sur `PATCH /api/events/{id}`.
+- Introspection manuelle (containsKey/instanceof/casts) supprimée du controller (67→4 lignes), mapping déplacé en couche service `EventServiceImpl.updateEvent(UUID, EventUpdateRequest)`.
+- Champs DTO (croisés code réel, pas l'issue) : title, type, durationValue, durationUnit, isRecurring, recurrenceUnit, backgroundColor, borderColor, textColor. productId préservé via originalProductId+setProduct.
+- **Décision clé :** `@Size(min=1,max=100)` sur title (PAS `@NotBlank`) → rejette "" (400) mais tolère absence (null) car le path front `updateEventColor` envoie les couleurs seules sans title. Service applique chaque champ si `!= null`.
+- 400 "titre vide" garanti via `@Valid` → `MethodArgumentNotValidException` → handler Spring défaut (pas besoin de GlobalExceptionHandler, qui arrive en #30).
+- Frontend : AUCUNE modif nécessaire (contrat JSON identique).
+
+## Fichiers
+- `application/dtos/EventUpdateRequest.java` (créé)
+- `infrastructure/adapters/controllers/EventController.java` (updateEvent réduit)
+- `application/services/EventServiceImpl.java` (+updateEvent)
+- `domain/ports/services/EventService.java` (+signature)
+- `test/.../application/services/EventServiceImplTest.java` (créé, 5 tests)
+
+## Tests
+`mvn -Dtest=EventServiceImplTest test` → 5/5 verts. `mvn compile` OK.
+
+## Signaux mémoire
+- [MEMORY:pitfall] Avant de poser `@NotBlank` sur un DTO de PATCH, vérifier TOUS les call-sites front : un PATCH partiel légitime peut omettre le champ. Ici `@Size(min=1)` + application conditionnelle `if(!=null)`.
+- [MEMORY:decision] Mapping introspectif déplacé controller→service (hexagonal, surface minimale avant #30/#31).
+
+## Recommandations suite
+- RECOMMAND_REVIEWER : contrat REST P0 modifié — review du diff (décision @Size vs critère "titre vide→400").
+- Pas de RECOMMAND_DB_EXPERT (aucun schéma/migration).
+- BR-EVE-008 (IDOR ownership) explicitement reporté à #30.
+
+STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-1/issue-30-done.md
+++ b/docs/memory/sprints/sprint-1/issue-30-done.md
@@ -1,0 +1,21 @@
+# Issue #30 — DONE
+
+**Titre :** [SECURITY] Ownership checks (IDOR) + ControllerAdvice global
+**Vague :** V2 | **Modèle :** opus/high | **Commit :** b606af8
+
+## Résumé
+- Pattern identité : `@CookieValue("jwt")` → `jwtService.extractUsername` → `userService.findDomainUserByUsername` → `getId()` (identité authentifiée, jamais path param). EventController re-câblé sur les **ports domaine** (EventService/ProductService/UserService).
+- **EventController** PATCH/DELETE `/api/events/{id}` : helper `checkEventOwnership` (event→productId→product.getUser().getId()==caller.id) → 403 sinon, 404 si absent, 401 si token absent/inconnu. `@CrossOrigin(origins="*")` retiré (CORS gérée par SecurityConfig, non modifié).
+- **ProductController** : `productBelongsToUser` ajouté sur GET+DELETE `/products/{productId}` et GET `.../events` → ferme le trou IDOR product↔user (legacy `userId==jwt` conservé). Null-safe sur getUser().
+- **GlobalExceptionHandler** `@RestControllerAdvice` (infra) : Event/Product/Category/UserNotFoundException → 404 JSON `{timestamp,status,error,message}`, message générique (PAS `ex.getMessage()`) → zéro fuite stacktrace/PII.
+- Tests : EventControllerOwnershipTest + ProductControllerOwnershipTest (403 cross-user + 200 owner), MockMvc standalone + Mockito. **Suite complète 11 tests / 0 échec.** Compile OK.
+
+## Signaux mémoire
+- [MEMORY:business-rule] BR-EVE-008 : propriétaire event = event→productId→product.getUser().getId() (Event domaine ne porte que productId). Côté products, `userId==jwt` NE SUFFIT PAS — vérifier `product.getUser().getId()==userId`.
+- [MEMORY:pattern] Ownership IDOR : helper privé renvoyant ResponseEntity d'erreur non-null (ou null si OK) pour factoriser 401/404/403.
+
+## Recommandations suite
+- **RECOMMAND_SECURITY_EXPERT** : un JWT malformé dans le helper d'ownership EventController lèverait une JwtException non mappée → 500 (ProductController GET wrappe en try/catch, pas le helper events). À traiter (mapper JwtException dans le handler, ou try/catch) — à cadrer avec #31.
+- Pas de RECOMMAND_DB_EXPERT (aucun schéma/requête).
+
+STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-1/issue-31-done.md
+++ b/docs/memory/sprints/sprint-1/issue-31-done.md
@@ -1,0 +1,20 @@
+# Issue #31 — DONE
+
+**Titre :** [SECURITY] @Valid partout + @EnableMethodSecurity + session STATELESS
+**Vague :** V3 | **Modèle :** opus/high | **Commit :** de0c095
+
+## Résumé
+- `@Valid` ajouté sur les `@RequestBody` manquants : AuthController.login+register, EventController.createEvent, ProductController.createProduct, CategoryController.createCategory. updateEvent déjà `@Valid` (#28, non doublé). Imports `jakarta.validation.Valid` ajoutés.
+- SecurityConfig : `@EnableMethodSecurity` + `.sessionManagement(STATELESS)`. CORS + authorizeHttpRequests + chaîne JwtFilter intacts. Ownership #30 / GlobalExceptionHandler non touchés.
+- Tests 400 : AuthControllerValidationTest (email invalide, password vide) + EventControllerValidationTest (nom vide, service jamais appelé). MethodArgumentNotValidException → 400 confirmé.
+- **Non-régression suite COMPLÈTE : 6 classes / 14 tests, 0 failure / 0 error.** Contexte Spring boote sous STATELESS + @EnableMethodSecurity. Pas de JSESSIONID (sessions désactivées, auth = cookie JWT custom). Compile OK.
+
+## Signaux mémoire
+- [MEMORY:pattern] `@Valid` est inerte si le DTO n'a aucune contrainte Bean Validation. `AuthRequest` n'a aucune annotation → `@Valid` sur login est cohérent mais sans effet. Vérifier que le DTO porte bien des contraintes.
+
+## Recommandations suite (RECOMMAND_FOLLOWUP)
+1. JWT malformé dans `checkEventOwnership` (EventController) → `JwtException` non mappée → 500 (hérité de #30, hors scope #31).
+2. `AuthRequest` sans contraintes : ajouter `@NotBlank` username/password pour rejeter payload vide en 400.
+3. Category model : confirmer présence d'annotations sinon `@Valid` createCategory inerte.
+
+STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-2/architect-plans.md
+++ b/docs/memory/sprints/sprint-2/architect-plans.md
@@ -1,0 +1,39 @@
+# Mini-plans architect — Sprint 2
+
+issue_32:
+  fichiers_cles:
+    - "backend/.../infrastructure/adapters/controllers/AuthController.java"
+    - "backend/.../application/dtos/UserResponse.java (nouveau, sans password)"
+    - "backend/.../infrastructure/security/SecurityConfig.java (cookie login/logout cohérent)"
+    - "backend/.../infrastructure/entities/UserEntity.java (unique username/email — niveau JPA en attendant Flyway S3)"
+  couches_touchees: ["application", "infrastructure"]
+  strategie_test: "unit + integration (/me sans password)"
+  risque_regression: "BR-AUT-008 — /me ne doit jamais fuiter le hash ; cohérence Secure/SameSite/Domain login vs logout"
+  ordre_ecriture: "UserResponse DTO -> /me -> cookie -> contrainte unique (coordonnée avec #42)"
+  zod_dto_sync: "OUI (consumer /me front)"
+  possibly_done: false
+
+issue_33:
+  fichiers_cles:
+    - "backend/.../infrastructure/security/SecurityConfig.java (headers)"
+    - "backend/pom.xml (Bucket4j)"
+    - "backend/.../infrastructure/security/RateLimitFilter.java (nouveau)"
+  couches_touchees: ["infrastructure"]
+  strategie_test: "integration (429 après N tentatives)"
+  risque_regression: "rate-limit sur /auth/* ; CSP/HSTS peuvent casser le front Next.js si trop stricts"
+  ordre_ecriture: "dep Bucket4j -> filtre rate-limit -> headers SecurityConfig"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  depend_intra: "V2 après #32 (SecurityConfig partagé)"
+
+issue_51:
+  fichiers_cles:
+    - "backend/.../infrastructure/.../GlobalExceptionHandler.java (issu de #30)"
+    - "backend/.../infrastructure/security/JwtFilter.java"
+  couches_touchees: ["infrastructure"]
+  strategie_test: "integration (401 non-authentifié vs 403 non-autorisé)"
+  risque_regression: "les exceptions levées dans JwtFilter ne traversent PAS le ControllerAdvice -> écriture directe dans HttpServletResponse"
+  ordre_ecriture: "mapping 401 vs 403 dans ControllerAdvice + handler JwtFilter"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  depend_inter: "requiert le ControllerAdvice de #30 (Sprint 1)"

--- a/docs/memory/sprints/sprint-3/architect-plans.md
+++ b/docs/memory/sprints/sprint-3/architect-plans.md
@@ -1,0 +1,41 @@
+# Mini-plans architect — Sprint 3
+
+issue_34:
+  fichiers_cles:
+    - "backend/src/main/resources/application.properties"
+    - "backend/src/main/resources/application-{dev,prod}.properties (nouveaux)"
+    - ".gitignore (corriger la règle qui ne matche pas le vrai chemin)"
+    - "frontend/.env.example (nouveau)"
+  couches_touchees: ["infrastructure (config)"]
+  strategie_test: "smoke (boot avec variables d'env)"
+  risque_regression: "la rotation de jwt.secret invalide tous les tokens existants (déconnexion globale)"
+  ordre_ecriture: "externaliser -> profils dev/prod -> rotation secret"
+  zod_dto_sync: "NON"
+  possibly_done: false
+
+issue_42:
+  fichiers_cles:
+    - "backend/pom.xml (flyway-core + flyway-database-postgresql)"
+    - "backend/src/main/resources/db/migration/V1__baseline.sql (nouveau)"
+    - "backend/src/main/resources/db/migration/V2__unique_constraints.sql (username/email)"
+    - "backend/src/main/resources/application.properties (ddl-auto=validate)"
+  couches_touchees: ["infrastructure"]
+  strategie_test: "integration (boot + migrate sur base de test)"
+  risque_regression: "la baseline DOIT refléter exactement le schéma généré par Hibernate ; ddl-auto=validate bloque au boot si divergence"
+  ordre_ecriture: "dep Flyway -> baseline SQL -> contraintes uniques -> bascule ddl-auto validate"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  depend_intra: "V2 après #34 (application.properties partagé)"
+
+issue_43:
+  fichiers_cles:
+    - "backend/.../infrastructure/entities/*.java (toutes les entités)"
+    - "backend/src/main/resources/db/migration/V3__audit_columns.sql (created_at/updated_at/version)"
+    - "backend/.../config @EnableJpaAuditing"
+  couches_touchees: ["infrastructure"]
+  strategie_test: "unit (equals/hashCode) + integration (auditing)"
+  risque_regression: "equals/hashCode mal défini -> détachement JPA ; @Version change la sémantique de save"
+  ordre_ecriture: "migration colonnes -> annotations entités + EnableJpaAuditing -> equals/hashCode"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  depend_intra: "V3 après #42 (migration Flyway requise)"


### PR DESCRIPTION
## Sprint 1 — Sécurité backend P0 (IDOR, validation, DTO)

Durcissement sécurité backend prioritaire : fermeture des failles IDOR, activation de la validation silencieuse, et typage du endpoint `updateEvent`. Cohésion ~0.33 — exécution séquentielle (fichiers partagés `EventController`/`SecurityConfig`).

### Issues livrées
| # | Type | Résumé |
|---|------|--------|
| #28 | refactor | DTO typé `EventUpdateRequest` remplace `Map<String,Object>` sur `PATCH /api/events/{id}` ; mapping déplacé controller→service |
| #30 | security | Ownership IDOR (events PATCH/DELETE + products) + `GlobalExceptionHandler` (404 JSON) + retrait `@CrossOrigin(*)` |
| #31 | security | `@Valid` sur tous les `@RequestBody` + `@EnableMethodSecurity` + session `STATELESS` |

### Changements clés
- **IDOR fermé** sur events (`PATCH`/`DELETE`/**`POST`**) et products : ownership résolu via l'identité JWT authentifiée (event→product→`product.user.id`), jamais via un path param. Le `POST /api/events` (création) a été ajouté au périmètre suite à la review (même classe de vuln).
- **Validation effective** : `@Valid` déclenche enfin les contraintes Bean Validation (titre vide → 400, email invalide → 400). `AuthRequest` doté de `@NotBlank`.
- **Robustesse JWT** : `JwtException` (token malformé/expiré) catchée dans tous les helpers d'ownership → 401 au lieu de 500/stacktrace.
- **Config sécurité** : sessions `STATELESS` (plus de `JSESSIONID`), `@EnableMethodSecurity` (prépare les futurs `@PreAuthorize`).
- **Décision DTO** : `@Size(min=1)` (pas `@NotBlank`) sur `title` pour préserver la sémantique PATCH partielle (path front « couleurs seules »).
- **Anti-fuite** : `GlobalExceptionHandler` renvoie un message générique (pas d'ID/PII/stacktrace) ; `login` ne sérialise plus l'objet `Exception`.

### BR impactées
BR-EVE-001 (titre requis), BR-EVE-008 (ownership events), BR-PRO-004 (ownership products), BR-PROD-001 (nom produit).

### Tests
- **Backend : 16/16 verts** (`mvn -DskipTests=false test`, BUILD SUCCESS).
- Couverture : 403 cross-user (event PATCH+DELETE, product GET+DELETE), 400 validation (event, auth login), DTO PATCH partiel, JwtException→401.
- Frontend : aucun changement → pas de run / pas de coverage E2E à compléter.
- Audit complet : `docs/memory/audits/sprint-1-test-coverage.md`.

### Review batch (1 cycle correctif appliqué)
2 CRITIQUES + 2 MAJEURS in-scope corrigés dans `ec1e399` (IDOR createEvent, JwtException→500, test PATCH cross-user, AuthRequest/login leak).

### Follow-ups (à arbitrer en `/sprint end`)
- Cookie `Secure=false` (conditionner à l'env)
- `GET /auth/me` expose l'objet User complet → **déjà planifié Sprint 2 #32 (fuite /me)**
- ProductController injecte les `*Impl` au lieu des ports (refactor hexagonal)
- `EventServiceImpl.findEventById` double-hit DB + `printStackTrace` (pré-existant)
- `getEventsByProductId` 404 sur liste vide ; `hasAuthority`→`hasRole` ; identité via `SecurityContextHolder`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
