### PR TITLE
Audit d'exactitude des context-packs (S1-S10) — br-auth/br-events/cp-frontend/coverage

### DIFF
--- a/.ai-env/context-packs/br-auth.md
+++ b/.ai-env/context-packs/br-auth.md
@@ -31,7 +31,7 @@ CRUD simple côté persistance — **pas de lifecycle d'état métier** sur `Use
 | `POST /api/auth/login` | ✅ | ✅ | ✅ | — | `permitAll`, pose cookie HttpOnly ; body = `{"message":...}` sans JWT depuis S4 #104 (BR-AUT-007) |
 | `POST /api/auth/logout` | ✅ | ✅ | ✅ | — | `permitAll`, efface cookie (MaxAge=0) |
 | `POST /api/auth/refresh` | ⚠️ | ✅ | ✅ | ✅ (toutes les 6h frontend) | `permitAll` ; valide expiration+signature avant ré-émission depuis S4 #105 (BR-AUT-009) |
-| `GET /api/auth/me` | ❌ | ✅ | ✅ | — | `permitAll` mais exige cookie `jwt` ; ⚠️ renvoie l'objet `User` domaine avec mot de passe hashé (BR-AUT-008) |
+| `GET /api/auth/me` | ❌ | ✅ | ✅ | — | `permitAll` mais exige cookie `jwt` ; renvoie `UserResponse` (DTO sans password, ✅ RÉSOLU S9, BR-AUT-008) |
 | Accès `/api/users/**`, `/api/products/**`, `/api/events/**` | ❌ | ✅ | ✅ | — | exige token valide (JwtFilter) |
 | Endpoints `hasAuthority('ROLE_ADMIN')` | ❌ | ❌ | ❌ | — | ⚠️ rôle ADMIN mort, aucun endpoint ne l'utilise |
 
@@ -55,16 +55,16 @@ CRUD simple côté persistance — **pas de lifecycle d'état métier** sur `Use
 ### BR-AUT-003 — Validation des champs d'inscription
 **Règle** : Le `system` MUST rejeter un `register` dont `name`/`username` ne font pas 3..20 caractères, `email` non valide, ou `password` < 6 caractères.
 **Pourquoi** : Garantir des credentials exploitables et un email correct.
-**Implémentation** : annotations Bean Validation sur `RegisterRequest` (`@NotBlank`, `@Size(min=3,max=20)`, `@Email`, `@Size(min=6)`).
+**Implémentation** : annotations Bean Validation sur `RegisterRequest` (`@NotBlank`, `@Size(min=3,max=20)`, `@Email`, `@Size(min=6)`) + `@Valid` sur `@RequestBody` (`AuthController.java:151`).
 **Test attendu** : `AuthControllerTest#register_shouldReturn400_whenPasswordTooShort`.
-> ⚠️ **NON IMPLÉMENTÉ (code mort)** : `@Valid` ABSENT sur `@RequestBody RegisterRequest` (`AuthController.register` l.104). Toutes les annotations de `RegisterRequest` ne sont JAMAIS déclenchées → aucune validation serveur. Côté frontend, `RegisterData` n'a pas de schéma Zod → aucune validation client non plus. **Fix attendu : ajouter `@Valid`.**
+> ✅ RÉSOLU (Sprint 9) : `@Valid` présent sur `register` (`AuthController.java:151`) → les Bean Validations de `RegisterRequest` sont déclenchées (validation serveur active). Côté frontend, `RegisterSchema` Zod existe (`frontend/src/lib/schemas/auth.ts:47`, cf. A12).
 
 ### BR-AUT-004 — Validation des credentials de login
 **Règle** : Le `system` MUST rejeter un `login` dont `username` < 3 ou `password` < 6 caractères.
 **Pourquoi** : Cohérence avec les contraintes d'inscription, éviter des requêtes d'auth triviales.
-**Implémentation** : `AuthRequest` côté backend ; `LoginSchema` Zod côté frontend (`username z.string().min(3)`, `password z.string().min(6)`).
+**Implémentation** : `AuthRequest` côté backend + `@Valid` sur `login` (`AuthController.java:97`) ; `LoginSchema` Zod côté frontend (`username z.string().min(3)`, `password z.string().min(6)`).
 **Test attendu** : `AuthControllerTest#login_shouldReject_whenUsernameTooShort`.
-> ⚠️ **NON IMPLÉMENTÉ côté backend** : `AuthRequest` ne porte AUCUNE annotation de validation et `@Valid` est absent. Seul le frontend (Zod) contraint ces champs.
+> ✅ RÉSOLU (Sprint 9) : `@Valid` présent sur `login` (`AuthController.java:97`) — également sur forgot/reset password. La validation backend est active (plus uniquement Zod frontend).
 
 ### BR-AUT-005 — Échec d'authentification → 401, jamais de fuite interne
 **Règle** : Le `system` MUST renvoyer `401 UNAUTHORIZED` (`"Invalid username or password"`) sur mauvais credentials et NE MUST PAS exposer de détail interne d'exception.
@@ -90,9 +90,9 @@ CRUD simple côté persistance — **pas de lifecycle d'état métier** sur `Use
 ### BR-AUT-008 — `/me` retourne l'utilisateur courant sans secret
 **Règle** : `GET /me` MUST renvoyer les données de l'utilisateur identifié par le token et NE MUST PAS exposer le mot de passe (même hashé).
 **Pourquoi** : Un hash ne doit jamais transiter par l'API (risque de cassage offline, surface inutile).
-**Implémentation** : `AuthController.getUserDetails` (l.75-101) — extrait username, `validateToken`, renvoie l'utilisateur.
+**Implémentation** : `AuthController.getUserDetails` — extrait username, `validateToken`, renvoie `UserResponse.fromDomain(...)` (`AuthController.java:140`).
 **Test attendu** : `AuthControllerTest#me_shouldNotExposePasswordHash`.
-> ⚠️ **VIOLATION CRITIQUE** : l.93 renvoie directement l'objet domaine `User.get()` → le champ `password` (hash) est sérialisé dans la réponse HTTP. **Fix attendu : projection / DTO sans password.**
+> ✅ RÉSOLU (Sprint 9) : `/me` renvoie `UserResponse.fromDomain(...)` (`AuthController.java:140`), DTO sans champ `password` (`UserResponse.java`). Le hash n'est plus sérialisé dans la réponse HTTP (cf. A1).
 
 ### BR-AUT-009 — Refresh exige un token encore valide
 **Règle** : `POST /refresh` MUST vérifier que le token courant est valide (non expiré) avant d'émettre un nouveau token, sinon `401`.
