### PR TITLE
Rafraîchir context-packs post-S10 (br-products à jour + cp-backend/hexagonal Spring Boot)

### DIFF
--- a/.ai-env/context-packs/br-products.md
+++ b/.ai-env/context-packs/br-products.md
@@ -7,14 +7,14 @@
 
 ## 1. Lifecycles (machines à états)
 
-**Product** — CRUD simple, pas de lifecycle d'état métier (aucun champ `status`/`active`/`ARCHIVED` sur `ProductEntity`).
+**Product** — soft delete depuis Sprint 10 (#50). Champ `archived` (booléen, défaut `false`, ajouté V7/#44) sur `ProductEntity` + `@SQLRestriction("archived = false")` sur l'entité → les produits archivés sont invisibles de TOUTES les lectures Hibernate (listings produits ET join-fetch events).
 
 | Etat | Description | Transitions sortantes |
 | --- | --- | --- |
-| (Created) | Produit créé via `POST`, événements créés en cascade | -> (Deleted) via `DELETE` |
-| (Deleted) | Suppression PHYSIQUE (`existsById` puis delete) | aucune |
+| (Created) | Produit créé via `POST`, événements créés en cascade | modifiable via `PATCH` ; -> (Archived) via `DELETE` |
+| (Archived) | Soft delete : `archived = true`, `DELETE` retourne **204**. Invisible partout via `@SQLRestriction` | définitif pour cette wave (pas d'endpoint de restauration) |
 
-⚠️ Suppression PHYSIQUE observée (`deleteById` après `existsById`) — **pas de soft delete**, contraire à la convention projet. Aucun champ `deletedAt`/`active` sur `ProductEntity`.
+✅ Soft delete implémenté S10 (#50). Historique (avant S10) : suppression PHYSIQUE (`deleteById`) — corrigé.
 
 **Event** (entité agrégée) — pas de lifecycle propre côté `products` ; cycle de vie piloté par le produit (`cascade=ALL`, `orphanRemoval=true`).
 
@@ -24,10 +24,11 @@
 
 | Action | user (authentifié) | admin | system | Notes |
 | --- | --- | --- | --- | --- |
-| `POST` créer produit + events | ✅ self uniquement | ❌ inexistant | ⚠️ résout Category & User, calcule end dates | userId du body ignoré, écrasé par path `{userId}` |
-| `GET` lister produits (avec events) | ✅ self uniquement | ❌ | ⚠️ full table scan + filtre in-memory | accepte cookie JWT **OU** header Bearer (incohérent) |
-| `GET` produit par id | ✅ self uniquement | ❌ | — | 404 si absent |
-| `DELETE` produit | ✅ self uniquement | ❌ | — | retourne 200 (devrait être 204) |
+| `POST` créer produit + events | ✅ self uniquement | ❌ inexistant | ⚠️ résout Category & User, calcule end dates | userId body ignoré (écrasé par path). Catégorie cible validée par ownership (S10, cf. BR-PRO-010) |
+| `GET` lister produits (avec events) | ✅ self uniquement | ❌ | ⚠️ filtre user in-memory (perf) ; archived filtrés en SQL (`@SQLRestriction`) | accepte cookie JWT **OU** header Bearer (incohérent) |
+| `GET` produit par id | ✅ self uniquement | ❌ | — | 404 si absent/archivé |
+| `PATCH` produit (S10 #50) | ✅ self uniquement | ❌ | — | maj partielle nom/catégorie. 200/400/404/403. Catégorie cible validée (BR-PRO-010) |
+| `DELETE` produit | ✅ self uniquement | ❌ | — | soft delete `archived=true`, retourne **204** (S10 #50) |
 | `GET` events d'un produit | ✅ self uniquement | ❌ | — | ⚠️ 404 si liste vide (sémantique erronée) |
 
 ⚠️ Contrôle d'ownership fait **manuellement** dans le controller (extraction username depuis JWT cookie -> load User -> compare `user.getId()` au path `{userId}`), sans `@PreAuthorize` ni Spring Security method security.
@@ -39,8 +40,8 @@
 ### BR-PRO-001 — Nom de produit obligatoire et borné
 **Règle** : un utilisateur MUST fournir un `name` non vide, longueur 1..100, à la création d'un produit.
 **Pourquoi** : intégrité des données, un produit anonyme n'a pas de sens métier.
-**Implémentation** : `ProductCreationRequest.name` — `@NotBlank` + `@Size(min=1, max=100)`. Front : `productCreateSchema.name = z.string().min(3)`.
-**Test attendu** : `ProductControllerTest#createProduct_rejectsBlankName`, `#createProduct_rejectsNameOver100`.
+**Implémentation** : création = `ProductCreationRequest.name` (`@NotBlank` + `@Size(min=1, max=100)`). Update (S10) = `ProductUpdateRequest.name` nullable pour patch partiel : `@Size(min=1,max=100)` + `@Pattern(".*\\S.*")` (le `@Pattern` skip null mais rejette `" "` blanc — un `@NotBlank` casserait le patch partiel). Front : `productCreateSchema.name = z.string().min(3)`.
+**Test attendu** : `ProductControllerTest#createProduct_rejectsBlankName`, `#createProduct_rejectsNameOver100`, `#patchProduct_blankName_returns400`.
 **⚠️ DESYNC** : Zod impose `min(3)`, backend impose `min(1)` — noms de 1-2 caractères acceptés backend mais refusés front. Voir `.claude/rules-jit/zod-dto-sync.md`.
 **⚠️ Entité non protégée** : `ProductEntity.name` sans `@Column(nullable=false)` ni Bean Validation — un nom NULL peut être persisté si le DTO est contourné.
 
@@ -79,12 +80,23 @@
 **Test attendu** : `ProductServiceImplTest#getProductsWithEvents_filtersByUserAndHasEvents`.
 **⚠️ PERF (anti-pattern)** : aucun filtre SQL `WHERE user_id = ?` — scan complet de la table puis filtre Java (O(N)). Ne passe pas à l'échelle. -> requête JPQL/Panache avec filtre DB.
 
-### BR-PRO-007 — Suppression conditionnée à l'existence
-**Règle** : `DELETE` MUST vérifier l'existence (`existsById`) avant suppression ; lève `ProductNotFoundException` sinon.
-**Pourquoi** : retour d'erreur explicite plutôt que delete silencieux.
-**Implémentation** : `ProductServiceImpl.deleteById`.
-**Test attendu** : `ProductServiceImplTest#deleteById_throwsWhenMissing`.
-**⚠️ Soft delete NON IMPLÉMENTÉ** : suppression physique alors que la convention impose le soft delete. **⚠️ Code HTTP** : retourne 200 au lieu de 204.
+### BR-PRO-007 — Soft delete (archive) conditionné à l'existence ✅ (S10 #50)
+**Règle** : `DELETE` MUST vérifier l'existence (`orElseThrow(ProductNotFoundException)`) puis positionner `archived = true` (soft delete, PAS de suppression physique) ; retourne **204**.
+**Pourquoi** : réversibilité + convention projet soft-delete ; retour d'erreur explicite si absent.
+**Implémentation** : `ProductServiceImpl.archiveById` (ex-`deleteById`) + `@SQLRestriction("archived = false")` sur `ProductEntity` (invisibilité globale). Ownership vérifié en amont (BR-PRO-004).
+**Test attendu** : `ProductServiceImplTest`, `ProductControllerOwnershipTest`, `ProductArchivedFilterIntegrationTest` (archived invisible partout).
+**⚠️ Pitfall JPA (PIT-S10-003)** : l'update-in-place charge l'entité gérée et recopie les champs (le domaine sans `@Version` casse un `save(mapper.toEntity(domain))` détaché).
+
+### BR-PRO-009 — Mise à jour partielle produit (PATCH) ✅ (S10 #50)
+**Règle** : `PATCH /users/{userId}/products/{productId}` met à jour nom et/ou catégorie (partiel). 200 / 400 (nom vide/>100, BR-PRO-001) / 404 (absent ou pas au user) / 403 (ownership path≠JWT).
+**Implémentation** : `ProductUpdateRequest` (name/categoryId nullable), `ProductServiceImpl.updateProduct` (update-in-place de l'entité gérée). Ownership path==JWT (BR-PRO-004).
+**Test attendu** : `ProductControllerOwnershipTest#patchProduct_*`.
+
+### BR-PRO-010 — Catégorie cible d'un produit : ownership validé (anti cross-tenant) ✅ (S10 #50 review)
+**Règle** : à la création ET à l'update d'un produit, la catégorie cible (`categoryId`) n'est assignable QUE si elle appartient à l'appelant (`ownerId == caller`) OU est système (`ownerId == null`). Sinon → `CategoryNotFoundException` (**404**, pas 403 : anti-énumération d'UUID d'autrui).
+**Pourquoi** : sans ce check, un user rattache son produit à la catégorie d'un autre (linkage cross-tenant) + oracle 404/200 pour énumérer les catégories d'autrui.
+**Implémentation** : helper `ProductServiceImpl.resolveAssignableCategory(categoryId, callerId)` (callerId = `user.getId()` en create, `product.getUser().getId()` en update). Voir [[PIT-S10-005]].
+**Test attendu** : `ProductServiceImplTest` (create/update vers catégorie d'autrui → 404 ; système/propre → OK).
 
 ### BR-PRO-008 — Sémantique 404 sur collection d'events vide (NON CONFORME)
 **Règle attendue** : `GET /products/{productId}/events` DEVRAIT retourner `200` avec une liste (éventuellement vide).
@@ -106,7 +118,7 @@
 
 ## 5. Anti-patterns documentés
 
-1. **Fuite du modèle de domaine** : `ResponseEntity<Product>`, `ResponseEntity<List<Product>>`, `ResponseEntity<List<Event>>` renvoyés directement — aucun DTO de réponse, expose la structure interne y compris l'objet `User`. -> introduire des response DTO.
+1. ~~**Fuite du modèle de domaine**~~ ✅ RÉSOLU (S10, absorb PR #153) : `ProductController` renvoie désormais `ProductResponse`/`EventResponse` (catégorie réduite à `{id,name}`), l'objet `User`/owner n'est plus exposé.
 2. **Dépendance hexagonale inversée** : `ProductService` (port domaine) importe `ProductCreationRequest` (DTO application).
 3. **Annotation infra dans le domaine** : `ProductRepository` (port domaine) annoté `@Repository` (Spring).
 4. **Couplage aux implémentations** : `ProductController` injecte `ProductServiceImpl`, `EventServiceImpl`, `UserServiceImpl` au lieu des interfaces de port.
@@ -114,7 +126,7 @@
 6. **NPE non gardé** : `createProduct` appelle `request.getEvents().forEach()` sans null check (cf. BR-PRO-005).
 7. **UUID hard-codés au front** : le sélecteur de catégorie embarque des UUID en dur (`7446a49c...`, `dbc134fb...`) — casse à tout changement DB. -> charger les catégories via API.
 8. **Desync Zod/DTO** : `name` Zod `min(3)` vs backend `@Size(min=1)` (cf. BR-PRO-001).
-9. **Codes HTTP incorrects** : `DELETE` renvoie 200 au lieu de 204 ; events vides renvoient 404 (cf. BR-PRO-008).
+9. **Codes HTTP** : ~~`DELETE` renvoie 200~~ ✅ RÉSOLU S10 (204 + soft delete) ; RESTE : events vides renvoient 404 (cf. BR-PRO-008, non traité).
 10. **Annotation Jackson sur entité de persistance** : `@JsonManagedReference` sur `ProductEntity.events` — concern présentation sur entité infra.
 11. **`@Valid` manquant** : pas de `@Valid` visible sur le `@RequestBody` de `ProductController` — la Bean Validation de `ProductCreationRequest` peut ne pas être déclenchée.
 12. **Authentification incohérente** : `getProducts` accepte cookie JWT **ou** header Bearer ; les autres endpoints sont cookie-only.
@@ -125,5 +137,6 @@
 ## Référence
 
 - Coverage actuelle : `coverage-products.md`
-- Backend : `backend/src/main/java/com/matimeline/eventmanager/` — `domain/ports/services/ProductService.java`, `domain/ports/repositories/ProductRepository.java`, `application/.../ProductServiceImpl.java`, `infrastructure/.../ProductEntity.java`, `infrastructure/.../ProductController.java`, DTO `ProductCreationRequest`
+- Backend : `backend/src/main/java/com/matimeline/eventmanager/` — `domain/ports/services/ProductService.java`, `domain/ports/repositories/ProductRepository.java`, `application/.../ProductServiceImpl.java` (`resolveAssignableCategory`, `updateProduct`, `archiveById`), `infrastructure/.../ProductEntity.java` (`@SQLRestriction`), `infrastructure/.../ProductController.java`, DTOs `ProductCreationRequest` / `ProductUpdateRequest` / `ProductResponse` / `EventResponse` (S10)
+- Conventions transverses backend : voir `cp-backend.md` §Conventions MyTimeline (DTO en HTTP, ownership cible + 404, update-in-place JPA, DataIntegrity→409 scopé)
 - Frontend : `frontend/src/components/products/` — sélecteur de catégorie + schémas Zod `productCreateSchema` / `productSchema` (`eventCreationSchema` réutilisé)

--- a/.ai-env/context-packs/cp-backend.md
+++ b/.ai-env/context-packs/cp-backend.md
@@ -1,80 +1,104 @@
-# Context-pack : Backend le langage backend / Quarkus
+# Context-pack : Backend (MyTimeline — Spring Boot 3 / Java 21)
 
-> ⚠️ EXEMPLE Layer B (instance EdelWheels / Quarkus-Next). À RÉGÉNÉRER par /ai-env:setup pour ta stack. Voir REBUILD-PLAN.md §2.2.
+> Référence maître : `.claude/rules-jit/backend.md`
+> À charger pour TOUTE tâche backend. Package racine : `com.matimeline.eventmanager`.
 
-> Reference maitre : `.claude/rules-jit/backend.md`
-> A charger pour TOUTE tache backend
+## Stack réelle
 
-## Stack
+Java 21 + Spring Boot 3.2.2 + Spring Web (MVC) + Spring Data JPA (Hibernate) + PostgreSQL 16 +
+Flyway 9.22.3 (core, support Postgres inclus) + Spring Security (JWT cookie HttpOnly, jjwt 0.11.5) +
+Lombok (DTOs uniquement) + Bucket4j (rate limiting in-memory) + Testcontainers 1.20.6 (tests).
+PAS de Quarkus / Panache / CDI. Aucun `io.quarkus.*`, `@ApplicationScoped`, `@QuarkusTest`, `persist()`.
 
-le langage backend + le framework backend + l'ORM + l'outil de migration + le provider d'identité + la base de données
+## Conventions MyTimeline (source de vérité projet — issues des reviews S10)
 
-## Conventions le langage backend
+Ces 4 conventions transverses sont revenues comme BUGS en review. Les respecter par défaut. Détail :
+`docs/memory/pitfalls.md` (PIT-S10-*) et `docs/memory/patterns.md` (PAT-S10-*).
 
-- **Records** pour DTOs (request/response immuables)
-- **Sealed Classes** pour etats metier
-- **Pattern Matching**, Streams
-- **Validation** : `@Valid` + Bean Validation sur tous les `@RequestBody`
-- **Reponses** : `Response.ok(dto).build()` ou `Response.created(uri).build()`
-- **Erreurs** : le format d'erreur
-- **Logging** : le logger injecte — jamais `System.out`
-- **Config** : `@ConfigProperty` pour valeurs externalisees
-- **JPA constructeurs** : `public Entity() {}` (pas protected)
+1. **Jamais de domain model / entité JPA renvoyé par un `@RestController`** — toujours un `*Response` DTO
+   (record ou classe Lombok `@Getter`/`@AllArgsConstructor`, méthode `fromDomain(...)`). Réduire la
+   catégorie et les sous-objets au strict minimum. NE JAMAIS exposer l'objet `User`/owner ni les champs
+   internes (`archived`, `ownerId`, `version`). Ex : `ProductResponse` masque user/archived/color et réduit
+   la catégorie à `{id,name}` ; `CategoryResponse` remplace `ownerId` par un booléen dérivé `system`.
+   AP récurrent : catégories (#52) ET produits — vu 2×. Réf PAT-S10 / `CategoryResponse`, `ProductResponse`.
+2. **Ownership : vérifier la ressource CIBLE, pas seulement la ressource parente ; 404 (pas 403) pour une
+   ressource d'autrui** (anti-énumération d'UUID — un 403 confirmerait l'existence de l'id). Ex : à
+   l'assignation d'une `categoryId` à un produit, valider `category.ownerId == caller || ownerId == null`,
+   sinon `CategoryNotFoundException` -> 404 (cf. `ProductServiceImpl.resolveAssignableCategory`). Résolution
+   du caller depuis le cookie JWT : helper `resolveCaller(token)` (cf. `CategoryController`). Réf PIT-S10-005.
+3. **`DataIntegrityViolationException` -> 409 mappé au niveau SERVICE, dans un `try/catch` autour du SEUL
+   `save()` concerné** — JAMAIS un `@ExceptionHandler(DataIntegrityViolationException)` global : il
+   masquerait toute violation FK/contrainte sous un 409 trompeur. Ex : `CategoryServiceImpl.createCategory`
+   et `updateCategory` catchent localement -> `CategoryNameConflictException`. Le handler global a été
+   SUPPRIMÉ (cf. note dans `GlobalExceptionHandler`). Réf PAT-S10-002 / PIT-S10-002.
+4. **Update JPA = charger l'entité gérée (`findById`) + recopier les champs mutables (update-in-place)** —
+   ne PAS faire `repository.save(mapper.toEntity(domain))` en UPDATE : les domain models n'ont pas de
+   `@Version`, l'entité reconstruite est détachée (version=null) -> `persist()` échoue ("uninitialized
+   version") ou `merge()` lève un OptimisticLock. Charger le managed, recopier name/color/etc., laisser
+   Hibernate piloter `@Version`/`updated_at`. Cible d'une FK : `entityManager.getReference(...)` (pas une
+   entité détachée). Cf. `CategoryRepositoryJpaImpl.save`, `ProductRepositoryJpaImpl.save`. Réf PIT-S10-003.
+5. **Soft delete via `@SQLRestriction("archived = false")` sur l'entité** — filtre TOUTES les lectures
+   Hibernate (findById/findAll/associations) automatiquement (cf. `ProductEntity`). Pour les opérations
+   transverses qui doivent voir les lignes filtrées (réassignation avant delete de catégorie, comptage
+   avant purge), utiliser du SQL NATIF bindé pour contourner le `@SQLRestriction` (cf.
+   `ProductRepositoryJpaImpl.countByCategoryId` / `updateCategoryForProducts`). Réf PAT-S10-001 / PIT-S10-004.
 
-## Regles transversales entites
+## Conventions Spring Boot
 
-- **Soft delete** (règle métier suppression) : champ `deleted_at` obligatoire, JAMAIS de DELETE physique
-- **UUID v7** (règle métier clés primaires) sur toutes les cles primaires
-- **Ownership** (règle métier ownership) : verifier l'identifiant propriétaire sur chaque endpoint GET/PUT/DELETE securise, admins bypassent via `isAdmin`
+- Controllers : `@RestController` + `@RequestMapping("/api/...")`, verbes `@GetMapping`/`@PostMapping`/
+  `@PatchMapping`/`@DeleteMapping`. Injecter les PORTS (interfaces), pas les `*Impl`.
+- Services : `@Service` sur `*Impl` (dans `application/services/`), constructeur `@Autowired`.
+- `@Transactional` de `org.springframework.transaction.annotation` ; `@Transactional(readOnly = true)` sur
+  les lectures. La réassignation + delete de catégorie doit rester dans UNE transaction atomique.
+- Repos JPA : `@Repository` + `extends SimpleJpaRepository<Entity, UUID> implements <PortDomaine>`,
+  requêtes JPQL/native via `EntityManager` bindé (`.setParameter`), `.setMaxResults(1)` au lieu d'un `get(0)`.
+- DTOs : `application/dtos/` (Lombok `@Getter`/`@AllArgsConstructor` ou records). `@Valid` + Bean Validation
+  sur tout `@RequestBody`.
+- Erreurs : `GlobalExceptionHandler` (`@RestControllerAdvice`) mappe les exceptions DOMAINE
+  (`*NotFoundException` -> 404, `CategoryNameConflictException`/`CategoryInUseException` -> 409...). Corps
+  plat `{"error": "..."}` pour les erreurs métier. Les 401/403 de la chaîne Security sont gérés par
+  `SecurityConfig` (authenticationEntryPoint / accessDeniedHandler), PAS par le handler — ne pas dupliquer.
+- Entités : `@Entity`, `@GeneratedValue(strategy = AUTO)` UUID, `@Version`, audit `@CreatedDate`/
+  `@LastModifiedDate` + `@EntityListeners(AuditingEntityListener.class)`, `equals/hashCode` sur l'id.
 
-## Securite
+## Migrations Flyway
 
-- `@RolesAllowed` sur chaque endpoint protege
-- Aucune donnee sensible dans les logs
-- Aucune concatenation SQL
-- `l'identité de sécurité` (pas `JsonWebToken`) avec le provider d'identite
+- `backend/src/main/resources/db/migration/V{n}__description.sql`. Dernière : `V8__category_ownership.sql`.
+  Prochaine = `V{n+1}`. Vérifier : `ls db/migration/V*.sql | sort -V | tail -1`.
+- JAMAIS rééditer une migration déjà appliquée (checksum) -> créer `V{n+1}`. Rollback commenté dans le fichier.
+- Flyway 9.x : support Postgres DANS `flyway-core`, ne PAS ajouter `flyway-database-postgresql` (Flyway 10+).
+- `ddl-auto=validate` (dev, prod, test) : Hibernate ne modifie jamais le schéma, Flyway est la source de
+  vérité. Une entité désalignée du schéma -> échec au boot. `baseline-on-migrate=true`.
 
-## Migrations l'outil de migration
+## Sécurité
 
-- `db/migration/V{n}__{description}.sql`
-- Rollback commente dans chaque fichier
-- JAMAIS modifier une migration deja appliquee
-- Derniere migration : `ls {{MIGRATIONS_DIR}}/V*.sql | sort -V | tail -1` (hook `check-stack-drift.sh` avertit en cas de drift)
+- `SecurityConfig` (Spring Security), JWT signé (jjwt) porté par un cookie HttpOnly `jwt`. `JwtService`
+  (extractUsername...), `JwtFilter`, `RateLimitingFilter` (Bucket4j, par IP — `trust-forwarded-header=false`).
+- Identité dérivée du JWT, JAMAIS d'un param. Ownership vérifié manuellement dans les controllers via
+  `resolveCaller(token)` -> compare l'id (403 pour la ressource possédée d'autrui côté catégorie ;
+  404 pour la ressource-cible d'autrui, cf. convention 2).
+- Secrets via env (`JWT_SECRET`, `DB_PASSWORD`, `BREVO_API_KEY`) — aucun default en profil prod (fail-fast).
+  `ProfileSafetyGuard` refuse le boot si profil `dev` actif avec marqueur d'env prod. Aucune concat SQL.
 
-## l'ORM
+## Null-safety & qualité
 
-- `persist()` = INSERT only. Pour upsert → `getEntityManager().merge()`
-- `TranslationRepository` implemente directement par `l'ORMRepository`
+- `orElseThrow(() -> new XxxNotFoundException(id))` quand l'entité DOIT exister — jamais `orElse(null)` +
+  null-check en aval (NPE caché). `getReference` pour attacher une FK sans charger l'entité.
+- Méthodes > 20 lignes -> décomposer ; complexité > 5 -> refactorer ; pas de magic values ; risque N+1 ->
+  `fetch join`/`@BatchSize` ; index DB sur colonnes filtrées/triées (cf. `V5__fk_indexes.sql`).
 
-## Null safety
+## Tests
 
-- `orElseThrow()` quand l'entite DOIT exister — jamais `orElse(null)` + null checks downstream
-- Fallback explicite obligatoire pour les valeurs nullable externes (locale, enum)
+- Lancer via le WRAPPER OBLIGATOIRE : `./scripts/test-quiet.sh backend` (ou `backend/./mvnw`). Docker
+  REQUIS (Testcontainers). Property `docker.api.version=1.44` dans le pom (pipe `api.version` vers surefire)
+  — pièce docker-java : sans elle, "Could not find a valid Docker environment".
+- Slices controllers : `@ExtendWith(MockitoExtension.class)` + `MockMvcBuilders.standaloneSetup(...)` +
+  mocks Mockito (cf. `CategoryControllerTest`). Services : test unitaire `@ExtendWith(MockitoExtension.class)`.
+- Intégration : `@SpringBootTest` + `@Transactional` (rollback) + `extends AbstractPostgresIntegrationTest`
+  (singleton container Postgres 16, profil `test`, Flyway rejoue V1..Vn from scratch). PAS de H2.
+- Surefire matche `**/*Test.java` (les `*IntegrationTest` inclus). Données de test uniques par test (UUID),
+  pas de constantes partagées.
 
-## Tests `@QuarkusTest`
+## Référence pour approfondir
 
-- **`@TestTransaction`** (pas `@Transactional`) pour rollback automatique — `@Transactional` commit et pollue les tests suivants. **PIT recurrent**.
-- Test data : valeurs uniques par test (generateur AtomicInteger ou UUID), jamais de constantes partagees entre tests
-
-## Qualite du code
-
-- Methodes > 20 lignes → decomposer
-- Complexite cyclomatique > 5 → refactorer
-- Pas de magic numbers/strings
-- Nommage explicite
-- **Risque N+1** : `fetch join` ou `@BatchSize`
-- Toute liste paginee
-- Index DB prevus pour colonnes filtrees/triees
-
-## Pitfalls backend frequents
-
-- `@Transactional` dans tests → pollue tests suivants. Toujours `@TestTransaction`.
-- `orElse(null)` + null check downstream → NPE cache. `orElseThrow()`.
-- `persist()` pour update → INSERT duplique. `getEntityManager().merge()`.
-- Concatenation SQL → injection. Query params obligatoires.
-- Migration modifiee apres deploiement → cluster inconsistant. Creer V{n+1}.
-
-## Reference pour approfondir
-
-`.claude/rules-jit/backend.md` (rule versionnee)
-`docs/memory/pitfalls.md` (filtre par PIT-XX backend)
+`.claude/rules-jit/backend.md` · `docs/memory/pitfalls.md` (PIT-S10-*) · `docs/memory/patterns.md` (PAT-S10-*)

--- a/.ai-env/context-packs/cp-backend.md
+++ b/.ai-env/context-packs/cp-backend.md
@@ -94,6 +94,10 @@ Ces 4 conventions transverses sont revenues comme BUGS en review. Les respecter 
   — pièce docker-java : sans elle, "Could not find a valid Docker environment".
 - Slices controllers : `@ExtendWith(MockitoExtension.class)` + `MockMvcBuilders.standaloneSetup(...)` +
   mocks Mockito (cf. `CategoryControllerTest`). Services : test unitaire `@ExtendWith(MockitoExtension.class)`.
+  ⚠ `standaloneSetup` BYPASSE la chaîne Spring Security → il ne teste que le 403/404 renvoyé par le
+  contrôleur lui-même (ownership manuel). Pour tester les **401/403 imposés par Spring Security**
+  (auth manquante, rate-limit), utiliser `@SpringBootTest` + `@AutoConfigureMockMvc` (cf.
+  `AuthErrorContractIntegrationTest`, `RateLimitingAndHeadersIntegrationTest`) — sinon faux verts.
 - Intégration : `@SpringBootTest` + `@Transactional` (rollback) + `extends AbstractPostgresIntegrationTest`
   (singleton container Postgres 16, profil `test`, Flyway rejoue V1..Vn from scratch). PAS de H2.
 - Surefire matche `**/*Test.java` (les `*IntegrationTest` inclus). Données de test uniques par test (UUID),

--- a/.ai-env/context-packs/cp-hexagonal.md
+++ b/.ai-env/context-packs/cp-hexagonal.md
@@ -1,58 +1,71 @@
-# Context-pack : Architecture hexagonale
+# Context-pack : Architecture hexagonale (MyTimeline)
 
-> ⚠️ EXEMPLE Layer B (instance EdelWheels / Quarkus-Next). À RÉGÉNÉRER par /ai-env:setup pour ta stack. Voir REBUILD-PLAN.md §2.2.
+> Référence maître : `.claude/rules/hexagonal.md`
+> À charger pour TOUTE tâche backend touchant `com.matimeline.eventmanager.*`
+> Stack RÉELLE : Spring Boot 3.2.2 + Java 21 + Spring Data JPA + Flyway + Spring Security.
 
-> Reference maitre : `.claude/rules/hexagonal.md`
-> A charger pour TOUTE tache backend touchant `{{JAVA_PACKAGE}}.*`
-
-## Structure obligatoire
+## Structure réelle des 3 couches (`backend/src/main/java/com/matimeline/eventmanager/`)
 
 ```
-{{JAVA_PACKAGE}}/
-├── domain/            # Couche metier pure (Java pur, 0 framework)
-├── application/       # Ports (interfaces) et use cases
-└── infrastructure/    # Adapters techniques (JPA, REST, Quarkus)
+domain/                         # PUR Java, ZÉRO framework (hors jakarta.validation)
+  models/                       # Product, Category, User, Event... POJO getters/setters écrits À LA MAIN
+  ports/services/               # INTERFACES métier : ProductService, CategoryService, EmailService...
+  ports/repositories/           # INTERFACES persistance : ProductRepository, CategoryRepository...
+  exceptions/                   # CategoryNotFoundException, ProductNotFoundException, CategoryInUseException...
+application/                     # orchestration métier
+  services/*Impl                # @Service : ProductServiceImpl implements ProductService (port domaine)
+  dtos/                         # *Request / *Response (records OU classes Lombok @Getter/@AllArgsConstructor)
+  mappers/                      # @Component : ProductMapper, CategoryMapper (entity <-> domain)
+infrastructure/                 # TOUT l'adaptateur technique
+  adapters/controllers/         # @RestController : ProductController, CategoryController + GlobalExceptionHandler
+  adapters/repositories/jpa/    # @Repository : *RepositoryJpaImpl extends SimpleJpaRepository implements <port>
+  adapters/email/               # BrevoEmailService implements EmailService (port domaine)
+  entities/                     # @Entity JPA : ProductEntity, CategoryEntity (@Version, @SQLRestriction...)
+  security/                     # SecurityConfig, JwtService, JwtFilter, RateLimitingFilter
+  config/                       # AsyncConfig, ClockConfig, ProfileSafetyGuard
 ```
 
-## Imports interdits — AUDIT AUTOMATIQUE par hook `check-hexagonal.sh`
+⚠ SPÉCIFICITÉ MyTimeline : les PORTS (services ET repositories) sont dans `domain/ports/`, PAS dans
+`application/`. Un pack générique qui place les ports dans application/ est FAUX pour ce projet.
 
-### `domain/` NE DOIT JAMAIS importer :
-- `jakarta.*` (sauf annotations validation : `@NotNull`, `@Valid`, `@Size`)
-- `io.quarkus.*`
-- `javax.*`
-- `{{JAVA_PACKAGE}}.infrastructure.*`
-- `{{JAVA_PACKAGE}}.application.*` (sauf interfaces de ports)
+## Règle de dépendance (imports interdits par couche)
 
-### `application/` NE DOIT JAMAIS importer :
-- `{{JAVA_PACKAGE}}.infrastructure.*`
-- `io.quarkus.*` (sauf annotations CDI basiques : `@ApplicationScoped`, `@Inject`)
+- `domain/` : AUCUN import Spring / Jakarta Persistence / infrastructure / Lombok sur les models.
+  Seul `jakarta.validation` toléré sur les DTOs. Les models sont des POJO (pas de `@Entity`, getters manuels).
+  Interdits : `org.springframework.*`, `jakarta.persistence.*`, `com.matimeline.eventmanager.infrastructure.*`.
+- `application/` : peut importer `domain/` (models, ports, exceptions) + stéréotypes Spring (`@Service`,
+  `@Transactional` de `org.springframework.transaction`, `@Autowired`, `@Component`). NE DOIT PAS importer
+  `infrastructure/` (entities, JPA, security).
+- `infrastructure/` : peut tout importer. Implémente les ports domaine. Seul endroit avec `@Entity`,
+  `EntityManager`, `@RestController`, Spring Security.
 
-### `infrastructure/` peut importer tout :
-- `{{JAVA_PACKAGE}}.domain.*`
-- `{{JAVA_PACKAGE}}.application.*`
-- Tous les frameworks necessaires
+## Qui implémente quel port
 
-## DEC-009 — Ports obligatoires
+- Port MÉTIER (`domain/ports/services/*Service`) -> impl dans `application/services/*Impl` (`@Service`).
+- Port PERSISTANCE (`domain/ports/repositories/*Repository`) -> impl dans
+  `infrastructure/adapters/repositories/jpa/*RepositoryJpaImpl` (`@Repository`, extends `SimpleJpaRepository`).
+- Port TECHNIQUE externe (`domain/ports/services/EmailService`) -> impl dans `infrastructure/adapters/email/`.
 
-- `application/` ne touche JAMAIS `infrastructure/` directement
-- Les ports (interfaces) sont definis dans `application/`
-- Les implementations (adapters) sont dans `infrastructure/`
+## Anti-patterns RÉELS observés dans ce code (à ne PAS reproduire / à corriger)
 
-## Anti-patterns a proscrire
+1. **Port domaine qui importe un DTO application** — `ProductService.createProduct(ProductCreationRequest)`
+   et `updateProduct(UUID, ProductUpdateRequest)` importent `application.dtos.*` DEPUIS `domain/ports/`.
+   Viole la règle de dépendance (domaine -> application). Contre-exemple SAIN : `CategoryService` prend des
+   params domaine (`String name, String color, UUID ownerId`). NE PAS étendre le pattern DTO-dans-port.
+2. **Controller injectant les `*Impl` au lieu des ports** — `ProductController` déclare
+   `UserServiceImpl`, `EventServiceImpl`, `ProductServiceImpl` en champs (couplage à l'impl concrète).
+   Le bon exemple est `CategoryController` : il dépend des PORTS `CategoryService`, `UserService`.
+   Tout nouveau controller injecte les INTERFACES.
+3. **`@Repository` Spring sur un port domaine** — le port `domain/ports/repositories/*` reste une interface
+   PURE. L'annotation `@Repository` va sur l'IMPL JPA (`infrastructure`), jamais sur le port.
+4. **Entité JPA / domain model renvoyé par un `@RestController`** — toujours mapper vers un `*Response`
+   (cf. `CategoryResponse.fromDomain`, `ProductResponse.fromDomain`). Voir cp-backend.md convention 1.
 
-- Entite JPA dans `domain/` → deplacer vers `infrastructure/persistence/`
-- `@Path`, `@GET`, `@POST` dans `domain/` ou `application/`
-- `l'ORMRepository` dans `application/` → port + adapter infra
-- Static method call vers `application` depuis `domain`
+## Checklist avant de valider une tâche backend
 
-## Checklist implementation
-
-- [ ] La logique metier est dans `domain/` (pure)
-- [ ] Les use cases sont dans `application/` via ports
-- [ ] Les adapters (REST, JPA, HTTP client) sont dans `infrastructure/`
-- [ ] Le hook `check-hexagonal.sh` passe sans erreur
-
-## Reference pour approfondir
-
-`.claude/rules/hexagonal.md` (rule versionnee)
-`docs/memory/decisions.md#DEC-009`
+- [ ] Nouveau service métier -> interface dans `domain/ports/services/` + impl `@Service` dans `application/services/`.
+- [ ] Nouveau repo -> interface dans `domain/ports/repositories/` + impl `@Repository` JPA dans `infrastructure/adapters/repositories/jpa/`.
+- [ ] Controller dépend des PORTS (interfaces), pas des `*Impl`.
+- [ ] Aucun import `infrastructure.*` dans `application/`, aucun import Spring/JPA dans `domain/`.
+- [ ] I/O HTTP = DTOs (`*Request`/`*Response`), jamais l'entité ni le domain model brut.
+- [ ] Nouvel `Entity` <-> `domain model` couvert par un mapper `@Component` dans `application/mappers/`.


### PR DESCRIPTION
## Rafraîchissement des context-packs après Sprint 10

Point d'arrêt sur les packs injectés dans chaque briefing de dev. Deux problèmes traités :

### 1. `br-products.md` était devenu FAUX (P1)
Le pack décrivait encore l'état pré-Sprint 10 (contredisant ce qui est livré en `dev`) :
- « aucun champ `archived` / pas de soft delete / suppression physique » → corrigé : soft delete `archived` + `@SQLRestriction`, `DELETE` → 204.
- pas de `PATCH` → ajouté (BR-PRO-009).
- ajout **BR-PRO-010** : ownership de la catégorie CIBLE validé (404 anti-énumération, `resolveAssignableCategory`).
- anti-patterns #1 (fuite domain model → `ProductResponse`) et #9 (DELETE 200) marqués RÉSOLUS.

### 2. `cp-backend.md` / `cp-hexagonal.md` étaient des templates GÉNÉRIQUES QUARKUS (P2 + P3)
Ils parlaient de Quarkus / Panache / `@QuarkusTest` / `{{JAVA_PACKAGE}}` alors que la stack est **Spring Boot 3 + Java 21 + Spring Data JPA + Flyway + Spring Security + Testcontainers + Lombok**. Chaque briefing devait jusqu'ici préfixer « ignore le Quarkus » — tax supprimé.
Réécrits sur la base d'un **scan du code réel** (architect) :
- `cp-hexagonal` : structure réelle (⚠ **ports dans `domain/ports/`**, pas `application/` — le template générique était faux), imports interdits par couche, anti-patterns réels observés (DTO importé dans un port, controller injectant les `*Impl`).
- `cp-backend` : stack réelle + section **« Conventions MyTimeline »** codifiant 5 conventions transverses récurrentes issues des reviews S10 (DTO en HTTP obligatoire, ownership cible + 404, `DataIntegrityViolationException`→409 scopé au service, JPA update-in-place, soft delete `@SQLRestriction` + SQL natif transverse) — avec renvois vers `pitfalls.md` (PIT-S10-*) et `patterns.md` (PAT-S10-*).

### Non inclus (déféré)
- `cp-frontend.md` : la stack (Next.js app router) correspond au template, seuls des placeholders restent — pass plus léger, non bloquant.

Aucun changement de code applicatif — docs/packs uniquement.
