### PR TITLE
:memo: Fix CLAUDE.md — Flyway actif, ddl-auto=validate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 ## État du projet
 
 - Sprint en cours : voir `docs/memory/sprint-history.md` (si créé)
-- Migrations : `backend/src/main/resources/db/migration/` (dossier vide — Hibernate ddl-auto=update actif)
+- Migrations : Flyway actif (source de vérité), `backend/src/main/resources/db/migration/` contient V1..V13 (dernier : `V13__export_jobs.sql`) ; `ddl-auto=validate` (dev + prod). Tout changement de schéma exige une migration V{N} + un mapping entité exact, sinon `SchemaManagementException` au boot. **Prochaine migration : V14.**
 
 ## Stack
 

--- a/docs/memory/sprint-history.md
+++ b/docs/memory/sprint-history.md
@@ -756,3 +756,51 @@
 **Status :** Terminé
 
 > **Plan S29–S33 généré le 2026-07-07** (`/ai-env:sprint plan 5 -c focus MVP`, cohésion moyenne **0.61**, aucun sprint < 0.3). Fil directeur MVP = **shippable en prod** : déploiement (S29) → garde-fous boot (S30) → sécurité exposition (S31) → légal RGPD backend (S32) → conformité EU frontend (S33). Le cœur fonctionnel étant déjà livré (S1–S28), ces 5 sprints n'ajoutent quasiment aucune feature. **Vérif code-state Phase 0.5** : #235 confirmé ouvert (es/de 404), #160 possibly_done (2/4 sites déjà faits). **Backlog HORS MVP explicite :** #88/#102 (monétisation + Redis = ADR post-MVP), #212 (avatar MinIO — LocalStorageAdapter + volume Docker suffisent pour ship), #56/#210 (design-shell MVP-adjacent), #69/#196/#219 (scale), #145/#234/#209/#232 (tests non bloquants), #125/#127/#148 (polish), #215 (à requalifier : test.fixme, vrai bug prod ?). **Ajustements possibles au démarrage :** tirer #235 en S31, sortir #223 en S30, remonter #212 dans S29 (même docker-compose.yml que #37).
