### PR TITLE
:bug: apiClient — exclure /auth/me du handler 401 global (fix golden-path E2E)

### DIFF
--- a/docs/audit/e2e-review-2026-07-11.md
+++ b/docs/audit/e2e-review-2026-07-11.md
@@ -98,6 +98,10 @@ Register (pas de token) reste 201. La CI passe un `JWT_SECRET` Base64 valide ; i
 en local. **Ce n'est pas le bug golden-path**, mais ça bloque toute vérif E2E locale — et le défaut
 Base64-invalide + l'exception silencieuse méritent sans doute un correctif séparé.
 
+> ✅ **Résolu sur `dev` par #259** (`da929b6`, « fix login 500 — secret JWT dev non Base64 +
+> catch silencieux »), mergé depuis. Ce doc a été rédigé sur base Sprint 29 (avant #259) ;
+> le piège ci-dessus n'existe plus sur la branche cible. Conservé pour trace mémoire.
+
 ## Points d'outillage relevés (hors correctif)
 
 - **Pas de reporter JSON** → `report.json` et `scripts/digest-e2e-report.sh` attendus par ce skill

--- a/docs/audit/e2e-review-2026-07-11.md
+++ b/docs/audit/e2e-review-2026-07-11.md
@@ -1,0 +1,106 @@
+# Rapport Review E2E — 2026-07-11
+
+## Résumé
+
+> ⚠️ Aucun reporter JSON n'est configuré (`playwright.config.ts` → `list`/`github`), donc
+> **pas de `report.json`** et le script attendu `scripts/digest-e2e-report.sh` **n'existe pas**.
+> Diagnostic établi depuis `test-results/.last-run.json` + l'unique `error-context.md` capturé.
+
+| Indicateur | Valeur |
+|------------|--------|
+| Tests en échec (unexpected) | **1** |
+| Fichiers impactés | 1 (`golden-path.spec.ts`) |
+
+| Diagnostic | Count |
+|------------|-------|
+| TEST_BUG | 0 |
+| **CODE_BUG** | **1 (corrigé)** |
+| BR_DRIFT | 0 |
+| BR_QUESTION | 0 |
+| FRAGILE / Flaky | 0 |
+
+## Diagnostic
+
+### `e2e/golden-path.spec.ts:93` — « parcours complet full-stack » → **CODE_BUG**
+
+**Symptôme** : après un login réussi, `expect(getByTestId('dashboard')).toBeVisible()` échoue ;
+le snapshot montre la page de **login** avec le status « Session expirée, redirection vers la page
+de connexion... ».
+
+**Cause racine (déterministe, pas un problème de délai)** :
+
+Le toast « Session expirée » vient de l'intercepteur **401 global** (`apiClient.ts`) sur un endpoint
+**non-inline**. Le coupable n'est PAS un 401 post-login mais le **timer de redirection résiduel de
+la sonde d'auth initiale** :
+
+1. `page.goto('/fr/register')` = **chargement de page complet** → `AuthProvider` (monté à la
+   RACINE, `app/layout.tsx:52`) appelle `fetchUser()` → `GET /api/auth/me` → **401** (visiteur
+   anonyme, aucun cookie).
+2. `/auth/me` n'étant pas dans `INLINE_AUTH_ENDPOINTS`, l'intercepteur global déclenche :
+   `toast('Session expirée')` + `setTimeout(() => window.location.href = '/fr/login', 1500)`.
+3. register → login → dashboard sont des **navigations SPA** (`router.push`/`router.replace`) :
+   elles **n'annulent PAS** le timer `window`. Le parcours E2E rapide atteint le dashboard
+   (`data-testid="dashboard"` brièvement visible) en **moins de 1500 ms**.
+4. Le timer résiduel se déclenche → **`window.location.href = '/fr/login'`** (navigation dure) →
+   le dashboard est détruit, retour sur /login avec le toast « Session expirée ». → assertion KO,
+   snapshot exactement conforme.
+
+**Pourquoi `auth.setup.ts` (flux login→dashboard identique) passe** : son provisioning est SÉRIEL
+avec retries et attentes (`expect(login-form).toBeVisible({timeout: 8000})`, backoff register), donc
+> 1500 ms s'écoulent avant le login → le timer initial se déclenche sans dommage pendant la phase
+register (rechargement /register→/login toléré). Golden-path est simplement assez rapide pour
+exposer le bug latent.
+
+**Impact hors E2E** : tout visiteur **non connecté** atterrissant sur une page publique
+(landing/login/register) reçoit un toast « Session expirée » injustifié + un rebond vers /login
+après 1,5 s. Bug réel côté produit, pas seulement côté test.
+
+## Correction appliquée
+
+`frontend/src/services/apiClient.ts` — ajout de `/auth/me` à `INLINE_AUTH_ENDPOINTS` :
+un 401 sur la **sonde d'authentification anonyme** est désormais relayé au caller
+(`AuthContext.fetchUser` → `setUser(null)`), **sans** toast ni redirection globale. L'expiration
+RÉELLE d'une session reste couverte par les endpoints de données authentifiés (produits/événements),
+eux non exclus.
+
+- Test de non-régression ajouté : `frontend/src/services/apiClient.test.ts` — « ne toast NI ne
+  redirige sur un 401 de la sonde /auth/me ». **6/6 tests apiClient PASS.**
+
+## Vérification empirique (run réel 2026-07-11)
+
+Stack montée localement : Postgres + backend Spring Boot (Docker) + frontend `next dev`
+(`NEXT_PUBLIC_API_URL=/api`, `E2E_API_PROXY_TARGET=http://localhost:8080`).
+
+**Preuve déterministe du mécanisme ET du correctif** (sonde : visite anonyme de `/fr/register`,
+attente 2,5 s) :
+
+| Version | URL après 2,5 s | « Session expirée » visible |
+|---------|-----------------|-----------------------------|
+| **SANS** le fix | `→ /fr/login` (rebond) | **oui (1)** |
+| **AVEC** le fix | `/fr/register` (stable) | **non (0)** |
+
+- Golden-path (serveur chaud) **PASS 6/6**, confirmé sur plusieurs runs (exit 0).
+- La reproduction est **sensible au timing** : sur un serveur *froid* (compilation de route au 1er
+  hit > 1500 ms) le rebond tombe hors de la fenêtre et golden-path passe même SANS le fix — c'est
+  exactement pourquoi ce test était **flaky** (le run initial de l'utilisateur avait perdu la course,
+  les miens la gagnaient). La sonde ci-dessus lève cette ambiguïté : le bug est réel et le fix le
+  supprime de façon déterministe.
+- Un flake résiduel isolé (1 échec juste après un redémarrage du serveur, non reproduit sur 5 runs
+  suivants) reste possible sous contention ; sans lien avec le mécanisme corrigé.
+
+### Piège d'environnement rencontré (hors sujet, noté pour mémoire)
+
+Booter le backend avec le **secret JWT par défaut** de `application-dev.properties` /
+`docker-compose.yml` (`dev-only-insecure-secret-change-me-0000…`) casse TOUT login : `JwtService`
+fait `Decoders.BASE64.decode(secret)`, or ce défaut contient des `-` (invalides en Base64 standard)
+→ `generateToken` lève → login renvoie **500** (`authentication_failed`, exception avalée sans log).
+Register (pas de token) reste 201. La CI passe un `JWT_SECRET` Base64 valide ; il faut faire pareil
+en local. **Ce n'est pas le bug golden-path**, mais ça bloque toute vérif E2E locale — et le défaut
+Base64-invalide + l'exception silencieuse méritent sans doute un correctif séparé.
+
+## Points d'outillage relevés (hors correctif)
+
+- **Pas de reporter JSON** → `report.json` et `scripts/digest-e2e-report.sh` attendus par ce skill
+  n'existent pas. Ajouter `reporter: [['json', { outputFile: 'test-results/report.json' }], ...]`.
+- **Trace non retenue en local** (`trace: 'on-first-retry'` + `retries: 0`) : aucune trace/HAR sur
+  le 1er échec local. `trace: 'retain-on-failure'` rendrait les diagnostics non-aveugles.

--- a/frontend/src/services/apiClient.test.ts
+++ b/frontend/src/services/apiClient.test.ts
@@ -98,6 +98,39 @@ describe('apiClient response interceptor', () => {
     }
   })
 
