### PR TITLE
:white_check_mark: Isoler les tests d'intégration via Testcontainers Postgres

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -28,6 +28,24 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<!--
+			Testcontainers : on surcharge la version managée par le BOM Spring Boot
+			3.2.2 (1.19.3) vers 1.20.6. La 1.19.3 embarque docker-java 3.3.4 qui
+			négocie une version d'API trop ancienne et se fait rejeter en HTTP 400
+			par les moteurs Docker récents (Docker Desktop ≥ 4.x, Engine 29.x,
+			MinAPIVersion 1.44). La 1.20.6 embarque un docker-java récent compatible.
+		-->
+		<testcontainers.version>1.20.6</testcontainers.version>
+		<!--
+			Épingle la version d'API Docker utilisée par docker-java (le client de
+			Testcontainers). Sa valeur par défaut tombe HORS de la plage supportée
+			par les moteurs Docker récents (Docker Desktop 4.x / Engine 29.x exposent
+			MinAPIVersion 1.44) : la requête /v1.xx/info renvoie alors HTTP 400 et
+			Testcontainers conclut « Could not find a valid Docker environment ».
+			1.44 = plancher supporté par tout moteur ≥ 25.0. Injectée dans le JVM
+			forké par surefire (cf. build/plugins). Surcharge : -Ddocker.api.version=1.51.
+		-->
+		<docker.api.version>1.44</docker.api.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -73,6 +91,23 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!--
+			Testcontainers (#…) — les tests @SpringBootTest démarrent désormais
+			contre un conteneur Postgres JETABLE (même dialecte que la prod, Flyway
+			rejoue V1/V2 from scratch), plus contre la base dev partagée localhost:5432.
+			Version pilotée par la property testcontainers.version (cf. <properties>,
+			surchargée à 1.20.6 pour compatibilité moteur Docker récent).
+		-->
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -132,6 +167,20 @@
 									</path>
 							</annotationProcessorPaths>
 					</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<systemPropertyVariables>
+						<!--
+							Passé au JVM de test pour que docker-java (Testcontainers)
+							négocie une version d'API Docker supportée par le moteur
+							local. Sans ça, détection Docker en échec (HTTP 400 sur /info).
+						-->
+						<api.version>${docker.api.version}</api.version>
+					</systemPropertyVariables>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/backend/src/test/java/com/matimeline/eventmanager/EventmanagerApplicationTests.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/EventmanagerApplicationTests.java
@@ -3,8 +3,10 @@ package com.matimeline.eventmanager;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import com.matimeline.eventmanager.support.AbstractPostgresIntegrationTest;
+
 @SpringBootTest
-class EventmanagerApplicationTests {
+class EventmanagerApplicationTests extends AbstractPostgresIntegrationTest {
 
 	@Test
 	void contextLoads() {

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/security/AuthErrorContractIntegrationTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/security/AuthErrorContractIntegrationTest.java
@@ -15,6 +15,8 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.matimeline.eventmanager.support.AbstractPostgresIntegrationTest;
+
 /**
  * Integration contract for issue #51: 401 vs 403 must be distinguished by the
  * real Spring Security filter chain, never collapse to 403-for-anonymous nor
@@ -24,7 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
  */
 @SpringBootTest
 @AutoConfigureMockMvc
-class AuthErrorContractIntegrationTest {
+class AuthErrorContractIntegrationTest extends AbstractPostgresIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/security/RateLimitingAndHeadersIntegrationTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/security/RateLimitingAndHeadersIntegrationTest.java
@@ -22,6 +22,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import com.matimeline.eventmanager.support.AbstractPostgresIntegrationTest;
+
 import io.github.bucket4j.TimeMeter;
 
 /**
@@ -36,7 +38,7 @@ import io.github.bucket4j.TimeMeter;
  */
 @SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
 @AutoConfigureMockMvc
-class RateLimitingAndHeadersIntegrationTest {
+class RateLimitingAndHeadersIntegrationTest extends AbstractPostgresIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/src/test/java/com/matimeline/eventmanager/support/AbstractPostgresIntegrationTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/support/AbstractPostgresIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.matimeline.eventmanager.support;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Socle des tests {@code @SpringBootTest} : démarre UN conteneur Postgres
+ * jetable, partagé entre toutes les classes de test, à la place de la base dev
+ * partagée {@code localhost:5432/eventmanager}.
+ *
+ * <p>Motivation (incident 2026-06-25) : faire tourner les @SpringBootTest contre
+ * la base dev réelle les rendait non déterministes (mutations concurrentes entre
+ * worktrees) et cassait toute la suite quand la base dev était dans un état
+ * incohérent (doublons d'email faisant échouer la migration V2 {@code uq_users_email}).
+ *
+ * <p>Pattern <em>singleton container</em> : le conteneur est démarré une seule
+ * fois dans un bloc statique et JAMAIS arrêté explicitement — il est réutilisé
+ * par toutes les classes filles (rapidité) puis réclamé par le sidecar Ryuk de
+ * Testcontainers à l'arrêt de la JVM. On évite ainsi {@code @Testcontainers} +
+ * {@code @Container} qui, combinés à l'héritage, redémarreraient/arrêteraient le
+ * conteneur par classe.
+ *
+ * <p>Postgres officiel (même dialecte que la prod) : Flyway rejoue V1 (baseline)
+ * puis V2 (contraintes uniques) sur un schéma vierge, et Hibernate valide
+ * (profil {@code test}, {@code ddl-auto=validate}). Pas de H2 : son dialecte
+ * divergent produirait des faux positifs sur les contraintes / types uuid.
+ */
+@ActiveProfiles("test")
+public abstract class AbstractPostgresIntegrationTest {
+
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine");
+
+    static {
+        POSTGRES.start();
+    }
+
+    /**
+     * Injecte les coordonnées du conteneur (port aléatoire) dans l'environnement
+     * Spring AVANT le démarrage du contexte, écrasant les defaults
+     * {@code localhost:5432/eventmanager} de application.properties.
+     */
+    @DynamicPropertySource
+    static void datasourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,25 @@
+# =============================================================
+# Profil TEST — base Postgres ÉPHÉMÈRE (Testcontainers), JAMAIS la base dev.
+# Activé via @ActiveProfiles("test") (AbstractPostgresIntegrationTest).
+#
+# La datasource (url/username/password) est injectée DYNAMIQUEMENT depuis le
+# conteneur jetable par @DynamicPropertySource — elle override les defaults
+# localhost:5432/eventmanager de application.properties. Aucune valeur de
+# connexion en dur ici (le conteneur expose un port aléatoire).
+# =============================================================
+
+# Schéma géré par Flyway (V1 baseline + V2 contraintes uniques), rejoué FROM
+# SCRATCH sur le conteneur vierge. Hibernate se contente de valider (#42).
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=false
+
+# Flyway actif : conteneur vierge → V1 puis V2 jouées intégralement.
+# baseline-on-migrate sans effet sur un schéma vide (aucun objet préexistant),
+# conservé pour cohérence avec les autres profils.
+spring.flyway.enabled=true
+spring.flyway.baseline-on-migrate=true
+spring.flyway.locations=classpath:db/migration
+
+# Secret JWT factice (NON secret) : neutralise ${JWT_SECRET} potentiellement
+# absent de l'env CI/local et garde les @SpringBootTest auto-suffisants.
+jwt.secret=test-only-insecure-secret-0000000000000000000000000000000000000000000000000000000000000000


### PR DESCRIPTION
## Contexte

Les 3 classes `@SpringBootTest` (`EventmanagerApplicationTests`, `AuthErrorContractIntegrationTest`, `RateLimitingAndHeadersIntegrationTest`) démarraient contre la **vraie base dev partagée** `localhost:5432/eventmanager`, sans profil de test isolé.

Conséquences observées le **2026-06-25** :
- Runs **non déterministes** : plusieurs worktrees/sessions opéraient en parallèle sur la même base, provoquant des mutations concurrentes pendant les tests.
- **Suite entièrement cassée** quand la base dev contenait 3 comptes au même email → la migration Flyway V2 (`uq_users_email`) échouait au boot de tous les `@SpringBootTest`.

## Changements

- **`pom.xml`** : dépendances `org.testcontainers:postgresql` + `junit-jupiter` (scope test) ; `testcontainers.version` surchargée à **1.20.6** (le BOM Spring Boot 3.2.2 fournit 1.19.3).
- **`application-test.properties`** (nouveau profil `test`) : `ddl-auto=validate`, Flyway actif (rejoue V1/V2/V3 *from scratch* sur le conteneur), `jwt.secret` factice → profil **auto-suffisant** (tourne sans `DB_PASSWORD`).
- **`AbstractPostgresIntegrationTest`** : conteneur **singleton** `postgres:16-alpine` (un seul, réutilisé entre toutes les classes, démarré en bloc statique, réclamé par Ryuk à la sortie JVM) + `@ActiveProfiles("test")` + `@DynamicPropertySource` injectant l'URL/credentials du conteneur. Les 3 classes l'étendent.
- **Fix détection Docker** : docker-java (transport `zerodep`) épingle par défaut une version d'API Docker hors de la plage du moteur récent (Engine 29.x → MinAPIVersion 1.44), `/v1.xx/info` renvoie HTTP 400 → « Could not find a valid Docker environment ». Property `docker.api.version=1.44` passée au JVM forké via `maven-surefire-plugin` (`DOCKER_API_VERSION` en env ne marche pas, docker-java ne lit que la propriété `api.version`).

Choix **singleton + `@DynamicPropertySource`** plutôt que `@ServiceConnection`/`@Container` : garantit un unique conteneur réutilisé entre classes, sans piège de cycle de vie lié à l'héritage.

## Vérifié

- `cd backend && mvn -o test` (offline) : **32 tests, 0 échec, 0 erreur, BUILD SUCCESS**.
- **Un seul** conteneur Postgres créé puis réutilisé par les 3 classes.
- Datasource = `jdbc:postgresql://localhost:<port-aléatoire>/test` ; **aucune** connexion à `localhost:5432/eventmanager`.
- Flyway applique V1 (baseline) → V2 (contraintes uniques) → V3 (audit columns #43) ; Hibernate `validate` passe.
- Suite verte **même sans `DB_PASSWORD`** (découplage de l'env dev confirmé).

## Limites / à savoir

- **`postgres:16-alpine`** est un choix par défaut, non aligné avec une version Postgres prod précise (non vérifiée). Risque de dérive de dialecte faible (bien moindre que H2).
- **`api.version=1.44`** est un plancher : un poste tournant un moteur Docker **< 25.0** (API < 1.44) échouerait. Surchargeable : `-Ddocker.api.version=1.51`.
- Ces 3 classes exigent désormais un **démon Docker actif**. Le repo n'a pas de CI : si une CI est ajoutée, elle devra fournir Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)