### PR TITLE
:wrench: Sprint 4 — réparer le tooling de test backend (mvnw + scripts/test-quiet.sh)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 HELP.md
 target/
-!.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
 
@@ -45,7 +44,10 @@ build/
 
 # === BACKEND (Spring Boot) ===
 backend/target/
-backend/.mvn/
+# Maven wrapper TRACKÉ (cd backend && ./mvnw) — type only-script, pas de jar.
+# On garde le wrapper versionné mais on ignore les éventuels artefacts .mvn locaux.
+backend/.mvn/*
+!backend/.mvn/wrapper/
 backend/.idea/
 backend/*.iml
 backend/*.iws

--- a/backend/.mvn/wrapper/maven-wrapper.properties
+++ b/backend/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/backend/mvnw
+++ b/backend/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.2
+# Apache Maven Wrapper startup batch script, version 3.3.4
 #
 # Optional ENV vars
 # -----------------
@@ -105,14 +105,17 @@ trim() {
   printf "%s" "${1}" | tr -d '[:space:]'
 }
 
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
 # parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
   case "${key-}" in
   distributionUrl) distributionUrl=$(trim "${value-}") ;;
   distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
   esac
-done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
-[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
 
 case "${distributionUrl##*/}" in
 maven-mvnd-*bin.*)
@@ -130,7 +133,7 @@ maven-mvnd-*bin.*)
   distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
   ;;
 maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
-*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
 esac
 
 # apply MVNW_REPOURL and calculate MAVEN_HOME
@@ -227,7 +230,7 @@ if [ -n "${distributionSha256Sum-}" ]; then
     echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
   elif command -v sha256sum >/dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
   elif command -v shasum >/dev/null; then
@@ -252,8 +255,41 @@ if command -v unzip >/dev/null; then
 else
   tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
 fi
-printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
-mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
 
 clean || :
 exec_maven "$@"

