### PR TITLE
:wrench: gitignore .mcp.json (clé API) + frontend/.ai-env/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,9 @@ node_modules/
 
 # === Outillage local Claude Code (métriques tokens, worktrees, cache — non projet) ===
 .claude/
+
+# === Config MCP locale (contient des clés API — ne jamais committer) ===
+.mcp.json
+
+# === State local du plugin ai-env (régénérable, non projet) ===
+frontend/.ai-env/


### PR DESCRIPTION
## Quoi
- `.mcp.json` → gitignoré : contient des **clés API MCP** (ne doit jamais être commité).
- `frontend/.ai-env/` → gitignoré : state local régénérable du plugin ai-env, non projet.

## Nettoyage associé (déjà fait en local, hors diff)
- `backend/pom.xml.correct` supprimé (doublon identique au `pom.xml` de dev).

> ⚠️ La clé Exa présente dans `.mcp.json` a transité par un chat LLM → **rotation recommandée** côté dashboard Exa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)