### PR TITLE
Fix review PR #138 — 4 MINEUR (Zod reset, log Brevo, escape lien, @Id)

### DIFF
--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/email/BrevoEmailService.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/email/BrevoEmailService.java
@@ -84,7 +84,7 @@ public class BrevoEmailService implements EmailService {
             // l'exception jusqu'au contrôleur (BR-AUT-005 : la réponse 200 ne doit
             // pas dépendre de la disponibilité de Brevo, sinon on fuit l'existence
             // du compte via un timing/erreur différent).
-            log.error("Échec de l'envoi de l'email de réinitialisation via Brevo : {}", ex.getMessage());
+            log.error("Échec de l'envoi de l'email de réinitialisation via Brevo : {}", ex.getClass().getSimpleName());
         }
     }
 
@@ -100,11 +100,15 @@ public class BrevoEmailService implements EmailService {
         // On garde safeName brut pour le champ JSON "to.name" (sérialisé par Brevo,
         // pas du HTML) ; on n'échappe que la branche htmlContent.
         String escapedName = HtmlUtils.htmlEscape(safeName);
+        // Defense-in-depth : le lien est sûr aujourd'hui (token UUID + base configurée),
+        // mais on échappe l'URL avant insertion dans l'attribut href pour ne pas dépendre
+        // d'une base future non contrôlée (cohérent avec l'échappement de safeName).
+        String escapedResetLink = HtmlUtils.htmlEscape(resetLink);
         String htmlContent =
                 "<p>Bonjour " + escapedName + ",</p>"
                 + "<p>Vous avez demandé la réinitialisation de votre mot de passe MyTimeline. "
                 + "Cliquez sur le lien ci-dessous pour choisir un nouveau mot de passe :</p>"
-                + "<p><a href=\"" + resetLink + "\">Réinitialiser mon mot de passe</a></p>"
+                + "<p><a href=\"" + escapedResetLink + "\">Réinitialiser mon mot de passe</a></p>"
                 + "<p>Ce lien est valable 15 minutes. Si vous n'êtes pas à l'origine de cette demande, "
                 + "ignorez simplement cet email.</p>"
                 + "<p>L'équipe MyTimeline</p>";

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/entities/PasswordResetTokenEntity.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/entities/PasswordResetTokenEntity.java
@@ -20,7 +20,9 @@ import java.util.UUID;
 public class PasswordResetTokenEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    // Pas de @GeneratedValue : l'id UUID est assigné applicativement avant persist
+    // (PasswordResetServiceImpl -> new PasswordResetToken(UUID.randomUUID(), ...)).
+    // super.save() (SimpleJpaRepository) fait alors un merge/INSERT sur id non nul.
     private UUID id;
 
     @Column(name = "user_id", nullable = false)

--- a/frontend/src/lib/schemas/auth.ts
+++ b/frontend/src/lib/schemas/auth.ts
@@ -110,15 +110,17 @@ export const ResetPasswordSchema = z.object({
 
 export type ResetPasswordData = z.infer<typeof ResetPasswordSchema>
 
-/** Schéma formulaire : `newPassword` + confirmation (le token est hors formulaire). */
+/**
+ * Schéma formulaire : `newPassword` + confirmation (le token est hors formulaire).
+ * Contrainte alignée sur le register ET le backend (`ResetPasswordRequest` =
+ * min 6, BR-AUT-003) : PAS d'exigence majuscule/chiffre ici, sinon le form reset
+ * serait plus strict que l'inscription (un compte `abcdef` ne pourrait pas se
+ * réinitialiser). Cf. pit-auth : le client ne doit pas surcontraindre le contrat backend.
+ */
 export const createResetPasswordFormSchema = (t: Translate) =>
   z
     .object({
-      newPassword: z
-        .string()
-        .min(6, { message: t('validation.password.min') })
-        .regex(/[A-Z]/, { message: t('validation.password.uppercase') })
-        .regex(/[0-9]/, { message: t('validation.password.number') }),
+      newPassword: z.string().min(6, { message: t('validation.password.min') }),
       confirmPassword: z.string(),
     })
     .refine((data) => data.newPassword === data.confirmPassword, {


### PR DESCRIPTION
## Fix review PR #138 — 4 MINEUR (Sprint 8 auth)

Suite à la revue post-merge de la PR #138 (`/review-pr 138`). Corrige 4 findings MINEUR. Les 2 MAJEUR de la revue sont déjà suivis en backlog (#140 fail-fast Brevo, #143 TOCTOU token).

### Corrections
1. **Cohérence Zod reset ↔ backend** (`frontend/src/lib/schemas/auth.ts`) : `createResetPasswordFormSchema` aligné sur `min 6` (retrait de l'exigence majuscule+chiffre), qui matche le contrat backend `ResetPasswordRequest @Size(min=6)` (BR-AUT-003).
2. **Anti-fuite PII en log** (`BrevoEmailService`) : erreur d'envoi loggée via `ex.getClass().getSimpleName()` au lieu de `ex.getMessage()` (qui pouvait contenir l'email renvoyé par Brevo).
3. **Escape defense-in-depth** (`BrevoEmailService`) : `resetLink` (href de l'email) passé par `HtmlUtils.htmlEscape`.
4. **Nettoyage entité** (`PasswordResetTokenEntity`) : retrait de `@GeneratedValue(AUTO)` redondant (l'`id` UUID est assigné applicativement avant persist).

### Tests (vérifiés)
- Backend **84/84** · Frontend **23/23** · `next build` SSG **OK**.

### ⚠ Follow-up identifié (non traité ici — décision de politique)
Le **form register** exige majuscule+chiffre alors que le backend (`RegisterRequest`) n'impose que `min 6` → incohérence symétrique à celle corrigée sur reset. À trancher : ajouter la complexité au backend partout (register + reset) OU l'assouplir sur le form register. Hors scope de ce fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