--- a/docs/memory/pitfalls.md
+++ b/docs/memory/pitfalls.md
@@ -14,8 +14,12 @@ Un PATCH partiel légitime peut omettre un champ (ex: endpoint « couleurs seule
 ## PIT-S1-004 — `git add -A` dans un worktree sprint capture les artefacts d'orchestration
 Le worktree sprint contient des fichiers untracked d'orchestration (`docs/memory/sprints/sprint-N/*` briefings/done.md). `git add -A` les capture par erreur. Stager explicitement les fichiers source/test (`git add <paths>` ciblés). (Sprint 1 correction post-review)
 
-## PIT-S2-001 — Build backend = `cd backend && mvn`, pas de `./mvnw` ni `scripts/test-quiet.sh`
-Le `mvnw` racine est cassé (`.mvn/wrapper` manquant) et le `pom.xml` vit dans `backend/`. Toujours `cd backend && mvn ...` (mvn système). Un hook PreToolUse bloque `mvn test` nu → préfixer `SKIP_DELEGATION=1 mvn test` pour les petites suites. Les tests d'intégration tapent une vraie Postgres (HikariPool au boot du contexte). (Sprint 2 #32/#33)
+## PIT-S2-001 — Build backend = `cd backend && mvn` (wrapper + helper réparés Sprint 4)
+~~Le `mvnw` racine est cassé (`.mvn/wrapper` manquant)~~ **RÉSOLU (Sprint 4, PR #113)** : le wrapper vit désormais dans `backend/` (`backend/mvnw` + `backend/.mvn/wrapper/maven-wrapper.properties`, type `only-script`, Maven 3.9.9, tracké). Le `mvnw`/`mvnw.cmd` racine orphelins (pas de `pom.xml` racine) ont été supprimés. Lancer les tests de l'une de ces façons :
+- `./scripts/test-quiet.sh unit` (depuis la racine) — sortie condensée, agrège `Tests run:` + verdict, log complet en `/tmp` ; scopes : `unit|backend|coverage|e2e|frontend|all`.
+- `cd backend && ./mvnw test` (wrapper) ou `cd backend && SKIP_DELEGATION=1 mvn -q test` (mvn système).
+
+Un hook PreToolUse bloque `mvn test` nu → préfixer `SKIP_DELEGATION=1` (le helper le fait déjà). Les tests d'intégration tapent une **Postgres jetable Testcontainers** (`@DynamicPropertySource`, port aléatoire) — pas la base dev, et **aucun `DB_PASSWORD` requis** sur le profil `test`. Docker doit tourner. (Sprint 2 #32/#33, réparé Sprint 4)
 
 ## PIT-S2-002 — Tester un contrat 401/403 Spring Security exige le full filter chain
 `MockMvcBuilders.standaloneSetup` (utilisé par des tests existants) bypasse Spring Security → 401/403 jamais déclenchés = faux verts. Pour valider entryPoint/accessDeniedHandler et l'ownership, utiliser `@SpringBootTest` + `@AutoConfigureMockMvc`. Corollaire : les exceptions levées DANS un filtre ne traversent pas le `@RestControllerAdvice` (hors DispatcherServlet). (Sprint 2 #51)

--- a/scripts/test-quiet.sh
+++ b/scripts/test-quiet.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# test-quiet.sh — lanceur de tests à sortie condensée pour MyTimeline.
+#
+# Isole la sortie verbeuse Maven/Testcontainers du contexte appelant (agent
+# test-runner, briefings de sprint) et ne remonte que l'essentiel : la ligne
+# "Tests run: ..." et le statut BUILD SUCCESS/FAILURE. En cas d'échec, la
+# sortie complète est conservée dans un fichier de log dont le chemin est
+# affiché.
+#
+# Usage (appelable depuis la racine du repo OU n'importe où) :
+#   ./scripts/test-quiet.sh [scope]
+#
+# Scopes :
+#   unit | backend   (défaut) → suite backend Spring Boot (Testcontainers Postgres, Docker requis)
+#   coverage                  → idem + rapport de couverture si jacoco est configuré
+#   e2e | frontend            → tests frontend (aucun runner configuré à ce jour → skip explicite)
+#   all                       → backend puis frontend
+#
+# Commande sous-jacente backend (la sortie verbeuse part dans un log, seul
+# l'agrégat "Tests run:" + le verdict sont affichés) :
+#   cd backend && SKIP_DELEGATION=1 ./mvnw test
+# La variante quiet validée manuellement reste équivalente et fonctionne :
+#   cd backend && SKIP_DELEGATION=1 ./mvnw -q test
+# (SKIP_DELEGATION=1 neutralise le hook qui bloque `mvn test` nu ; le profil de
+#  test injecte la datasource via Testcontainers, aucun DB_PASSWORD requis.)
+#
+set -euo pipefail
+
+# --- Résolution du repo root depuis l'emplacement réel du script -------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." >/dev/null 2>&1 && pwd)"
+BACKEND_DIR="${REPO_ROOT}/backend"
+FRONTEND_DIR="${REPO_ROOT}/frontend"
+
+SCOPE="${1:-unit}"
+
+# --- Backend : sélectionne le wrapper si présent, sinon mvn système ----------
+backend_mvn_cmd() {
+  if [ -x "${BACKEND_DIR}/mvnw" ]; then
+    echo "./mvnw"
+  elif command -v mvn >/dev/null 2>&1; then
+    echo "mvn"
+  else
+    echo "" # ni wrapper ni mvn
+  fi
+}
+
+run_backend() {
+  local goals=( "$@" ) # ex. ("test") ou ("test" "jacoco:report")
+  local mvn_bin
+  mvn_bin="$(backend_mvn_cmd)"
+  if [ -z "${mvn_bin}" ]; then
+    echo "✗ Ni ./mvnw (backend) ni mvn système trouvés — impossible de lancer les tests backend." >&2
+    return 127
+  fi
+
+  local logfile
+  logfile="$(mktemp -t mytimeline-backend-tests.XXXXXX.log)"
+
+  echo "▶ Backend : ${mvn_bin} ${goals[*]}  (cwd=backend, SKIP_DELEGATION=1)"
+  echo "  log complet → ${logfile}"
+
+  local status=0
+  # Sortie verbeuse complète capturée dans le log ; seul l'essentiel est affiché.
+  # (Pas de -q ici, sinon surefire masque l'agrégat "Tests run:" et "BUILD SUCCESS"
+  #  qu'on veut justement remonter. Le -q manuel reste valide hors script.)
+  ( cd "${BACKEND_DIR}" && SKIP_DELEGATION=1 "${mvn_bin}" "${goals[@]}" ) \
+    >"${logfile}" 2>&1 || status=$?
+
+  # Résumé condensé : agrégat surefire (ligne "Tests run:" SANS suffixe "- in ...",
+  # c.-à-d. le total du bloc Results) + le verdict du build.
+  grep -E "^\[INFO\] Tests run:|^Tests run:" "${logfile}" | grep -v -- "- in " | tail -n 1 || true
+  grep -E "BUILD (SUCCESS|FAILURE)" "${logfile}" | tail -n 1 || true
+
+  if [ "${status}" -ne 0 ]; then
+    # En cas d'échec, remonter aussi les classes/tests en échec pour le diagnostic.
+    grep -E "Tests run:.*(Failures: [1-9]|Errors: [1-9])|FAIL|\[ERROR\]" "${logfile}" | tail -n 30 || true
+    echo "✗ Backend : échec (exit ${status}). Sortie complète : ${logfile}" >&2
+    return "${status}"
+  fi
+  echo "✓ Backend : OK"
+  rm -f "${logfile}"
+  return 0
+}
+
+run_frontend() {
+  # Aucun runner de test configuré dans frontend/package.json (ni Playwright,
+  # ni Jest/Vitest) au moment de l'écriture. On skippe explicitement plutôt que
+  # de remonter un faux échec. À câbler ici quand un script "test"/"e2e" existera.
+  if [ -f "${FRONTEND_DIR}/package.json" ] \
+     && grep -qE '"(test|e2e|test:e2e)"[[:space:]]*:' "${FRONTEND_DIR}/package.json"; then
+    echo "▶ Frontend : npm test"
+    ( cd "${FRONTEND_DIR}" && npm test --silent )
+    echo "✓ Frontend : OK"
+  else
+    echo "⊘ Frontend : aucun runner de test configuré (package.json sans script test/e2e) — skip."
+  fi
+  return 0
+}
+
+case "${SCOPE}" in
+  unit|backend)
+    run_backend test
+    ;;
+  coverage)
+    # Pas de plugin jacoco dans backend/pom.xml à ce jour : 'coverage' exécute la
+    # suite. Brancher le goal jacoco (ex. "test jacoco:report") quand il sera ajouté.
+    if grep -q "jacoco" "${BACKEND_DIR}/pom.xml" 2>/dev/null; then
+      run_backend test jacoco:report
+    else
+      echo "ℹ jacoco non configuré dans backend/pom.xml — exécution de la suite sans rapport de couverture."
+      run_backend test
+    fi
+    ;;
+  e2e|frontend)
+    run_frontend
+    ;;
+  all)
+    run_backend test
+    run_frontend
+    ;;
+  -h|--help|help)
+    sed -n '2,40p' "${BASH_SOURCE[0]}"
+    ;;
+  *)
+    echo "Scope inconnu : '${SCOPE}'. Scopes valides : unit | backend | coverage | e2e | frontend | all" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Contexte
Le tooling de test backend était cassé, forçant chaque agent/dev à un fallback `mvn` système manuel (RECOMMAND_FOLLOWUP relevé par plusieurs agents pendant le Sprint 4, PR #113) :
1. `./mvnw` racine inutilisable — `.mvn/wrapper/` jamais commité, et le `pom.xml` vit dans `backend/`.
2. `scripts/test-quiet.sh` (référencé par les briefings de sprint et l'agent `test-runner`) inexistant.

## Changements
- **Wrapper Maven dans `backend/`** (à côté du pom) : `backend/mvnw`, `backend/mvnw.cmd`, `backend/.mvn/wrapper/maven-wrapper.properties` (type `only-script`, Maven 3.9.9, tracké). `cd backend && ./mvnw test` fonctionne.
- **`mvnw`/`mvnw.cmd` racine supprimés** : orphelins, aucun `pom.xml` racine pour les utiliser.
- **`.gitignore`** : track `backend/.mvn/wrapper/`, retrait de la négation racine `maven-wrapper.jar` devenue inutile.
- **`scripts/test-quiet.sh`** : wrapper sortie condensée appelable depuis la racine. Scopes `unit|backend|coverage|e2e|frontend|all`. Remonte l'agrégat `Tests run:` + verdict ; sortie verbeuse complète dans un log `/tmp`. Préfère le wrapper backend, retombe sur `mvn` système, exporte `SKIP_DELEGATION=1`.
- **`docs/memory/pitfalls.md`** : `PIT-S2-001` mis à jour (état résolu).

## Vérification
Docker up (Testcontainers Postgres) :
- `./scripts/test-quiet.sh unit` (depuis la racine) → **41 tests, BUILD SUCCESS**
- `cd backend && SKIP_DELEGATION=1 mvn -q test` (commande sous-jacente) → **41 tests, BUILD SUCCESS**
- `backend/./mvnw -version` → Maven 3.9.9 OK

## Limites connues
- Scope `coverage` : pas de jacoco dans le pom → exécute la suite sans rapport (message explicite).
- Scopes `e2e`/`frontend` : aucun runner JS configuré dans `frontend/package.json` → skip volontaire (câblage prêt dès qu'un script `test`/`e2e` existera).

🤖 Generated with [Claude Code](https://claude.com/claude-code)