@@ -128,7 +128,7 @@ CRUD simple côté persistance — **pas de lifecycle d'état métier** sur `Use
 - **Aucune relation JPA** : `UserEntity` est une table `users` autonome (pas de `@OneToMany`/`@ManyToOne`).
 - **Dépendances logiques sortantes** : `users`, `products`, `events` exigent un `User` authentifié (`ROLE_USER`) via JwtFilter — le domaine `auth` est producteur de l'identité consommée par ces domaines (notamment `userId` dans `/api/users/{userId}/products/**`).
 - **Couplage infrastructure (à surveiller)** : `AuthController` importe et injecte des classes infra (`UserServiceImpl` concret, `JwtService`, `CustomUserDetailsService`, `CustomUserDetails`) — voir anti-patterns.
-- **Frontend** : `useAuth` (state d'auth, localStorage) et `apiClient` (intercepteur axios 401/403 → redirect `/login`, refresh périodique) dépendent des contrats de ce domaine.
+- **Frontend** : `AuthContext` (state d'auth via re-fetch `GET /api/auth/me` au montage, cookie HttpOnly seul, plus de localStorage depuis #135/S9 ; `useAuth` = ré-export) et `apiClient` (intercepteur axios 401/403 → redirect `/login`, refresh périodique) dépendent des contrats de ce domaine.
 
 ---
 
@@ -136,8 +136,8 @@ CRUD simple côté persistance — **pas de lifecycle d'état métier** sur `Use
 
 | # | Anti-pattern | Localisation | Gravité |
 |---|--------------|--------------|:-------:|
-| A1 | `/me` renvoie l'objet domaine `User` → hash de mot de passe exposé en HTTP | `AuthController` l.93 | CRITIQUE |
-| A2 | `@Valid` absent sur `@RequestBody RegisterRequest` → toutes les Bean Validations sont du code mort | `AuthController` l.104 | CRITIQUE |
+| A1 | ✅ RÉSOLU (S9) : `/me` renvoie `UserResponse.fromDomain(...)` (DTO sans password) — hash plus exposé | `AuthController.java:140` | ~~CRITIQUE~~ |
+| A2 | ✅ RÉSOLU (S9, #BR-AUT-003) : `@Valid` présent sur `register` → Bean Validations actives | `AuthController.java:151` | ~~CRITIQUE~~ |
 | A3 | ~~JWT brut renvoyé dans le body du login~~ → ✅ RÉSOLU S4 #104 (body `{"message":...}`) | `AuthController` | ~~HAUTE~~ |
 | A4 | `catch (Exception)` renvoie l'objet exception dans le body (500) → fuite d'internes ⚠️ partiel : login/refresh renvoient désormais `{"error":...}` générique (#113) mais `catch` toujours présent | `AuthController` | MOYENNE |
 | A5 | ~~`refresh` n'invalide pas un token expiré avant ré-émission~~ → ✅ RÉSOLU S4 #105 (`validateToken` avant `generateToken`) | `AuthController` | ~~HAUTE~~ |
@@ -145,14 +145,15 @@ CRUD simple côté persistance — **pas de lifecycle d'état métier** sur `Use
 | A7 | ~~`domain="localhost"` en dur~~ → ✅ RÉSOLU S4 #99 (`@Value("${app.cookie.domain}")`, prod host-only) | `AuthController` | ~~HAUTE~~ |
 | A8 | `AuthController` injecte `UserServiceImpl` concret + importe classes infra → viole hexagonal/DIP | l.24-28, 38 | MOYENNE |
 | A9 | `role` stocké en `String` (domaine + entité) ; enum `Role` inutilisée → pas de type safety ni contrainte DB | `UserEntity`, `User` | MOYENNE |
-| A10 | `UserEntity` sans `@Column(unique=true)` sur `username` (doublon possible en course concurrente). `email` OK : `uq_users_email` (V2 #32). VARCHAR(255) nullable par défaut. | `UserEntity` | MOYENNE |
-| A11 | `useAuth.register` passe `username` comme `name` ET premier argument → le champ `name` vaut toujours `username`, l'input `name` réel est ignoré | `useAuth.ts` l.54 | MOYENNE |
-| A12 | `RegisterData` sans schéma Zod → aucune validation client à l'inscription | frontend register flow | MOYENNE |
-| A13 | Refresh périodique via `setInterval` (6h) au chargement du module, sans cleanup ni vérif d'auth réelle | `apiClient.ts` l.22 | BASSE |
-| A14 | `CustomUserDetails` : `isAccountNonExpired/NonLocked/CredentialsNonExpired/isEnabled` renvoient `true` en dur (`need to implement logic`) | `CustomUserDetails` | BASSE |
-| A15 | `UserServiceImpl.updateUser` sans `@Transactional` (alors que `createUser` l'a) | `UserServiceImpl` | BASSE |
+| A10 | ✅ RÉSOLU (S9) : `@Column(unique = true)` présent sur `username` (`UserEntity.java:23`) — doublon bloqué au niveau DB. `email` : `uq_users_email` (V2 #32). | `UserEntity.java:23` | ~~MOYENNE~~ |
+| A11 | ✅ RÉSOLU (S9) : `authService.registerUser(name, username, email, password)` mappe correctement `name` et `username` séparément (`authService.ts:24-31`) | `authService.ts:24-31` | ~~MOYENNE~~ |
+| A12 | ✅ RÉSOLU (S9) : `RegisterSchema` Zod existe (`frontend/src/lib/schemas/auth.ts:47`) → validation client à l'inscription | `frontend/src/lib/schemas/auth.ts:47` | ~~MOYENNE~~ |
+| A13 | Refresh périodique via `setInterval` (6h) au chargement du module, sans cleanup ni vérif d'auth réelle | `apiClient.ts:31` | BASSE |
+| A14 | `CustomUserDetails` : `isAccountNonExpired/NonLocked/CredentialsNonExpired/isEnabled` renvoient `true` en dur (`need to implement logic`) | `CustomUserDetails.java:40-59` | BASSE |
+| A15 | ✅ RÉSOLU (S9) : `@Transactional` présent sur `updateUser` (`UserServiceImpl.java:37`) | `UserServiceImpl.java:37` | ~~BASSE~~ |
 | A16 | Enum `Role.ADMIN` jamais référencée par un `hasAuthority` → rôle ADMIN mort | sécurité globale | BASSE |
-| A17 | `useAuth` lit l'utilisateur depuis `localStorage` au montage sans vérification serveur | `useAuth.ts` | BASSE |
+| A17 | ✅ RÉSOLU (#135, S9) : plus aucun localStorage — `AuthContext.tsx:34-39,60-64,108-111` re-fetch `GET /api/auth/me` au montage (cookie HttpOnly seul). `useAuth.ts` = simple ré-export. Réf DEC-S9-002. | `AuthContext.tsx`, `useAuth.ts` | ~~BASSE~~ |
+| A18 | Champ `avatar` sur `User`/`UserEntity` (V7, #44, S9) présent backend (`UserEntity.java:32`, `User.java:12`) mais ABSENT du contrat frontend (`UserResponse` ne l'expose pas, `UserSchema` `frontend/src/types/user.ts` ne l'a pas) → avatar backend non exposé au front, dette **issue #151 (Sprint 13)** | `UserEntity.java:32`, `frontend/src/types/user.ts` | MOYENNE |
 
 ---
 

--- a/.ai-env/context-packs/br-events.md
+++ b/.ai-env/context-packs/br-events.md
@@ -7,7 +7,7 @@
 
 ## 1. Lifecycles (machines à états)
 
-**EventEntity** — CRUD simple, **pas de lifecycle d'état métier** (aucun champ `status`/`state`, pas de soft-delete : la suppression est physique via `deleteById`).
+**EventEntity** — CRUD simple, pas de machine à états `status`/`state`. `#44` (S9) a introduit un champ **`archived`** (`EventEntity.java:57-58`, `Event.java`) — flag de type soft-delete existant, mais `DELETE` reste une suppression physique via `deleteById` (le flag `archived` ne remplace pas encore le hard-delete). Nuance : soft-delete partiellement amorcé, pas complet.
 
 Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une nature figée à la création :
 
@@ -17,6 +17,8 @@ Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une n
 | `single`   | Événement ponctuel → `endDate` = `startDate`             | `calculateEndDate` retourne `startDate` inchangée (branche `if` non prise)          |
 
 ⚠️ Aucune contrainte d'enum sur `type` côté backend : toute chaîne hors `duration`/`single` est acceptée et traitée comme `single` (branche `if` non prise → `endDate = startDate`).
+
+**CHECK constraint `ck_events_recurrence_unit`** (V7, #44) : limite `recurrence_unit` à WEEK/MONTH/YEAR au niveau DB (lié à PIT-S9-001). Une valeur legacy invalide en base fait échouer l'insertion/maj → V10 (prévue S12) neutralisera les valeurs invalides existantes.
 
 ---
 
@@ -70,7 +72,7 @@ Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une n
 ### BR-EVE-006 — recurrenceUnit requis quand isRecurring=true
 **Règle** : quand `isRecurring=true`, `recurrenceUnit` DEVRAIT être obligatoire (`weeks/months/years`).
 **Pourquoi** : une récurrence sans unité est inexploitable.
-**⚠️ NON IMPLÉMENTÉ** : aucune contrainte ni backend (`EventCreationRequest.recurrenceUnit` sans `@NotBlank` ni validation conditionnelle) ni frontend (`eventCreationSchema` ne refine pas `recurrenceUnit`). `recurrenceUnit` reste librement null même avec `isRecurring=true`.
+**✅ RÉSOLU partiel (Sprint 9, #44)** : enum `RecurrenceUnit` (WEEK/MONTH/YEAR) livré backend (`RecurrenceUnit.java`), parsing tolérant legacy via `RecurrenceUnit.fromString`, conversion au service (`EventServiceImpl.java:52,83`). Le DTO `EventCreationRequest.recurrenceUnit` reste `String` en façade puis converti en enum. **ENCORE VALIDE** : aucune contrainte « obligatoire si `isRecurring=true` » (`@NotBlank`/refine conditionnel toujours manquant back + front) → `recurrenceUnit` reste librement null même avec `isRecurring=true`.
 **Test attendu** : `EventCreationRequestValidationTest.shouldRequireRecurrenceUnitWhenRecurring` (à créer après ajout de la règle).
 
 ### BR-EVE-007 — isRecurring obligatoire à la création
@@ -86,11 +88,12 @@ Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une n
 **✅ IMPLÉMENTÉ Sprint 1 (#30/#91)** : `EventController` vérifie l'ownership sur `createEvent` (productId du caller), `updateEvent` et `deleteEvent` via le helper `checkEventOwnership` (`event → productId → product.getUser().getId() == caller.getId()`, sinon 403). Identité dérivée du JWT (`resolveCaller`), jamais d'un path param. `JwtException` → 401 (pas 500).
 **Test attendu** : `EventControllerSecurityTest.shouldReturn403WhenPatchingForeignEvent` + `shouldReturn403WhenDeletingForeignEvent`.
 
-### BR-EVE-009 — Couleurs cohérentes sur le formulaire d'édition
-**Règle** : sur l'édition, `backgroundColor`/`borderColor`/`textColor` DOIVENT être traités de façon cohérente (un seul schéma source de vérité).
-**Pourquoi** : éviter des erreurs de validation/runtime divergentes pour le même formulaire.
-**⚠️ NON IMPLÉMENTÉ (schéma dupliqué)** : deux `eventEditSchema` divergents — `types/event.ts` (couleurs `optional`, seul `backgroundColor` présent) vs `EventEditForm.tsx` (3 couleurs `z.string()` requises). Aucune validation de format hex côté backend (`backgroundColor/borderColor/textColor` String libres, nullable).
-**Test attendu** : `eventEditSchema.test.ts.shouldValidateColorsConsistently` (après consolidation en un schéma unique).
+### BR-EVE-009 — Modèle couleur event (migration design v3 #44)
+**Règle** : l'event porte UNE couleur unique cohérente entre backend et frontend.
+**Pourquoi** : éviter des erreurs de validation/runtime divergentes ; le modèle 3-couleurs était redondant.
+**✅ BACKEND RÉSOLU (Sprint 9, #44)** : colonne UNIQUE `color` (`EventEntity.java:59`, `V7__design_v3_schema.sql:67-79`) ; `border_color`/`text_color` **DROP définitif** (migration irréversible).
+**⚠️ FRONTEND NON migré** : `frontend/src/types/event.ts:13-15` + `EventEditForm.tsx:262-264` conservent le modèle 3-couleurs (`backgroundColor`/`borderColor`/`textColor`) → désync front/back, dette **issue #150 (sync Zod, non livrée)**. Aucune validation format hex côté backend (`color` String libre).
+**Test attendu** : `eventEditSchema.test.ts.shouldValidateColorsConsistently` (après migration front sur `color` unique).
 
 ### BR-EVE-010 — Champ allDay : nom de sérialisation
 **Règle** : le frontend MUST lire le champ booléen "journée entière" sous la clé sérialisée par le backend.
@@ -105,6 +108,22 @@ Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une n
 **Lien** : « actif » = non archivé (dépend du soft-delete événement, cf. modèle v3 #44) ; comptage à garder atomique en cas de création concurrente / offline (#76).
 **Test attendu** : `PlanPolicyTest.shouldCountActiveNonArchivedEvents` + `shouldCountRecurringAsOne` + `EventControllerQuotaTest.shouldReturn402WhenTierLimitReached` (quand l'enforcement sera activé).
 
+### BR-EVE-012 — recurrenceEndDate (champ #44, non couvert par une règle antérieure)
+**Règle** : `recurrenceEndDate` borne la fin d'une récurrence.
+**Implémentation** : champ réel `EventEntity.java:47-48`, `Event.java` ; exposé en PATCH `EventUpdateRequest.java:37`.
+**⚠️ GAP validation** : AUCUNE contrainte `recurrenceEndDate > startDate` (backend) → une date de fin antérieure au début est acceptée silencieusement.
+**Test attendu** : `EventValidationTest.shouldRejectRecurrenceEndDateBeforeStart` (à créer).
+
+### BR-EVE-013 — archived en PATCH uniquement (asymétrie create/update)
+**Règle** : `archived` (flag soft-delete amorcé) est modifiable via PATCH mais pas fixable à la création.
+**Implémentation** : présent en PATCH `EventUpdateRequest.java:40`, mappé `EventServiceImpl.java:90-92` ; ABSENT de `EventCreationRequest` (pas de création d'event déjà archivé).
+**Test attendu** : `EventServiceImplTest.shouldToggleArchivedOnPatch`.
+
+### BR-EVE-014 — Asymétrie DTO create vs update (bug produit potentiel)
+**Règle (constat)** : `EventCreationRequest` n'expose PAS `color`/`archived`/`recurrenceEndDate` — seul `EventUpdateRequest` les supporte.
+**Conséquence** : impossible de créer un event coloré directement → il faut créer puis PATCH. Asymétrie non documentée côté contrat, source de bug produit / friction UX.
+**Test attendu** : `EventCreationRequestContractTest.shouldExposeColorAtCreation` (après harmonisation).
+
 ---
 
 ## 4. Dépendances inter-domaines
@@ -114,6 +133,7 @@ Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une n
 - **Listing des events** : porté par `ProductController` (`GET /api/users/{userId}/products/{productId}/events`), pas par `EventController` → le domaine `events` dépend de l'auth produit/user.
 - ⚠️ **Couplage infra-infra** : `EventRepositoryJpaImpl` injecte `ProductRepositoryJpaImpl` (classe concrète) au lieu du port `ProductRepository` → viole l'inversion de dépendance hexagonale.
 - ⚠️ **Fuite DTO dans le port domaine** : `EventService` (port domaine) référence `EventCreationRequest` (couche application) dans `createEvent(...)` → le DTO applicatif pollue la définition du port.
+- ⚠️ **Impact `@SQLRestriction("archived=false")` de `ProductEntity`** : les events d'un produit archivé deviennent inaccessibles via `GET events` — le produit est résolu par `findById` d'abord, qui renvoie 404 (produit filtré par la restriction), donc le listing des events échoue en amont. Dépendance events↔products à connaître lors du debug « events introuvables ».
 
 ---
 
@@ -128,7 +148,7 @@ Le seul "état" implicite est le `type`, qui n'est PAS une transition mais une n
 - **Double round-trip DB** : `deleteById` fait `existsById` puis `deleteById` (2 requêtes) ; `findEventById` fait `existsById` puis `findEventById` (2 requêtes).
 - **Check vide dupliqué** : `EventServiceImpl.findDomainEventByProductId` lève `EventNotFoundException` sur liste vide, puis `ProductController` re-teste `isEmpty()` après coup.
 - **NPE potentielle** : `Utils.calculateEndDate` `switch(durationUnit)` sans null-guard quand `type='duration'`. (cf. BR-EVE-004)
-- **Suppression physique** : `deleteById` supprime réellement la ligne — pas de soft-delete (divergence avec la convention soft-delete du projet).
+- **Suppression physique** : `deleteById` supprime réellement la ligne. Nuance (S9 #44) : un champ `archived` (`EventEntity.java:57-58`, `Event.java`) existe désormais (soft-delete amorcé) mais `DELETE` reste un hard-delete — le flag n'est pas encore branché sur la suppression.
 - ~~**`@CrossOrigin(origins="*")`** sur `EventController`~~ : ✅ RETIRÉ Sprint 1 #30 — CORS gérée uniquement par `SecurityConfig` (`allowCredentials=true` + `allowedOrigins localhost:3000`).
 - **Schémas Zod dupliqués/divergents** : `eventEditSchema` défini deux fois (cf. BR-EVE-009) ; champ `allDay` vs `isAllDay` (cf. BR-EVE-010) ; `name.min(3)` front vs `@Size(min=1)` back ; `type` enum strict front vs `@NotBlank` libre back.
 

--- a/.ai-env/context-packs/coverage-auth.md
+++ b/.ai-env/context-packs/coverage-auth.md
@@ -1,42 +1,29 @@
-# Coverage : `auth`
+# Coverage — auth (màj post-S10)
 
-> État de couverture du domaine `auth` au 2026-06-25.
+> Énumération réelle des tests. Remplace la version 2026-06-25 (« zéro test auth » — faux positif).
 
----
+## Tests backend présents
+- `AuthControllerSecurityTest` (10 tests, slice Mockito + standaloneSetup) — register/login, échecs d'auth, contrats d'erreur du controller.
+- `AuthControllerValidationTest` (3 tests, slice Mockito + standaloneSetup) — validation Bean sur payloads register/login.
+- `AuthControllerDevProfileCookieTest` (2 tests, @SpringBootTest + standaloneSetup) — cookie de session en profil dev.
+- `AuthErrorContractIntegrationTest` (3 tests, intégration @SpringBootTest + Testcontainers Postgres) — forme JSON des erreurs d'auth bout-en-bout.
+- `RateLimitingAndHeadersIntegrationTest` (8 tests, intégration Testcontainers) — rate-limiting login/forgot + en-têtes de sécurité.
+- `PasswordResetEndpointsIntegrationTest` (5 tests, intégration Testcontainers) — endpoints forgot/reset password.
+- `PasswordResetServiceImplTest` (9 tests, unit Mockito) — logique reset (token, expiration, invalidation).
+- `ForgotPasswordAsyncTest` (2 tests, @SpringBootTest) — envoi asynchrone du mail forgot-password.
+- `UserServiceImplTest` (3 tests, unit Mockito) — service utilisateur (création/lecture).
+- `UserControllerTest` (9 tests, slice Mockito + standaloneSetup) — endpoints profil utilisateur.
 
-## 1. Matrice de couverture par action
+## Tests frontend / E2E
+- `src/contexts/AuthContext.test.tsx` (6) — état d'auth client.
+- `src/hooks/useCurrentUser.test.tsx` (2), `src/services/authService.test.ts` (1) — hook user courant, service auth.
+- Pages (vitest/RTL) : `login/page.test.tsx` (3), `register/page.test.tsx` (3), `forgot-password/page.test.tsx` (2), `reset-password/page.test.tsx` (3).
+- E2E : aucun (`frontend/e2e/` = `.gitkeep` seul).
 
-| Action | `user` | `system` | Notes |
-|---|---|---|---|
-| S'inscrire | ⚠️ | n/a | Controller implémenté, pas de test dédié |
-| Se connecter | ⚠️ | n/a | Controller implémenté, pas de test dédié |
-| Valider token JWT | n/a | ⚠️ | JwtFilter implémenté, pas de test d'intégration |
-| Rafraîchir token | ❌ | n/a | Non implémenté |
+## Gaps restants (non couverts)
+- Aucun E2E du parcours inscription → connexion → accès protégé.
+- Validation JWT (filtre) : pas de test d'intégration isolé dédié (couverte indirectement via les *IntegrationTest).
+- Refresh token : non implémenté, donc non testé.
 
----
-
-## 2. Gaps prioritisés
-
-### P0 — Aucun test auth
-- **Symptôme** : Zéro test sur la chaîne register/login/JWT
-- **Cause** : Tests non écrits en phase initiale
-- **BR concernée** : BR-AUTH-001, BR-AUTH-002, BR-AUTH-003
-- **Action** : Écrire `AuthControllerTest` + `JwtServiceTest`
-
-### P1 — Pas de refresh token
-- **Symptôme** : Token expiré = reconnexion manuelle
-- **Action** : Implémenter endpoint `/auth/refresh`
-
----
-
-## 3. Coverage E2E
-
-| Scénario | Fichier test | Statut |
-|---|---|---|
-| Inscription → connexion → accès protégé | `e2e/auth/login.spec.ts` | ❌ non créé |
-
----
-
-## Référence
-
-- Pack métier stable : `br-auth.md`
+## Total : 54 tests backend (auth + user/reset)
+> Transverses hors domaine : `AuditingAndEqualityTest` (12), `ProfileSafetyGuardTest` (6, unit sans Spring) — non comptés ici.

--- a/.ai-env/context-packs/coverage-categories.md
+++ b/.ai-env/context-packs/coverage-categories.md
@@ -1,40 +1,20 @@
-# Coverage : `categories`
+# Coverage — categories (màj post-S10)
 
-> État de couverture du domaine `categories` au 2026-06-25.
+> Énumération réelle des tests. Remplace la version 2026-06-25 (« zéro test backend categories » — faux positif).
 
----
+## Tests backend présents
+- `CategoryServiceImplTest` (15 tests, unit Mockito) — CRUD service, règles métier (unicité, rejet suppression si utilisée).
+- `CategoryControllerTest` (22 tests, slice Mockito + standaloneSetup) — endpoints CRUD, codes d'erreur, ownership.
+- `CategoryDeleteReassignIntegrationTest` (5 tests, intégration @SpringBootTest + Testcontainers Postgres) — suppression avec réassignation des événements liés.
+- `GlobalExceptionHandlerValidationTest` (1 test, slice Mockito + standaloneSetup) — mapping validation → réponse HTTP (transverse, partiellement pertinent categories).
 
-## 1. Matrice de couverture par action
+## Tests frontend / E2E
+- Aucun test frontend dédié categories.
+- E2E : aucun (`frontend/e2e/` = `.gitkeep` seul).
 
-| Action | `user` | `admin` | Notes |
-|---|---|---|---|
-| Créer une catégorie | ⚠️ | n/a | Backend implémenté, pas de test |
-| Lister les catégories | ⚠️ | n/a | Backend implémenté, pas de test |
-| Modifier une catégorie | ⚠️ | n/a | Backend implémenté, pas de test |
-| Supprimer une catégorie | ⚠️ | n/a | Backend implémenté, pas de test |
+## Gaps restants (non couverts)
+- Aucun E2E « créer une catégorie → l'assigner à un événement ».
+- Aucun test frontend (formulaire/liste catégories).
 
----
-
-## 2. Gaps prioritisés
-
-### P0 — Zéro test backend categories
-- **BR concernée** : BR-CAT-001, BR-CAT-002
-- **Action** : `CategoryServiceImplTest`
-
-### P1 — Contrainte suppression non vérifiée
-- **BR concernée** : BR-CAT-002
-- **Action** : Vérifier que `CategoryServiceImpl.delete()` rejette si catégorie utilisée
-
----
-
-## 3. Coverage E2E
-
-| Scénario | Fichier test | Statut |
-|---|---|---|
-| Créer une catégorie, l'assigner à un événement | `e2e/categories/assign.spec.ts` | ❌ non créé |
-
----
-
-## Référence
-
-- Pack métier stable : `br-categories.md`
+## Total : 42 tests backend
+> `GlobalExceptionHandlerValidationTest` (1) est transverse ; les 42 incluent les 3 classes categories (15+22+5) + ce test transverse.

--- a/.ai-env/context-packs/coverage-events.md
+++ b/.ai-env/context-packs/coverage-events.md
@@ -1,43 +1,20 @@
-# Coverage : `events`
+# Coverage — events (màj post-S10)
 
-> État de couverture du domaine `events` au 2026-06-25.
+> Énumération réelle des tests. Remplace la version 2026-06-25 (« zéro test backend events » — faux positif).
 
----
+## Tests backend présents
+- `EventServiceImplTest` (5 tests, unit Mockito) — CRUD service, règles métier événement.
+- `EventControllerOwnershipTest` (3 tests, intégration @SpringBootTest + Testcontainers Postgres + standaloneSetup) — contrôle d'ownership sur GET/PUT/DELETE, 403 cross-user.
+- `EventControllerValidationTest` (1 test, slice Mockito + standaloneSetup) — validation Bean sur payload événement.
 
-## 1. Matrice de couverture par action
+## Tests frontend / E2E
+- `src/hooks/useProductsWithEvents.test.tsx` (2) — hook front produits+événements (transverse products/events).
+- Aucun autre test frontend dédié events (intégration FullCalendar non testée).
+- E2E : aucun (`frontend/e2e/` = `.gitkeep` seul).
 
-| Action | `user` | `admin` | Notes |
-|---|---|---|---|
-| Créer un événement | ⚠️ | n/a | Backend implémenté, pas de test |
-| Lister ses événements | ⚠️ | n/a | Backend implémenté, pas de test |
-| Modifier un événement | ⚠️ | n/a | Backend implémenté, pas de test |
-| Supprimer un événement | ⚠️ | n/a | Backend implémenté, pas de test |
-| Afficher sur calendrier | ⚠️ | n/a | Frontend FullCalendar intégré, pas d'E2E |
+## Gaps restants (non couverts)
+- Aucun E2E « créer un événement → voir sur calendrier » ni édition depuis calendrier.
+- Intégration FullCalendar (rendu, drag) non couverte.
+- Couverture controller events plus légère que categories/products (1 seul test validation, ownership à 3 cas).
 
----
-
-## 2. Gaps prioritisés
-
-### P0 — Zéro test backend events
-- **Symptôme** : EventServiceImpl non testée
-- **BR concernée** : BR-EVT-001, BR-EVT-002, BR-EVT-003
-- **Action** : `EventServiceImplTest` + `EventControllerIntegrationTest`
-
-### P1 — Pas d'E2E calendrier
-- **Symptôme** : Intégration FullCalendar non couverte
-- **Action** : `e2e/events/calendar.spec.ts`
-
----
-
-## 3. Coverage E2E
-
-| Scénario | Fichier test | Statut |
-|---|---|---|
-| Créer un événement, voir sur calendrier | `e2e/events/create.spec.ts` | ❌ non créé |
-| Modifier un événement depuis le calendrier | `e2e/events/edit.spec.ts` | ❌ non créé |
-
----
-
-## Référence
-
-- Pack métier stable : `br-events.md`
+## Total : 9 tests backend

--- a/.ai-env/context-packs/coverage-products.md
+++ b/.ai-env/context-packs/coverage-products.md
@@ -1,39 +1,20 @@
-# Coverage : `products`
+# Coverage — products (màj post-S10)
 
-> État de couverture du domaine `products` au 2026-06-25.
+> Énumération réelle des tests. Remplace la version 2026-06-25 (« zéro test backend products » — faux positif).
 
----
+## Tests backend présents
+- `ProductServiceImplTest` (6 tests, unit Mockito) — création/lecture/modification/archivage, règles métier service.
+- `ProductControllerOwnershipTest` (13 tests, slice Mockito + standaloneSetup) — contrôle d'ownership sur GET/PUT/DELETE sécurisés, 403 cross-user.
+- `ProductArchivedFilterIntegrationTest` (6 tests, intégration @SpringBootTest + Testcontainers Postgres) — filtre soft-delete/archivé au niveau repository.
 
-## 1. Matrice de couverture par action
+## Tests frontend / E2E
+- `src/hooks/useProductsWithEvents.test.tsx` (2) — hook front produits+événements (transverse products/events).
+- Aucun autre test frontend dédié products.
+- E2E : aucun (`frontend/e2e/` = `.gitkeep` seul).
 
-| Action | `user` | `admin` | Notes |
-|---|---|---|---|
-| Créer un produit | ⚠️ | n/a | Backend implémenté, pas de test |
-| Lister les produits | ⚠️ | n/a | Backend implémenté, pas de test |
-| Modifier un produit | ⚠️ | n/a | Backend implémenté, pas de test |
-| Supprimer un produit | ⚠️ | n/a | Backend implémenté, pas de test |
+## Gaps restants (non couverts)
+- Aucun E2E « créer un produit → voir dans la liste ».
+- Validation Bean des payloads produit non couverte par un test controller dédié (pas de `ProductControllerValidationTest`).
+- Composants UI produits (formulaires) sans test RTL.
 
----
-
-## 2. Gaps prioritisés
-
-### P0 — Zéro test backend products
-- **BR concernée** : BR-PROD-001, BR-PROD-002
-- **Action** : `ProductServiceImplTest`
-
-### P2 — Pas d'E2E produits
-- **Action** : `e2e/products/create.spec.ts`
-
----
-
-## 3. Coverage E2E
-
-| Scénario | Fichier test | Statut |
-|---|---|---|
-| Créer un produit, voir dans la liste | `e2e/products/create.spec.ts` | ❌ non créé |
-
----
-
-## Référence
-
-- Pack métier stable : `br-products.md`
+## Total : 25 tests backend

--- a/.ai-env/context-packs/cp-frontend.md
+++ b/.ai-env/context-packs/cp-frontend.md
@@ -1,88 +1,84 @@
-# Context-pack : Frontend Next.js 16 / TypeScript
+# Context-pack : Frontend MyTimeline (Next.js 15 App Router / React 18)
 
-> ⚠️ EXEMPLE Layer B (instance EdelWheels / Quarkus-Next). À RÉGÉNÉRER par /ai-env:setup pour ta stack. Voir REBUILD-PLAN.md §2.2.
+> À charger pour TOUTE tâche frontend. Décrit la stack RÉELLE (scan code, sprint 9).
+> Versions = source de vérité `frontend/package.json`. Ce pack ne réplique pas les
+> valeurs mineures : en cas de doute, relire le `package.json`.
 
-> Reference maitre : `.claude/rules-jit/frontend.md`
-> A charger pour TOUTE tache frontend
+## Stack réelle (versions du package.json)
 
-## Stack
+- **Next.js `^15.2.4`** — App Router, dev `next dev --turbopack`, build `next build`.
+- **React `^18.3.1`** + React DOM 18.3.1. ⚠ **PAS React 19** malgré `@types/react@^19`.
+- **TypeScript `^5`** strict (`strict: true`, `noEmit`), alias `@/* → src/*`, `@/app/* → app/*`.
+- **TanStack Query `^5.101.2`** (+ devtools) — état serveur. API v5 STRICT (forme objet, `gcTime`).
+- **Zod `^3.24.2`** — validation + inférence de types.
+- **React Hook Form `^7.54.2`** + `@hookform/resolvers@^4` (zodResolver).
+- **next-intl `^4.0.2`** — i18n, 4 locales `['fr','en','es','de']`, `localePrefix: 'always'`.
+- **Tailwind `^4.0.12`** (`@tailwindcss/postcss`) + `tailwind.config.ts` minimal + `postcss.config.mjs`.
+- **shadcn/ui** style `new-york`, `rsc: true`, icônes **lucide-react**, Radix (dialog, select, popover, dropdown, checkbox, label, slot).
+- **axios `^1.8.1`** (client HTTP), **react-hot-toast** (toasts globaux), **next-themes** (clair/sombre), **framer-motion**, **dayjs**, **react-colorful**.
+- Tests : **Vitest `^2.1.9`** + **RTL `^16`** + jest-dom (jsdom). **Playwright `^1.61`** configuré mais `frontend/e2e/` = `.gitkeep` VIDE → aucun E2E réel. Storybook 8 présent.
 
-le framework frontend + TypeScript strict + le framework CSS + la gestion d'état
+## Structure `frontend/`
 
-## Conventions TypeScript
+- **`app/`** (App Router, PAS `src/app/`) : `layout.tsx` (root, Server Component), `app/[locale]/` avec `dashboard/ login/ register/ forgot-password/ reset-password/ home/ privacy/ terms/`.
+- **`i18n.ts`** (racine) : `getRequestConfig`, charge les messages depuis **`public/locales/<locale>/<namespace>.json`** (fichiers par namespace : `auth common dashboard errors legal products register validation`).
+- **`middleware.ts`** : `next-intl/middleware`, `localePrefix: 'always'`, matcher exclut `api|_next|*.*`.
+- **`src/components/`** : `ui/` (shadcn : button, card, dialog, select, form, input, spinner, dropdown-menu, popover, language-selector…), `calendar/`, `pages/`, `products/`, + composants métier (`EventContent`, `EventEditForm`, `Testimonial*`, `theme-provider`).
+- **`src/contexts/`** : `AuthContext.tsx` (source unique du user), `QueryProvider.tsx`.
+- **`src/services/`** : `apiClient.ts` (axios + intercepteurs), `authService.ts`, `eventService.ts`, `productService.ts`.
+- **`src/hooks/`** : `useAuth.ts`, `useCurrentUser.ts`, `useProductsWithEvents.ts`.
+- **`src/lib/`** : `schemas/auth.ts` (Zod), `query-keys.ts`, `utils.ts`.
+- **`src/types/`** : `auth.ts` `user.ts` `event.ts` `product.ts` (schémas Zod + types, ré-exports).
+- **`src/styles/`** : `globals.css` `landing.css` `animations.css` + **`ds/`** (design tokens Graphite).
 
-- **TypeScript strict** : zero `any`, zero `as` cast non justifie
-- **Server Components** par defaut, `"use client"` uniquement si necessaire
-- `"use client"` inutile sur fichiers type-only (pas de hooks React)
-- **TanStack Query** cote client, `fetch` natif dans Server Components
-- **Forms** : React Hook Form + Zod
-- **Style** : Tailwind CSS + shadcn/ui UNIQUEMENT
+## Conventions
 
-## i18n (règle métier i18n) — langues configurées du projet
+- **Server Components par défaut** ; `'use client'` UNIQUEMENT si hooks/état/handlers (ex. `AuthContext`, `QueryProvider`, `useCurrentUser`). Le root `layout.tsx` reste serveur ; `QueryProvider` isole `QueryClientProvider` côté client.
+- **TypeScript strict** : zéro `any`, zéro `as` non justifié.
+- **État serveur = TanStack Query v5** (forme objet `useQuery({ queryKey, queryFn })`, `gcTime` pas `cacheTime`). Query keys centralisées : `src/lib/query-keys.ts` (factory hiérarchique par domaine, `as const`). NE PAS éparpiller les clés en littéraux → invalidations qui ratent leur cible. `QueryClient` créé via `useState` (une instance/durée de vie, jamais au niveau module en App Router).
+- **Auth = `AuthContext` source UNIQUE du user** (`useAuth()`). **#135 / DEC-S9-002** : PII (email, name) N'EST PLUS en `localStorage`. Session = cookie **JWT HttpOnly** (invisible JS). Restauration au montage par **re-fetch `GET /api/auth/me`** (`withCredentials`), `loading:true` le temps du re-fetch (pas de flash anonyme). `logout` ne purge aucun storage. `useCurrentUser` NE refait PAS d'appel `/me` : sa `queryFn` relit le user d'`AuthContext` (anti double-fetch). **Ne jamais réintroduire de PII persistée** → renvoyer vers DEC-S9-002.
+- **Sécurité logs** : ne JAMAIS logger l'objet axios brut (`error.config.data` = body → password en clair ; `error.config.headers` = Authorization/cookies). Utiliser un extracteur assaini (`safeErrorMessage`) — cf. `AuthContext`, `apiClient`.
+- **Formulaires = RHF + Zod** via `zodResolver`. Deux familles de schémas : « bruts » `*Schema` (service, parse payload, sans message) et factories i18n `create*Schema(t)` (form, messages traduits). Le token/param hors formulaire n'entre pas dans le schéma form (cf. reset-password).
+- **Redirections auth localisées** : construire l'URL avec la locale courante (`/${locale}/login`) — `localePrefix: 'always'` casse tout chemin non préfixé.
 
-- TOUJOURS `useTranslations("namespace")` — jamais de strings FR hardcodees
-- `useTranslations("ns")` separe par namespace (next-intl ne supporte pas `t("key", { ns })`)
-- Zod schemas : factory function `createSchema(messages)` avec `useMemo`
-- Module-level i18n : separer styles statiques + `buildConfig(t)` function
+## Sync Zod ↔ DTO backend (piège récurrent)
 
-## Formatage locale (règle métier locale/devise)
+Les schémas Zod front doivent rester alignés sur les DTO backend (Spring Boot). Désalignement = strip silencieux ou ZodError runtime.
+- `.nullable()` pour un champ nullable backend ; `.optional()` pour un champ absent. JAMAIS `.nullish()` en code manuel.
+- Endpoint paginé : `paginatedSchema(itemSchema)`, jamais `schema.array()` (le body est `{items,total,page,size}`).
+- Contraintes alignées BR-AUT-003 : username 3..20, email valide, password ≥ 6. Le client ne doit PAS surcontraindre le contrat backend (ex. reset ≠ register).
+- DTO connus : login `{username,password}`, register `{name,username,email,password}`, forgot `{email}`, reset `{token,newPassword}`, `/auth/me` → `UserSchema {id(uuid),name,username,email,role}`.
+- ⚠ Il n'existe PAS de règle `.claude/rules-jit/zod-dto-sync.md` à ce jour — appliquer cette checklist directement.
 
-- TOUJOURS `{{LOCALE_CONSTANT}}` de `@/lib/utils` — jamais `"{{LOCALE_CODE}}"` hardcode
-- SSR : utiliser le helper de formatage locale du projet (deterministe) — jamais `Intl.NumberFormat` inline (hydration mismatch)
-- `Intl.DateTimeFormat({{LOCALE_CONSTANT}}, ...)` pour dates
+## i18n (next-intl 4)
 
-## Montants (règle métier devise)
+- `useTranslations("namespace")` — JAMAIS de strings FR hardcodées. Pas de `t("key",{ns})` : un `useTranslations` par namespace.
+- Messages = `public/locales/<locale>/<namespace>.json` (mock/validation data en JSON, pas de FR inline).
+- Zod i18n : factory `create*Schema(t)` (option `useMemo` côté form pour stabilité).
 
-- Tout montant avec code devise ISO 4217
-- Utiliser `currency` du type response, JAMAIS hardcoder la devise du projet
+## Design system « Graphite » (`src/styles/ds/`)
 
-## Accessibilite
+- Direction B validée (S6, source projet Claude Design) : quasi-monochrome, accent bleu électrique unique pour *today/active*, type mono (Archivo display/ui + IBM Plex Mono) via `next/font` self-hosté (variables `--font-display/--font-mono`). Clair + sombre complets.
+- Tokens : `ds/tokens/` (`colors base spacing typography fonts`) + `ds/components/`, `ds/timeline.css`, `ds/i18n.css`, `ds/a11y-audit.md`, `ds/readme.md`.
+- **Theme-aware** : chaque composant doit fonctionner clair ET sombre (`next-themes`). Consulter `ds/readme.md` avant de créer un composant.
+- Éviter les hex inline → passer par les tokens CSS du DS.
 
-- **Spinners** : `role="status"` + `aria-label` + `<span class="sr-only">`
-- **Tables** : `aria-label` sur `<table>`, `scope="col"` sur `<th>`
-- **Barres progression** : `role="progressbar"` + `aria-valuenow/min/max`
-- **Boutons** : `focus:ring-2 focus:ring-accent`
-- **Elements interactifs custom** : `role="button"` + `tabIndex={0}` + `onKeyDown` (Enter/Space) + `focus:ring-2`
+## Accessibilité
 
-## Charts Recharts
+- Spinners : `role="status"` + `aria-label` + `<span class="sr-only">`.
+- Tables : `aria-label`, `scope="col"`. Interactifs custom : `role` + `tabIndex` + `onKeyDown` (Enter/Space) + `focus:ring-2`.
+- Cf. `src/styles/ds/a11y-audit.md`.
 
-- TOUJOURS `useChartTheme()` — JAMAIS de hex inline
-- Importer couleurs depuis `tokens.ts` ou `useChartTheme()`
-- `Number(value)` pour Tooltip formatter
+## Tests (Vitest + RTL) — pièges
 
-## Zod / DTO Synchronisation
+- **`React.use()` N'EXISTE PAS en React 18.3.1** (PIT-S8-005) — ne pas s'appuyer dessus dans code ou tests.
+- **`useSearchParams` exige un `<Suspense>`** englobant (PAT-S8-004).
+- **`next build` en CI attrape des erreurs invisibles aux tests RTL** (types/build strict, `ignoreBuildErrors:false`) — un run vitest vert ne garantit pas le build.
+- Setup `vitest.setup.ts` : jest-dom, cleanup RTL, mocks `next/font/google`, `next/navigation`, `matchMedia`. `useAuth` hors `<AuthProvider>` lève.
+- Objectif : run vitest sans ligne stderr. `act()` warning → test `async` + `await waitFor(...)`. Logs d'erreur intentionnels → `vi.spyOn(console,'error').mockImplementation(()=>{})` + `mockRestore()`.
+- ⚠ `frontend/e2e/` VIDE : `npm run test:e2e` sort 0 sans spec. Aucun parcours E2E couvert — ne pas présumer de garde-fou Playwright.
 
-Voir `.claude/rules-jit/zod-dto-sync.md` (ou Phase 2 : `cp-zod-dto-sync.md`).
-Resume :
-- `.nullable()` pour nullable backend
-- `.optional()` pour absent
-- JAMAIS `.nullish()` en code manuel (accepte dans code genere)
-- Endpoint pagine : TOUJOURS `paginatedSchema(itemSchema)`, jamais `schema.array()`
+## Références
 
-## Design
-
-- Consulter `la charte de design` et `les design tokens`
-- **Theme-aware** : chaque composant fonctionne en clair ET sombre
-- Mock data : format machine-readable, jamais strings FR hardcodees
-- Animations : `duration-300` standard
-
-## Tests — zero warning stderr (MEMO-007)
-
-Tout test livre doit produire un run vitest sans aucune ligne stderr.
-- **MockImage** : exclure `priority`, `fill`, `quality`, `placeholder`, `blurDataURL`, `loader`, `unoptimized` du spread `...rest` vers `<img>`
-- **`act()` warning** : render avec effets async → test `async` + `await waitFor(() => stableCondition)`
-- **Logs d'erreur intentionnels** : `vi.spyOn(console, "error").mockImplementation(() => {})` + `mockRestore()`
-
-## Pitfalls frontend frequents
-
-- `.nullish()` dans schema manuel → ZodError runtime (PIT-174)
-- `validated()` avec schema genere sans overlay nullable → strip silencieusement (PIT-180)
-- `Intl.NumberFormat('{{LOCALE_CODE}}')` inline → hydration mismatch SSR vs client (PIT-185)
-- `validated()` en `select:` sur fallback non-conforme (PIT-186)
-- `schema.array()` au lieu de `paginatedSchema()` → `.filter()` crash sur `{items, total, page, size}`
-
-## Reference pour approfondir
-
-`.claude/rules-jit/frontend.md` (rule versionnee)
-`.claude/rules-jit/zod-dto-sync.md` (checklist DTO/Zod)
-`docs/memory/pitfalls.md` (filtre par PIT-XX frontend)
+- `docs/memory/decisions.md` (DEC-S9-002 : PII hors localStorage), `docs/memory/patterns.md`, `docs/memory/pitfalls.md` (PIT-S8-005, PAT-S8-004).
+- `frontend/src/styles/ds/readme.md` (charte Graphite), `ds/a11y-audit.md`.


### PR DESCRIPTION
## Audit d'exactitude des context-packs (sprints 1-10)

Suite au rafraîchissement post-S10 (#155), audit systématique des packs restants contre le **code réel + l'historique des sprints**. Résultat : **7 packs sur 11 décrivaient un état périmé**. Cette PR les corrige.

Méthode : 3 agents read-only ont confronté chaque pack au code (`fichier:ligne`), puis corrections appliquées et relues.

### `br-auth.md` — ~9 faux positifs corrigés
Le pack marquait « NON IMPLÉMENTÉ » / « VIOLATION CRITIQUE » des choses **résolues depuis S4-S9**. Le plus grave : BR-AUT-008 « `/me` fuit le hash password (CRITIQUE) » → en réalité `UserResponse.fromDomain` (DTO sans password) depuis S9. Un reviewer l'aurait pris pour une faille ouverte. Marqués RÉSOLU : `@Valid` login/register (BR-AUT-003/004, A2), `/me` DTO (BR-AUT-008/A1), unique username (A10), bug name/username (A11), RegisterSchema Zod (A12), `@Transactional` updateUser (A15), PII localStorage retiré (A17, #135). Ajout A18 : `avatar` backend non exposé au front (dette #151). Restent vrais : A13, A14, BR-AUT-012.

### `br-events.md` — modèle pré-#44 corrigé
Le pack décrivait le modèle **3-couleurs** (`backgroundColor`/`borderColor`/`textColor`) alors que le backend est passé à une **colonne `color` unique** (#44/V7, border/text DROP). Corrections : BR-EVE-009 distingue backend RÉSOLU vs frontend non migré (dette #150) ; BR-EVE-006 = enum `RecurrenceUnit` livré (sous-point « obligatoire si isRecurring » toujours ouvert). Ajouts : BR-EVE-012 (`recurrenceEndDate`), BR-EVE-013 (`archived` PATCH-only), BR-EVE-014 (asymétrie DTO create/update), CHECK `ck_events_recurrence_unit`, impact `@SQLRestriction` produits→events.

### `cp-frontend.md` — régénéré Next.js réel
Était un template générique Quarkus-Next périmé (« À RÉGÉNÉRER », placeholders, « Next 16 »). Réécrit sur scan réel : Next `^15.2.4` App Router (`frontend/app/[locale]/`), React 18.3.1, TanStack Query 5, Zod 3, RHF 7, Tailwind 4, next-intl 4 (messages `public/locales/`), shadcn/Radix, DS Graphite (`src/styles/ds/`), AuthContext re-fetch /me (#135), pièges tests (React.use absent 18.3.1, Suspense useSearchParams, next build CI, e2e vide).

### `coverage-{auth,categories,events,products}.md` — réénumérés
Les 4 dataient du 25/06 et affirmaient tous « zéro test backend » — grossièrement faux. Réénumérés depuis les tests réels : **auth 54, categories 42, products 25, events 9** (~130 tests backend, types slice/unit/intégration-Testcontainers distingués), gaps honnêtes (aucun E2E — `frontend/e2e/` vide).

Aucun changement de code applicatif — packs `.ai-env/` uniquement.