+  it("ne toast NI ne redirige sur un 401 de la sonde /auth/me (visiteur anonyme)", async () => {
+    // Régression golden-path E2E 2026-07-11 : AuthProvider sonde /auth/me au montage
+    // (racine app). Pour un visiteur non connecté -> 401 = « pas authentifié » (normal),
+    // géré inline par AuthContext (setUser null). Ce 401 NE DOIT PAS déclencher le toast
+    // « Session expirée » ni le window.location.href=/login différé (qui, encore en vol,
+    // ramenait un utilisateur fraîchement connecté sur /login).
+    const setHref = vi.fn()
+    const originalDescriptor = Object.getOwnPropertyDescriptor(window, 'location')
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        pathname: '/fr/login',
+        set href(value: string) {
+          setHref(value)
+        },
+      },
+    })
+
+    try {
+      const meError = { response: { status: 401 }, config: { url: '/api/auth/me', method: 'get' } }
+      await expect(rejectionHandler!(meError)).rejects.toBeDefined()
+
+      expect(toastErrorMock).not.toHaveBeenCalled()
+      vi.advanceTimersByTime(1500)
+      expect(setHref).not.toHaveBeenCalled()
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(window, 'location', originalDescriptor)
+      }
+      vi.useRealTimers()
+    }
+  })
+
   it('affiche un toast serveur sur 500 sans rediriger', async () => {
     await expect(rejectionHandler!(makeError(500))).rejects.toBeDefined()
     expect(toastErrorMock).toHaveBeenCalledTimes(1)

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -72,12 +72,26 @@ if (typeof window !== 'undefined') {
  * du traitement global (toast + redirect vers /login) — sinon un 401 sur
  * /auth/login déclencherait une redirection vers la page de login elle-même
  * (boucle visuelle) au lieu d'afficher « identifiants invalides » sous le champ.
+ *
+ * `/auth/me` est la SONDE d'authentification anonyme : `AuthProvider` l'appelle au
+ * montage (racine de l'app, cf. app/layout.tsx) pour restaurer la session depuis le
+ * cookie (#135). Pour un visiteur NON connecté (aucun cookie), elle renvoie 401 —
+ * ce n'est PAS une session expirée mais la réponse normale « pas authentifié », déjà
+ * gérée par `AuthContext.fetchUser` (setUser(null)). Sans cette exclusion, ce 401 de
+ * sonde déclenchait le toast « Session expirée » + un `window.location.href=/login`
+ * différé de 1,5 s : sur une page publique (landing/login/register) le visiteur était
+ * rejeté vers /login, et en E2E le timer résiduel, encore en vol après un
+ * register->login->dashboard rapide (navigations SPA qui ne l'annulent pas), ramenait
+ * l'utilisateur fraîchement connecté sur /login (échec golden-path, 2026-07-11).
+ * L'expiration RÉELLE d'une session reste couverte par les endpoints de données
+ * authentifiés (produits/événements/...), eux non exclus.
  */
 const INLINE_AUTH_ENDPOINTS = [
   '/auth/login',
   '/auth/register',
   '/auth/forgot-password',
   '/auth/reset-password',
+  '/auth/me',
 ]
 
 /**


### PR DESCRIPTION
## Contexte
Modifs qui traînaient dans un working tree en detached HEAD (base Sprint 29). Portées proprement sur `dev` (Sprint 33) via cette branche.

## Changements
- **`apiClient.ts`** : ajoute `/auth/me` à `INLINE_AUTH_ENDPOINTS`. La sonde d'auth anonyme (`AuthProvider` au montage, #135) renvoie 401 pour un visiteur non connecté — réponse normale, pas une session expirée. Sans exclusion, ce 401 déclenchait le toast « Session expirée » + redirect `/login` différé 1,5 s, cassant le golden-path E2E `register→login→dashboard` (timer résiduel post-navigation SPA).
- **`apiClient.test.ts`** : tests correspondants.
- **`docs/audit/e2e-review-2026-07-11.md`** : doc d'audit E2E.

## Écarté volontairement
- `.mcp.json` — contenait une **clé API en clair** (rotation Exa à faire).
- `backend/pom.xml.correct` — doublon identique au `pom.xml` de dev.
- `frontend/.ai-env/setup-state.yaml` — state local outil.
- `pr-sprint.md` — version dev (Sprint 33) plus récente conservée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)