### PR TITLE
:bug: fix login 500 — secret JWT dev non Base64 + catch silencieux

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,9 @@ POSTGRES_DB=eventmanager
 
 # --- Sécurité JWT ---
 # Clé de signature du token. Valeur ci-dessous = dev INSÉCURISÉE, à régénérer.
-# En prod : chaîne aléatoire forte (>= 64 caractères), jamais commitée.
-JWT_SECRET=dev-only-insecure-secret-change-me-0000000000000000000000000000000000000000000000000000000000000000
+# DOIT être du Base64 STANDARD valide (le backend décode via Decoders.BASE64) et
+# décoder à >= 32 octets (HS256). En prod : générer p.ex. `openssl rand -base64 48`.
+JWT_SECRET=ZGV2LW9ubHktaW5zZWN1cmUtand0LXNlY3JldC1jaGFuZ2UtbWUtcGVyLXBvc3Qh
 
 # --- Frontend (variable PUBLIQUE, bakée au build de l'image frontend) ---
 # Le NAVIGATEUR (hôte) appelle le backend : l'URL doit être joignable depuis

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/AuthController.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/AuthController.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -45,6 +47,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
+
+    // Diagnostic : les catch (Exception e) génériques renvoyaient 500 SANS trace,
+    // rendant tout incident (secret JWT invalide, DB HS...) aveugle. On loggue
+    // désormais la stacktrace. logger.error(msg, e) — jamais la valeur d'un secret.
+    private static final Logger logger = LoggerFactory.getLogger(AuthController.class);
 
     private final AuthenticationManager authenticationManager;
     private final UserService userService;
