### PR TITLE
:bug: Création Product/Event cassée en base réelle (PIT-S10-003)

### DIFF
--- a/backend/src/main/java/com/matimeline/eventmanager/application/services/EventServiceImpl.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/application/services/EventServiceImpl.java
@@ -43,8 +43,13 @@ public class EventServiceImpl implements EventService {
         
         LocalDate startDate = (eventCreationRequest.getDate() != null) ? eventCreationRequest.getDate() : LocalDate.now();
 
+        // PIT-S10-003 / convention create : id NULL à la création. EventEntity porte
+        // @Version + @GeneratedValue(AUTO) ; un id pré-assigné route persist() vers l'état
+        // « détaché » (Hibernate 6.4 : "detached entity with generated id has an
+        // uninitialized version value null") et casse l'INSERT réel Postgres. @GeneratedValue
+        // attribue l'id, @Version s'initialise (aligné sur CategoryServiceImpl).
         Event event = new Event(
-                UUID.randomUUID(),
+                null,
                 eventCreationRequest.getName(),
                 eventCreationRequest.getType(),
                 eventCreationRequest.getDurationValue(),

--- a/backend/src/main/java/com/matimeline/eventmanager/application/services/ProductServiceImpl.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/application/services/ProductServiceImpl.java
@@ -54,15 +54,26 @@ public class ProductServiceImpl implements ProductService {
         // OU être système (ownerId == null). Sinon -> 404 (anti-énumération).
         Category category = resolveAssignableCategory(request.getCategory(), user.getId());
 
-        Product product = new Product(UUID.randomUUID(), request.getName(), category, user, new ArrayList<>());
+        // PIT-S10-003 / convention create : id NULL à la création. ProductEntity porte
+        // @Version + @GeneratedValue(AUTO) ; un id pré-assigné route persist() vers l'état
+        // « détaché » (Hibernate 6.4 : "detached entity with generated id has an
+        // uninitialized version value null") et casse l'INSERT réel Postgres. En laissant
+        // l'id à null, @GeneratedValue l'attribue et @Version s'initialise (aligné sur
+        // CategoryServiceImpl : new Category(null, ...)).
+        Product product = new Product(null, request.getName(), category, user, new ArrayList<>());
         // #158 : surcharge couleur produit (null = héritage de la catégorie côté front).
         product.setColor(request.getColor());
 
         request.getEvents().forEach(eventCreationRequest -> {
             LocalDate startDate = (eventCreationRequest.getDate() != null) ? eventCreationRequest.getDate() : LocalDate.now();
     
+            // id NULL (idem product) : l'EventEntity imbriquée est persistée en cascade,
+            // @GeneratedValue attribue l'id et @Version l'initialise. Un id pré-assigné
+            // reproduirait la PropertyValueException "detached entity ... uninitialized
+            // version" sur l'insert de l'event. Le lien au produit passe par l'objet parent
+            // (ProductMapper.toEntity), pas par ce productId (null ici, sans effet).
             Event event = new Event(
-                    UUID.randomUUID(),
+                    null,
                     eventCreationRequest.getName(),
                     eventCreationRequest.getType(),
                     eventCreationRequest.getDurationValue(),

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/repositories/jpa/ProductRepositoryJpaImpl.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/repositories/jpa/ProductRepositoryJpaImpl.java
@@ -13,6 +13,7 @@ import com.matimeline.eventmanager.domain.models.Product;
 import com.matimeline.eventmanager.domain.ports.repositories.ProductRepository;
 import com.matimeline.eventmanager.infrastructure.entities.CategoryEntity;
 import com.matimeline.eventmanager.infrastructure.entities.ProductEntity;
+import com.matimeline.eventmanager.infrastructure.entities.UserEntity;
 
 import jakarta.persistence.EntityManager;
 
@@ -71,8 +72,22 @@ public class ProductRepositoryJpaImpl
             }
         }
 
-        // CRÉATION : entité neuve, persist géré par SimpleJpaRepository.
+        // CRÉATION : entité neuve, persist géré par SimpleJpaRepository. Le mapper recopie
+        // les associations category/user en entités DÉTACHÉES (id set, version null) :
+        // persist() les voit comme "detached entity with generated id / uninitialized
+        // version" et échoue (même pitfall PIT-S10-003 que la branche UPDATE côté catégorie).
+        // On rattache donc des références GÉRÉES (getReference) sur les lignes existantes
+        // avant persist. Les events imbriqués (id null, cf. ProductServiceImpl) restent
+        // persistés en cascade sur ce parent.
         ProductEntity entity = productMapper.toEntity(domainProduct);
+        if (domainProduct.getCategory() != null && domainProduct.getCategory().getId() != null) {
+            entity.setCategory(entityManager.getReference(
+                    CategoryEntity.class, domainProduct.getCategory().getId()));
+        }
+        if (domainProduct.getUser() != null && domainProduct.getUser().getId() != null) {
+            entity.setUser(entityManager.getReference(
+                    UserEntity.class, domainProduct.getUser().getId()));
+        }
         ProductEntity savedEntity = super.save(entity);
         return productMapper.toDomain(savedEntity);
     }

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/repositories/ProductEventCreationIntegrationTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/repositories/ProductEventCreationIntegrationTest.java
@@ -1,0 +1,173 @@
+package com.matimeline.eventmanager.infrastructure.adapters.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.matimeline.eventmanager.application.dtos.EventCreationRequest;
+import com.matimeline.eventmanager.application.dtos.ProductCreationRequest;
+import com.matimeline.eventmanager.domain.models.Event;
+import com.matimeline.eventmanager.domain.models.Product;
+import com.matimeline.eventmanager.domain.ports.services.EventService;
+import com.matimeline.eventmanager.domain.ports.services.ProductService;
+import com.matimeline.eventmanager.infrastructure.entities.CategoryEntity;
+import com.matimeline.eventmanager.infrastructure.entities.UserEntity;
+import com.matimeline.eventmanager.support.AbstractPostgresIntegrationTest;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * Couvre le chemin de CRÉATION domaine réel (jamais exercé jusqu'ici) contre un
+ * vrai Postgres jetable (Testcontainers) :
+ *   - {@code ProductServiceImpl.createProduct} -> {@code new Product(UUID.randomUUID(), ...)}
+ *     -> {@code ProductMapper.toEntity} (qui recopie l'id) -> {@code super.save} (persist).
+ *   - {@code EventServiceImpl.createEvent} -> {@code new Event(UUID.randomUUID(), ...)}
+ *     -> {@code EventMapper.toEntity} (setId) -> {@code super.save} (persist).
+ *
+ * ProductEntity/EventEntity portent {@code @Version} + {@code @GeneratedValue(AUTO)}.
+ * Les autres tests d'intégration seed via {@code em.persist(new XEntity())} SANS setId :
+ * ce chemin (save d'une entité neuve avec id pré-assigné) n'était donc pas couvert.
+ *
+ * @Transactional -> rollback après chaque test.
+ */
+@SpringBootTest
+@Transactional
+class ProductEventCreationIntegrationTest extends AbstractPostgresIntegrationTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private EventService eventService;
+
+    private UserEntity persistUser() {
+        UserEntity user = new UserEntity();
+        String suffix = UUID.randomUUID().toString();
+        user.setName("create-user-" + suffix);
+        user.setUsername("create-user-" + suffix);
+        user.setEmail("create-user-" + suffix + "@example.test");
+        user.setPassword("x");
+        user.setRole("ROLE_USER");
+        em.persist(user);
+        return user;
+    }
+
+    /** Catégorie système (owner null) -> assignable à tout produit. */
+    private CategoryEntity persistSystemCategory() {
+        CategoryEntity category = new CategoryEntity();
+        category.setName("create-cat-" + UUID.randomUUID());
+        em.persist(category);
+        return category;
+    }
+
+    /** Création produit SANS event imbriqué : persist d'une ProductEntity neuve à id pré-assigné. */
+    @Test
+    void createProduct_persistsThroughRealPostgres() {
+        UserEntity user = persistUser();
+        CategoryEntity category = persistSystemCategory();
+        em.flush();
+
+        ProductCreationRequest request = new ProductCreationRequest();
+        request.setName("create-product-" + UUID.randomUUID());
+        request.setUserId(user.getId());
+        request.setCategory(category.getId());
+        request.setEvents(new ArrayList<>());
+
+        Product created = productService.createProduct(request);
+
+        assertThat(created).isNotNull();
+        assertThat(created.getId()).isNotNull();
+        em.flush();
+        em.clear();
+
+        assertThat(productService.findDomainProductById(created.getId()))
+                .isPresent()
+                .get()
+                .extracting(Product::getName)
+                .isEqualTo(request.getName());
+    }
+
+    /** Création produit AVEC event imbriqué : persist en cascade (ProductEntity + EventEntity neufs). */
+    @Test
+    void createProduct_withNestedEvent_persistsThroughRealPostgres() {
+        UserEntity user = persistUser();
+        CategoryEntity category = persistSystemCategory();
+        em.flush();
+
+        EventCreationRequest eventReq = new EventCreationRequest();
+        eventReq.setName("nested-event-" + UUID.randomUUID());
+        eventReq.setType("single");
+        eventReq.setDurationValue(1);
+        eventReq.setDurationUnit("days");
+        eventReq.setIsRecurring(false);
+        eventReq.setDate(LocalDate.of(2026, 7, 2));
+        eventReq.setIsAllDay(true);
+
+        ProductCreationRequest request = new ProductCreationRequest();
+        request.setName("create-product-nested-" + UUID.randomUUID());
+        request.setUserId(user.getId());
+        request.setCategory(category.getId());
+        request.setEvents(List.of(eventReq));
+
+        Product created = productService.createProduct(request);
+
+        assertThat(created).isNotNull();
+        assertThat(created.getId()).isNotNull();
+        em.flush();
+        em.clear();
+
+        List<Event> events = eventService.findDomainEventByProductId(created.getId());
+        assertThat(events).hasSize(1);
+        assertThat(events.get(0).getTitle()).isEqualTo(eventReq.getName());
+    }
+
+    /** Création event via EventService : persist d'une EventEntity neuve à id pré-assigné. */
+    @Test
+    void createEvent_persistsThroughRealPostgres() {
+        UserEntity user = persistUser();
+        CategoryEntity category = persistSystemCategory();
+        em.flush();
+
+        ProductCreationRequest productReq = new ProductCreationRequest();
+        productReq.setName("host-product-" + UUID.randomUUID());
+        productReq.setUserId(user.getId());
+        productReq.setCategory(category.getId());
+        productReq.setEvents(new ArrayList<>());
+        Product product = productService.createProduct(productReq);
+        em.flush();
+
+        EventCreationRequest eventReq = new EventCreationRequest();
+        eventReq.setName("standalone-event-" + UUID.randomUUID());
+        eventReq.setType("single");
+        eventReq.setDurationValue(2);
+        eventReq.setDurationUnit("days");
+        eventReq.setIsRecurring(false);
+        eventReq.setDate(LocalDate.of(2026, 7, 2));
+        eventReq.setIsAllDay(false);
+        eventReq.setProductId(product.getId());
+
+        Event created = eventService.createEvent(eventReq);
+
+        assertThat(created).isNotNull();
+        assertThat(created.getId()).isNotNull();
+        em.flush();
+        em.clear();
+
+        assertThat(eventService.findEventById(created.getId()))
+                .isPresent()
+                .get()
+                .extracting(Event::getTitle)
+                .isEqualTo(eventReq.getName());
+    }
+}


### PR DESCRIPTION
## Contexte

Même racine que le fix register récemment mergé sur `dev` (`68b1bc4`), mais **encore latente** côté Product/Event — non traité par ce commit.

`ProductServiceImpl.createProduct` et `EventServiceImpl.createEvent` construisaient l'agrégat via `new X(UUID.randomUUID(), ...)`. Les mappers recopient l'id → `SimpleJpaRepository.save` classe l'entité neuve comme **détachée** (isNew via `version==null`) → `persist()` d'une entité à id assigné + version null. Sous Hibernate 6.4.1 :

```
PropertyValueException: Detached entity with generated id '...' has an uninitialized version value 'null' : ProductEntity.version
```

→ `DataIntegrityViolationException` à l'INSERT Postgres réel. **La création réelle de produit/event était cassée.** Jamais couvert : les `@SpringBootTest` seedaient via `em.persist` **sans** `setId` (chemin `repository.save(new X(random))` jamais exercé).

## Fix (aligné sur CategoryServiceImpl + le fix register de dev)

- **ProductServiceImpl / EventServiceImpl** : `new Product(null, ...)` / `new Event(null, ...)` (produit **et** events imbriqués) → `@GeneratedValue` assigne l'id, `@Version` s'initialise.
- **ProductRepositoryJpaImpl** (branche CREATE) : les associations `category`/`user` reconstruites par le mapper sont **détachées** (même erreur sur l'association) → rattachées via `entityManager.getReference` (parade déjà utilisée en UPDATE / PIT-S10-003).

## Test

Nouveau `ProductEventCreationIntegrationTest` (`@SpringBootTest` + Testcontainers Postgres, extends `AbstractPostgresIntegrationTest`) : `createProduct` (sans/avec event imbriqué) + `createEvent` réels → persistance vérifiée. Échoue avant le fix (repro exacte de l'erreur), passe après.

## Vérification

Suite backend complète : **224/224** via `./scripts/test-quiet.sh backend` (Docker/Testcontainers), sur la base rebasée incluant le fix register de dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)