+
+## Sprint 34 — 2026-07-12 (PLANIFIE — cohésion 0.55, Supply-chain / CVE platform upgrade)
+**Objectif :** Résorber les CVE plateforme (Boot 3.5.x backend, next-intl/postcss frontend) + garde CI anti-drift BOM.
+**Milestone GitHub :** #34
+**Issues :** #260, #261, #224
+**Vagues :** V1 = #260 (pom) ∥ #261 (package.json) | V2 = #224 (après #260, asserte le BOM post-upgrade)
+**Migrations Flyway :** aucune
+**Dépend de :** aucune (racine)
+**Status :** Planifie
+
+## Sprint 35 — 2026-07-12 (PLANIFIE — cohésion 0.45, Prod boot safety & secrets)
+**Objectif :** Fail-fast au boot prod (COOKIE_DOMAIN/CORS vides, cookie.secure=false) + rotation des secrets exposés.
+**Milestone GitHub :** #35
+**Issues :** #253, #254, #249
+**Vagues :** V1 = #254 (ProfileSafetyGuard) ∥ #249 (ops) | V2 = #253 (même fichier ProfileSafetyGuard que #254)
+**Migrations Flyway :** aucune
+**Dépend de :** aucune (ordonné après S34 par prudence release)
+**Status :** Planifie
+
+## Sprint 36 — 2026-07-12 (PLANIFIE — cohésion 0.72, Export RGPD hardening)
+**Objectif :** Chemin de stockage dédié export + rate-limit GET export + scheduler de purge des exports expirés (index V14).
+**Milestone GitHub :** #36
+**Issues :** #264, #265, #267
+**Vagues :** V1 = #264 (storage) ∥ #265 (rate-limit) | V2 = #267 (purge via port de #264 ; introduit @EnableScheduling)
+**Migrations Flyway :** V14 (idx_export_jobs_expires_at)
+**Dépend de :** aucune (mais introduit le scheduling réutilisé en S37)
+**Status :** Planifie
+
+## Sprint 37 — 2026-07-12 (PLANIFIE — cohésion 0.80, Reset-password hardening)
+**Objectif :** Durcir le flux reset-password : E2E Playwright, rate-limit/lockout par token, verrou anti-TOCTOU (@Version, V15), purge TTL des tokens.
+**Milestone GitHub :** #37
+**Issues :** #145, #141, #143, #139
+**Vagues :** V1 = #145 (e2e) ∥ #141 (rate-limit) ∥ #143 (V15) | V2 = #139 (même service que #143 ; réutilise @EnableScheduling de S36)
+**Migrations Flyway :** V15 (colonne version password_reset_tokens)
+**Dépend de :** S36 (dure — @EnableScheduling bootstrappé par #267, réutilisé par #139)
+**Note :** 4 issues (dépasse règle ≤3) mais 9 pts, #143 = XS — validé tel quel par le dev.
+**Status :** Planifie
+
+## Sprint 38 — 2026-07-12 (PLANIFIE — cohésion 0.78, Auth error contract)
+**Objectif :** Uniformiser le contrat d'erreur JSON auth : AuthController /me,/register,/logout + codes stables GlobalExceptionHandler + durcir writeJsonError.
+**Milestone GitHub :** #38
+**Issues :** #125, #127, #126
+**Vagues :** V1 = #127 (codes stables) ∥ #126 (writeJsonError) | V2 = #125 (route via codes stables de #127)
+**Migrations Flyway :** aucune
+**Dépend de :** aucune (ordonné dernier)
+**Status :** Planifie
+
+> **Plan S34–S38 généré le 2026-07-12** (`/ai-env:sprint plan 5`, cohésion moyenne **0.66**, aucun sprint < 0.3). Fil directeur = **durcissement MVP shippable prod** : supply-chain CVE (S34) → boot-safety/secrets (S35) → export RGPD (S36) → reset-password (S37) → contrat erreur auth (S38). **Vérif code-state Phase 0.5** : aucune issue `possibly_done` — tout vérifié comme travail réel restant (RateLimitingFilter POST-only, pas de @Version reset-token, pas d'index expires_at, pas de @EnableScheduling, pas de spec E2E forgot/reset). **Dépendance dure :** S36→S37 (@EnableScheduling). **Migrations :** S36=V14, S37=V15 (une plage/sprint). **Drift détecté :** CLAUDE.md prétend `db/migration/` vide + `ddl-auto=update` — FAUX (V1..V13 actifs + `ddl-auto=validate`) → correction lancée via chip séparé. **[MEMORY:decision] Flyway = source de vérité** (tout changement schéma = migration + mapping entité). **Backlog hors thème :** features lourdes (#210/#195/#56/#69/#212/#102/#231/#88), a11y events (#226/#227/#228 → S39), hygiène hexagonale (#170/#185/#190/#221/#240/#244 → S40), sprint E2E dédié (#205/#209/#232/#234/#270/#271/#215), i18n (#72/#74/#90/#142/#172).

--- a/docs/memory/sprints/sprint-34/architect-plans.md
+++ b/docs/memory/sprints/sprint-34/architect-plans.md
@@ -1,0 +1,35 @@
+# Mini-plans architect — Sprint 34
+
+> Généré par /sprint plan (architect, 2026-07-12). Lu par /sprint start Phase 4.1
+> pour injection dans HEAD du briefing fullstack-dev (section "## Plan d'implémentation").
+> Thème : Supply-chain / CVE platform upgrade — cohésion 0.55 | Migrations : aucune | Dépend de : aucune (racine)
+
+```yaml
+issue_0260:
+  fichiers_cles: ["backend/pom.xml", "docs/security/cve-acceptance.md", "backend/src/test/java/.../StatelessSessionGuardTest.java"]
+  couches_touchees: ["build","infrastructure"]
+  strategie_test: "integration (Testcontainers full suite verte + trivy 0 HIGH Boot)"
+  risque_regression: "Boot 3.5 déplace le BOM → skew sur overrides (spring-security/tomcat/spring-framework/flyway/jackson) ; ddl-auto=validate impose que Testcontainers rejoue V1..V13 sans dérive."
+  ordre_ecriture: "pom (parent+overrides) → revalider flyway.version (Boot 3.5 bump Flyway) → run Testcontainers → trivy → doc"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "pom parent = 3.4.13 confirmé ; 3 CVE HIGH toujours acceptées dans docs/security/cve-acceptance.md."
+issue_0261:
+  fichiers_cles: ["frontend/package.json", "frontend/package-lock.json"]
+  couches_touchees: ["frontend/build"]
+  strategie_test: "integration (build + suite frontend + non-régression i18n routes localisées)"
+  risque_regression: "bump next-intl peut casser le routing i18n (middleware localisé) ; postcss XSS possiblement sans fix upstream → documenter au lieu de forcer."
+  ordre_ecriture: "bump next-intl → build → vérif routes /es /de /fr + formats → statuer postcss (fix ou veille tracée)"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "next ^15.2.4 + next-intl présents ; CVE MODERATE PROD non résolues."
+issue_0224:
+  fichiers_cles: ["backend/pom.xml", ".github/workflows/ci.yml", "backend/src/test/java/.../BomDriftTest.java (option JUnit)"]
+  couches_touchees: ["build","CI"]
+  strategie_test: "integration (diff mvn dependency:tree versionné OU test assertant versions effectives)"
+  risque_regression: "garde trop strict = faux échec CI à chaque bump légitime ; commenter le POURQUOI des overrides."
+  ordre_ecriture: "après #260 : capturer le BOM post-upgrade → garde reflète ce BOM"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: ".github/workflows/ci.yml existe ; aucun garde anti-drift BOM."
+```

--- a/docs/memory/sprints/sprint-35/architect-plans.md
+++ b/docs/memory/sprints/sprint-35/architect-plans.md
@@ -1,0 +1,34 @@
+# Mini-plans architect — Sprint 35
+
+> Généré par /sprint plan (architect, 2026-07-12). Lu par /sprint start Phase 4.1.
+> Thème : Prod boot safety & secrets — cohésion 0.45 | Migrations : aucune | Dépend de : aucune (ordonné après S34 par prudence release)
+
+```yaml
+issue_0253:
+  fichiers_cles: ["backend/.../infrastructure/config/ProdConfigStartupLogger.java", "backend/.../infrastructure/config/ProfileSafetyGuard.java", "backend/src/main/resources/application-prod.properties"]
+  couches_touchees: ["infrastructure"]
+  strategie_test: "integration (test boot : prod effective + var vide → échec explicite)"
+  risque_regression: "détection d'env prod erronée (ENVIRONMENT/APP_ENV) peut bloquer un déploiement légitime ; réutiliser la logique existante de ProfileSafetyGuard."
+  ordre_ecriture: "transformer WARN→exception dans le garde → message clair par variable → test boot bloquant"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "ProdConfigStartupLogger émet WARN seulement ; pas de fail-fast."
+issue_0254:
+  fichiers_cles: ["backend/.../infrastructure/config/ProfileSafetyGuard.java", "backend/src/main/resources/application-prod.properties"]
+  couches_touchees: ["infrastructure"]
+  strategie_test: "integration (test boot : prod effective + app.cookie.secure=false → échec)"
+  risque_regression: "même risque de détection d'env que #216/#111 ; cohérence avec le pattern ProfileSafetyGuard existant."
+  ordre_ecriture: "étendre ProfileSafetyGuard (pattern #216) → message Secure obligatoire → test boot"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "ProfileSafetyGuard existe (rate-limit #216) ; aucun garde sur app.cookie.secure."
+issue_0249:
+  fichiers_cles: [".env.production / secrets manager provider (OPS, hors repo)", "backend/.../infrastructure/security/JwtService.java (vérif post-rotation)"]
+  couches_touchees: ["ops"]
+  strategie_test: "manuel (login, envoi email, connexion DB testés post-rotation)"
+  risque_regression: "rotation JWT_SECRET = déconnexion globale de tous les utilisateurs actifs → fenêtre faible usage + comm préalable ; ne JAMAIS coller une valeur de secret."
+  ordre_ecriture: "générer nouvelles valeurs DB_PASSWORD/JWT_SECRET → vérifier BREVO_API_KEY dans l'historique → redéployer tous envs → tests fonctionnels"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "action ops distincte de la purge d'historique (#112) ; à coordonner avec inventaire #250."
+```

--- a/docs/memory/sprints/sprint-36/architect-plans.md
+++ b/docs/memory/sprints/sprint-36/architect-plans.md
@@ -1,0 +1,34 @@
+# Mini-plans architect — Sprint 36
+
+> Généré par /sprint plan (architect, 2026-07-12). Lu par /sprint start Phase 4.1.
+> Thème : Export RGPD hardening — cohésion 0.72 | Migrations : V14 (idx_export_jobs_expires_at) | Dépend de : aucune (mais introduit le scheduling réutilisé en S37 → S36 AVANT S37)
+
+```yaml
+issue_0264:
+  fichiers_cles: ["backend/.../infrastructure/adapters/LocalStorageAdapter.java", "backend/.../domain/ports/...StoragePort", "backend/.../application/services/ExportServiceImpl.java", "backend/.../AsyncExportRunner", "backend/src/main/resources/application-dev.properties", "application-prod.properties"]
+  couches_touchees: ["application","infrastructure"]
+  strategie_test: "integration (export écrit dans le nouveau base-path ; fail-fast si export-path absent en prod)"
+  risque_regression: "clé app.storage.export-path SANS default prod (convention #34) = fail-fast ; ne pas hériter des hypothèses avatar (taille max, rétention)."
+  ordre_ecriture: "clé config → port/qualifier export dédié (ou base-path paramétré) → cibler ExportServiceImpl/AsyncExportRunner → test"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "export écrit via app.storage.avatar-path (couplage avatar) confirmé ; pas de clé dédiée."
+issue_0265:
+  fichiers_cles: ["backend/.../infrastructure/security/RateLimitingFilter.java", "backend/.../infrastructure/security/RateLimitConfig.java"]
+  couches_touchees: ["infrastructure"]
+  strategie_test: "integration (GET /api/export synchrone throttlé ; polling /job + download non pénalisés)"
+  risque_regression: "throttle trop agressif casserait le polling /job légitime ou le re-download COMPLETED ; ne cibler que le GET synchrone coûteux."
+  ordre_ecriture: "ajouter GET /api/export au PATH_LIMITS (aujourd'hui POST-only) → test ; sinon tracer décision hors-scope + commentaire"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "RateLimitingFilter throttle POST uniquement (l.31-32) ; GET export non couvert."
+issue_0267:
+  fichiers_cles: ["backend/src/main/resources/db/migration/V14__idx_export_jobs_expires_at.sql", "backend/.../infrastructure/config/SchedulingConfig.java (nouveau, @EnableScheduling)", "backend/.../application/services/ExportPurgeScheduler.java", "backend/.../domain/ports/repositories/ExportJobRepository.java", "backend/.../infrastructure/adapters/repositories/jpa/ExportJobRepositoryJpaImpl.java"]
+  couches_touchees: ["domain","application","infrastructure"]
+  strategie_test: "integration (Testcontainers : job expiré → StoragePort.delete + ligne purgée ; idempotence fichier absent)"
+  risque_regression: "ddl-auto=validate : V14 doit matcher exactement ; scheduler ne doit pas purger un COMPLETED non expiré ; log sans PII."
+  ordre_ecriture: "V14 → port findExpired/delete → adapter JPA → SchedulingConfig @EnableScheduling → scheduler @Scheduled (StoragePort.delete puis delete ligne) → test"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "V13 a idx_export_jobs_user mais PAS idx_export_jobs_expires_at ; aucun @EnableScheduling → ce sprint bootstrappe le scheduling."
+```

--- a/docs/memory/sprints/sprint-37/architect-plans.md
+++ b/docs/memory/sprints/sprint-37/architect-plans.md
@@ -1,0 +1,46 @@
+# Mini-plans architect — Sprint 37
+
+> Généré par /sprint plan (architect, 2026-07-12). Lu par /sprint start Phase 4.1.
+> Thème : Reset-password hardening — cohésion 0.80 | Migrations : V15 (colonne version password_reset_tokens) | Dépend de : S36 (soft — @EnableScheduling bootstrappé par #267, réutilisé par #139)
+
+```yaml
+issue_0145:
+  fichiers_cles: ["frontend/e2e/forgot-password.spec.ts (nouveau)", "frontend/e2e/support/*", "frontend/e2e/global-setup.ts"]
+  couches_touchees: ["frontend/e2e"]
+  strategie_test: "E2E (forgot → lien tokenisé → reset → login, sur les 27 data-testid #53 déjà posés)"
+  risque_regression: "PREMIER E2E cross-system : nécessite interception email (BrevoEmailService) — mock/MailHog ou endpoint test-only exposant le token ; peut révéler une lacune de l'env E2E."
+  ordre_ecriture: "définir le canal de capture du token → spec Playwright → intégrer la suite"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "frontend/e2e/ existe (auth.setup, golden-path...) mais AUCUN spec forgot/reset ; flux backend #138 déjà mergé."
+issue_0141:
+  fichiers_cles: ["backend/.../infrastructure/security/RateLimitingFilter.java", "backend/.../adapters/controllers/AuthController.java (endpoint reset-password)"]
+  couches_touchees: ["infrastructure"]
+  strategie_test: "integration (N échecs sur un token → tentatives suivantes bloquées/ralenties)"
+  risque_regression: "message d'erreur doit rester générique (pas d'info exploitable) ; ne pas throttler les demandes légitimes."
+  ordre_ecriture: "étendre RateLimitingFilter (POST-only) au cas per-token → test échecs répétés"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "RateLimitingFilter limite forgot-password par IP ; aucune limite sur les tentatives de validation d'un token."
+issue_0143:
+  fichiers_cles: ["backend/.../PasswordResetTokenEntity.java", "backend/src/main/resources/db/migration/V15__password_reset_tokens_version.sql", "backend/.../PasswordResetServiceImpl.java"]
+  couches_touchees: ["domain","infrastructure"]
+  strategie_test: "integration (2 requêtes concurrentes de consommation → une seule réussit via OptimisticLockException)"
+  risque_regression: "ddl-auto=validate impose la migration V15 exacte ; gérer OptimisticLockException dans consume."
+  ordre_ecriture: "V15 ADD COLUMN version → @Version entité → catch OptimisticLock dans consume → test concurrence"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "V6/entité sans version confirmé ; commentaire 'versionné requis' présent mais champ absent."
+issue_0139:
+  fichiers_cles: ["backend/.../application/services/PasswordResetServiceImpl.java (ou scheduler dédié)", "backend/.../infrastructure/adapters/repositories/jpa/PasswordResetTokenRepositoryJpaImpl.java", "réutilise SchedulingConfig (S36)"]
+  couches_touchees: ["application","infrastructure"]
+  strategie_test: "integration (job supprime used_at IS NOT NULL OR expires_at < now()-interval ; ne touche pas un token valide)"
+  risque_regression: "borner la fenêtre de rétention pour ne pas supprimer un token encore valide en cours d'usage ; PAS de migration (DELETE simple)."
+  ordre_ecriture: "requête cleanup au repo → @Scheduled réutilisant @EnableScheduling de S36 → test bornes"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "aucun @Scheduled dans le repo ; table password_reset_tokens jamais purgée (sauf suppression compte)."
+```
+
+> Vagues : V1 = #145 ∥ #141 ∥ #143 (V15) | V2 = #139 (même service que #143 ; réutilise @EnableScheduling de S36).
+> Note capacité : 4 issues (dépasse règle ≤3) mais 9 pts, #143 = XS. Validé tel quel par le dev (2026-07-12).

--- a/docs/memory/sprints/sprint-38/architect-plans.md
+++ b/docs/memory/sprints/sprint-38/architect-plans.md
@@ -1,0 +1,37 @@
+# Mini-plans architect — Sprint 38
+
+> Généré par /sprint plan (architect, 2026-07-12). Lu par /sprint start Phase 4.1.
+> Thème : Auth error contract — cohésion 0.78 | Migrations : aucune | Dépend de : aucune (ordonné dernier)
+
+```yaml
+issue_0125:
+  fichiers_cles: ["backend/.../adapters/controllers/AuthController.java", "backend/.../adapters/controllers/GlobalExceptionHandler.java"]
+  couches_touchees: ["infrastructure"]
+  strategie_test: "integration (Content-Type: application/json + structure {error:...} sur /me, /register, /logout)"
+  risque_regression: "le frontend peut parser en dur des chaînes texte (ex. 'User already exists') → auditer frontend/src/lib avant merge."
+  ordre_ecriture: "après #127 : router les erreurs Auth via codes stables → remplacer ResponseEntity.body(texte) par Map.of(error,...) → tests"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "AuthController renvoie encore du texte brut sur /me,/register,/logout ; /login déjà JSON (#116)."
+issue_0127:
+  fichiers_cles: ["backend/.../adapters/controllers/GlobalExceptionHandler.java"]
+  couches_touchees: ["infrastructure"]
+  strategie_test: "integration (codes snake_case stables not_found/validation_failed dans body)"
+  risque_regression: "assertions tests existantes sur reasonPhrase à mettre à jour."
+  ordre_ecriture: "enum ErrorCode → buildBody utilise code stable au lieu de getReasonPhrase() → maj tests"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "handler status-based confirmé (22 statuts, reason-phrase utilisé)."
+issue_0126:
+  fichiers_cles: ["backend/.../infrastructure/security/SecurityConfig.java"]
+  couches_touchees: ["infrastructure"]
+  strategie_test: "integration (writeJsonError avec caractères ' et backslash produit un JSON valide)"
+  risque_regression: "défensif, réversible ; remplacer concat manuelle par Jackson/Map.of."
+  ordre_ecriture: "writeJsonError → Map.of(error,error) via ObjectMapper → test échappement"
+  zod_dto_sync: "NON"
+  possibly_done: false
+  etat_reel_du_code: "concat JSON manuelle confirmée dans writeJsonError."
+```
+
+> Vagues : V1 = #127 ∥ #126 | V2 = #125 (route via codes stables de #127).
+> Sous-capacité 4 pts assumée (reliquat P2/P3). Option non retenue : ajouter #134.


### PR DESCRIPTION
## Contexte

La section « État du projet » de `CLAUDE.md` affirmait à tort :
> Migrations : `backend/src/main/resources/db/migration/` (dossier vide — Hibernate ddl-auto=update actif)

## Réalité vérifiée

- `db/migration/` contient **V1..V13** (dernier : `V13__export_jobs.sql`)
- `application.properties` : `spring.flyway.enabled=true`, `locations=classpath:db/migration`
- `application-dev.properties` **et** `application-prod.properties` : `spring.jpa.hibernate.ddl-auto=validate` (pas `update`)

## Impact

Flyway est la source de vérité. Tout changement de schéma exige une migration `V{N}` + un mapping entité exact, sinon `SchemaManagementException` au boot. La doc induisait un agent en erreur (risque de modifier une entité sans migration). Prochaine migration = **V14**.

Correction de doc uniquement — 1 ligne, aucun impact runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)