### PR TITLE
:lock: Assainir les logs d'erreur axios dans eventService (fuite credentials)

### DIFF
--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -1,12 +1,13 @@
 import { Event, EventEditFormValues } from "@/types/event";
 import apiClient from "./apiClient";
+import { safeErrorMessage } from "@/lib/safe-error";
 
 export const getEventsByProductId = async (userId: string, productId: string): Promise<Event[]> => {
   try {
     const response = await apiClient.get(`/users/${userId}/products/${productId}/events`);
     return response.data;
   } catch (error) {
-    console.error("Erreur lors de la récupération des événements :", error);
+    console.error("Erreur lors de la récupération des événements :", safeErrorMessage(error));
     throw error;
   }
 };
@@ -25,7 +26,7 @@ export const updateEventColor = async (eventId: string, colors: EventColors): Pr
       throw new Error('Failed to update event colors');
     }
   } catch (error) {
-    console.error('Error updating event colors:', error);
+    console.error('Error updating event colors:', safeErrorMessage(error));
     throw error;
   }
 };
@@ -38,7 +39,7 @@ export const updateEvent = async (eventId: string, data: EventEditFormValues): P
       throw new Error('Failed to update event');
     }
   } catch (error) {
-    console.error('Error updating event:', error);
+    console.error('Error updating event:', safeErrorMessage(error));
     throw error;
   }
 }; 


### PR DESCRIPTION
## Contexte

Dernier service frontend loggant encore l'objet erreur **axios brut** via `console.error(..., error)`. L'objet porte `error.config.headers` (Authorization / cookies) et `error.config.data` (body). Même classe de fuite que **PR #132 / #157**.

Le helper partagé `safeErrorMessage` (`@/lib/safe-error`) et les correctifs `authService`/`productService`/`AuthContext` sont **déjà sur `dev`** (PR #157). Cette PR ne fait qu'ajouter le service manquant.

## Changements

`frontend/src/services/eventService.ts` — 3 catch assainis via `safeErrorMessage(error)` :
- `getEventsByProductId`
- `updateEventColor`
- `updateEvent`

## Vérifications

- `./scripts/test-quiet.sh frontend` → **60/60 vert**.
- Plus aucun `console.error(..., error)` brut dans `frontend/src/services/`.

## Hors périmètre (fuites restantes sur `dev`, non traitées ici)

`dashboard/page.tsx`, `EventContent.tsx`, `AddProducts.tsx` logguent aussi l'objet brut → à traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)