@@ -128,6 +135,7 @@ public class AuthController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(java.util.Map.of("error", "Invalid username or password"));
         } catch (Exception e) {
+            logger.error("Échec inattendu du login (username={})", authRequest.getUsername(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(java.util.Map.of("error", "authentication_failed"));
         }
@@ -167,6 +175,7 @@ public class AuthController {
         } catch (MalformedJwtException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized: Invalid token");
         } catch (Exception e) {
+            logger.error("Échec inattendu de /me", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An error occurred");
         }
     }
@@ -205,6 +214,7 @@ public class AuthController {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(java.util.Map.of("error", field + " already taken"));
         } catch (Exception e) {
+            logger.error("Échec inattendu de register (username={})", registerRequest.getUsername(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An error occurred during registration");
         }
     }
@@ -222,6 +232,7 @@ public class AuthController {
             response.addCookie(buildJwtCookie("", 0));
             return ResponseEntity.ok("Logged out successfully");
         } catch (Exception e) {
+            logger.error("Échec inattendu du logout", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An error occurred during logout");
         }
     }
@@ -292,6 +303,7 @@ public class AuthController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(java.util.Map.of("error", "token expiré ou invalide"));
         } catch (Exception e) {
+            logger.error("Échec inattendu du refresh", e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(java.util.Map.of("error", "an_error_occurred"));
         }

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/security/JwtService.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/security/JwtService.java
@@ -4,6 +4,8 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 
+import jakarta.annotation.PostConstruct;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -22,6 +24,25 @@ public class JwtService {
 
     @Value("${jwt.secret}")
     private String secretKey;
+
+    /**
+     * Garde-fou de boot (fail-fast) : valide le secret AU DÉMARRAGE plutôt qu'à
+     * chaque requête. Un secret non Base64 (p.ex. contenant '-') ou trop court
+     * (< 32 octets décodés, insuffisant pour HS256) faisait échouer getSigningKey()
+     * à CHAQUE login/refresh -> 500 opaque en boucle. Ici l'app refuse de démarrer
+     * avec un message clair. Le message n'expose JAMAIS la valeur du secret.
+     */
+    @PostConstruct
+    void validateSecret() {
+        try {
+            getSigningKey();
+        } catch (RuntimeException e) {
+            throw new IllegalStateException(
+                    "jwt.secret invalide : attendu du Base64 STANDARD décodant à >= 32 octets "
+                    + "(HS256). Cause : " + e.getClass().getSimpleName() + " — " + e.getMessage(),
+                    e);
+        }
+    }
 
     private SecretKey getSigningKey() {
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -15,7 +15,11 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.datasource.password=${DB_PASSWORD:motdepasse_dev_local}
 # JWT_SECRET : default dev local (NON secret, à régénérer par poste si besoin).
 # En prod, le profil prod impose JWT_SECRET via env sans default.
-jwt.secret=${JWT_SECRET:dev-only-insecure-secret-change-me-0000000000000000000000000000000000000000000000000000000000000000}
+# ATTENTION : la valeur doit être du Base64 STANDARD valide (JwtService décode via
+# Decoders.BASE64). L'ancien default contenait des '-' -> décodage KO -> tout login
+# renvoyait 500. Ce default est du Base64 alphanumérique (48 octets décodés >= 32
+# requis pour HS256). Décode en ASCII "dev-only-insecure-jwt-secret-change-me-per-post!".
+jwt.secret=${JWT_SECRET:ZGV2LW9ubHktaW5zZWN1cmUtand0LXNlY3JldC1jaGFuZ2UtbWUtcGVyLXBvc3Qh}
 
 # Cookie JWT (#99) — dev local : pas de HTTPS, domaine localhost.
 app.cookie.secure=false

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/security/JwtServiceSecretValidationTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/security/JwtServiceSecretValidationTest.java
@@ -1,0 +1,62 @@
+package com.matimeline.eventmanager.infrastructure.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Base64;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Garde-fou de régression pour le bug « secret JWT dev non Base64 » : l'ancien
+ * default {@code dev-only-insecure-secret-change-me-…} contenait des '-', invalides
+ * en Base64 STANDARD, ce qui faisait échouer {@code getSigningKey()} et renvoyait
+ * 500 sur chaque login. Ces tests sont purs (aucun contexte Spring, aucune DB) donc
+ * exécutés en CI systématiquement — la faille précédente passait justement inaperçue
+ * car l'e2e injectait un secret Base64 valide.
+ */
+class JwtServiceSecretValidationTest {
+
+    /** Le default dev réellement committé, à garder synchronisé avec application-dev.properties. */
+    private static final String DEV_DEFAULT_SECRET =
+            "ZGV2LW9ubHktaW5zZWN1cmUtand0LXNlY3JldC1jaGFuZ2UtbWUtcGVyLXBvc3Qh";
+
+    private JwtService newServiceWithSecret(String secret) {
+        JwtService service = new JwtService();
+        ReflectionTestUtils.setField(service, "secretKey", secret);
+        return service;
+    }
+
+    @Test
+    void devDefaultSecret_isValidBase64_atLeast32Bytes() {
+        byte[] decoded = Base64.getDecoder().decode(DEV_DEFAULT_SECRET);
+        assertThat(decoded.length)
+                .as("HS256 exige une clé >= 256 bits (32 octets)")
+                .isGreaterThanOrEqualTo(32);
+    }
+
+    @Test
+    void validateSecret_passes_andTokenRoundTrips_withValidBase64Secret() {
+        JwtService service = newServiceWithSecret(DEV_DEFAULT_SECRET);
+
+        // Boot fail-fast : ne doit PAS lever avec le default dev valide.
+        assertThatCode(service::validateSecret).doesNotThrowAnyException();
+
+        // Et un token émis avec ce secret se relit (ce qui échouait avec l'ancien default).
+        String token = service.generateToken("alice");
+        assertThat(service.extractUsername(token)).isEqualTo("alice");
+    }
+
+    @Test
+    void validateSecret_failsFast_onLegacyDashSecret() {
+        // Reproduit exactement l'ancien default dev cassé (contient des '-').
+        JwtService service = newServiceWithSecret(
+                "dev-only-insecure-secret-change-me-0000000000000000000000000000000000000000000000000000000000000000");
+
+        assertThatThrownBy(service::validateSecret)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Base64");
+    }
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -22,7 +22,10 @@ spring.flyway.locations=classpath:db/migration
 
 # Secret JWT factice (NON secret) : neutralise ${JWT_SECRET} potentiellement
 # absent de l'env CI/local et garde les @SpringBootTest auto-suffisants.
-jwt.secret=test-only-insecure-secret-0000000000000000000000000000000000000000000000000000000000000000
+# DOIT être du Base64 STANDARD valide (JwtService.validateSecret le décode au boot,
+# fail-fast). L'ancienne valeur contenait des '-' -> décodage KO ; elle ne cassait
+# rien tant qu'aucun token n'était signé, mais le garde-fou de boot la rejette.
+jwt.secret=dGVzdC1vbmx5LWluc2VjdXJlLWp3dC1zZWNyZXQtY2hhbmdlLW1lLXBlci1wb3N0IQ==
 
 # Stockage avatar (#75) — répertoire temporaire jetable pour les @SpringBootTest
 # (aucun STORAGE_AVATAR_PATH en env CI). LocalStorageAdapter crée le sous-dossier

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,10 @@ services:
       DB_USERNAME: ${DB_USERNAME:-eventuser}
       DB_PASSWORD: ${DB_PASSWORD:-motdepasse_dev_local}
       # Défaut dev insécurisé si absent du .env (profil dev tolère). À changer.
-      JWT_SECRET: ${JWT_SECRET:-dev-only-insecure-secret-change-me-0000000000000000000000000000000000000000000000000000000000000000}
+      # Base64 STANDARD valide (JwtService décode via Decoders.BASE64) : 48 octets
+      # décodés >= 32 requis pour HS256. L'ancien default à base de '-' cassait le
+      # décodage -> 500 sur tout login. Aligné sur application-dev.properties.
+      JWT_SECRET: ${JWT_SECRET:-ZGV2LW9ubHktaW5zZWN1cmUtand0LXNlY3JldC1jaGFuZ2UtbWUtcGVyLXBvc3Qh}
       # Avatars persistés sur le volume monté ci-dessous.
       STORAGE_AVATAR_PATH: /app/var/avatars
     ports:


### PR DESCRIPTION
## Contexte

Le default dev de `JWT_SECRET` (`dev-only-insecure-secret-change-me-0000…`) contient des `-`, **invalides en Base64 STANDARD**. `JwtService.getSigningKey()` décode via `Decoders.BASE64.decode()` → l'appel lève → **tout `POST /api/auth/login` renvoie 500** en local. Symptôme : `register` = 201 mais `login` = 500. La CI e2e injecte un `JWT_SECRET` Base64 valide, donc **ne voyait pas le bug**. Le `catch (Exception e)` du login avalait l'exception sans la logguer → diagnostic aveugle.

## Corrections

**1. Secret dev Base64 valide** — nouveau défaut `ZGV2LW9ubHktaW5zZWN1cmUt…` (Base64 standard alphanumérique, **48 octets décodés** ≥ 32 requis pour HS256), aligné dans :
- `application-dev.properties`
- `docker-compose.yml`
- `.env.example`

**2. Log des exceptions avalées** — ajout d'un `Logger` dans `AuthController` et `logger.error(…, e)` dans les **5** `catch (Exception e)` génériques (`login`, `me`, `register`, `logout`, `refresh`) qui renvoyaient un 500 muet. Aucun secret exposé dans les messages.

**3. Garde-fou de boot fail-fast** — `@PostConstruct validateSecret()` dans `JwtService` : un secret invalide fait échouer le **démarrage** avec un message clair, au lieu d'un 500 par requête. Cohérent avec le thème « Garde-fous de boot » de sprint 30.

**Effet de bord traité** — `application-test.properties` portait **le même défaut cassé** (`test-only-insecure-secret-0000…`). Sans correction, le garde-fou de boot casserait tout `@SpringBootTest` du profil test → passé en Base64 valide.

## Tests

- **Nouveau** `JwtServiceSecretValidationTest` (pur, sans DB → toujours joué en CI, là où l'e2e ratait le bug) : le défaut dev signe/relit un token ; l'ancien défaut à `-` est bien rejeté par `validateSecret()`.
- `mvn clean compile` ✅ (116 fichiers)
- `JwtServiceSecretValidationTest` ✅ 3/3
- `AuthControllerDevProfileCookieTest` + `RegisterLoginIntegrationTest` ✅ (register 201 + login 200, stack réelle)
- Suite auth/sécurité élargie (`me`, prod cookie, error contract, account deletion, boot logger) ✅ 25/25

**Réserve** : pas de boot HTTP manuel avec Postgres local ; la preuve `register 201 / login 200 / me 200` sans `JWT_SECRET` custom repose sur la composition (test unitaire : le défaut dev signe/relit un token valide ; tests d'intégration : flux HTTP complet via le vrai `JwtService`). Suite backend complète (>500 tests) non exécutée intégralement — seul le périmètre auth/sécurité touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
