### PR TITLE
Sprint 36 — Export RGPD hardening (stockage dédié, rate-limit GET, purge TTL)

### DIFF
--- a/backend/src/main/java/com/matimeline/eventmanager/application/services/AsyncExportRunner.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/application/services/AsyncExportRunner.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,7 +43,7 @@ public class AsyncExportRunner {
     public AsyncExportRunner(ExportJobRepository jobRepository,
                              UserDataExportAssembler assembler,
                              ExportRendererRegistry rendererRegistry,
-                             StoragePort storagePort,
+                             @Qualifier("exportStorage") StoragePort storagePort,
                              Clock clock) {
         this.jobRepository = jobRepository;
         this.assembler = assembler;

--- a/backend/src/main/java/com/matimeline/eventmanager/application/services/AvatarServiceImpl.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/application/services/AvatarServiceImpl.java
@@ -2,6 +2,7 @@ package com.matimeline.eventmanager.application.services;
 
 import java.util.Optional;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,7 +39,7 @@ public class AvatarServiceImpl implements AvatarService {
     private final UserRepository userRepository;
     private final long maxBytes;
 
-    public AvatarServiceImpl(StoragePort storagePort,
+    public AvatarServiceImpl(@Qualifier("avatarStorage") StoragePort storagePort,
                              UserRepository userRepository,
                              @Value("${app.storage.avatar-max-bytes:5242880}") long maxBytes) {
         this.storagePort = storagePort;

--- a/backend/src/main/java/com/matimeline/eventmanager/application/services/ExportPurgeScheduler.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/application/services/ExportPurgeScheduler.java
@@ -1,0 +1,85 @@
+package com.matimeline.eventmanager.application.services;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.matimeline.eventmanager.domain.models.export.ExportJob;
+import com.matimeline.eventmanager.domain.ports.repositories.ExportJobRepository;
+import com.matimeline.eventmanager.domain.ports.services.StoragePort;
+
+/**
+ * Purge périodique des exports RGPD expirés (issue #267, dette ADR-003 §3).
+ *
+ * <p>Les exports asynchrones (#58) déposent un fichier sur disque assorti d'une URL valable 24h
+ * ({@code ExportJob.expiresAt}). Sans purge, fichiers et lignes {@code export_jobs} s'accumulent
+ * indéfiniment (coût disque + rétention de données perso au-delà de leur utilité = mauvais RGPD).
+ * Ce scheduler balaye les jobs expirés et, pour chacun, supprime d'ABORD le fichier
+ * (via {@link StoragePort#delete}, idempotent) PUIS la ligne : si l'ordre était inversé et le
+ * process crashait entre les deux, le fichier deviendrait orphelin sans trace en base.
+ *
+ * <p>Couche APPLICATION : ne dépend que des ports du domaine ({@link ExportJobRepository},
+ * {@link StoragePort} qualifié {@code exportStorage}) et de l'horloge injectable ({@link Clock}).
+ * Aucun accès à l'impl JPA ni à {@code LocalStorageAdapter}.
+ *
+ * <p>Robustesse : un échec sur un job (I/O, DB) est isolé (try/catch par job) et n'empêche pas
+ * le traitement des suivants — le job échoué sera retenté au tick suivant. Log SANS PII :
+ * on ne journalise qu'un COMPTE, jamais email/user_id/storage_ref/jobId.
+ */
+@Component
+public class ExportPurgeScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(ExportPurgeScheduler.class);
+
+    private final ExportJobRepository exportJobRepository;
+    private final StoragePort exportStorage;
+    private final Clock clock;
+
+    public ExportPurgeScheduler(ExportJobRepository exportJobRepository,
+                                @Qualifier("exportStorage") StoragePort exportStorage,
+                                Clock clock) {
+        this.exportJobRepository = exportJobRepository;
+        this.exportStorage = exportStorage;
+        this.clock = clock;
+    }
+
+    /**
+     * Balaye et purge les jobs expirés. Fréquence CONFIGURABLE
+     * ({@code app.export.purge.interval-ms}, défaut 1h) ; premier passage différé
+     * ({@code app.export.purge.initial-delay-ms}, défaut 5 min) pour ne pas balayer au boot.
+     * Directement invocable (tests) sans attendre le tick.
+     */
+    @Scheduled(fixedDelayString = "${app.export.purge.interval-ms:3600000}",
+            initialDelayString = "${app.export.purge.initial-delay-ms:300000}")
+    @Transactional
+    public void purgeExpired() {
+        LocalDateTime now = LocalDateTime.now(clock);
+        List<ExportJob> expired = exportJobRepository.findExpired(now);
+        int purged = 0;
+        for (ExportJob job : expired) {
+            try {
+                String storageRef = job.getStorageRef();
+                if (storageRef != null) {
+                    // Fichier d'abord (idempotent : réf absente = no-op), ligne ensuite.
+                    exportStorage.delete(storageRef);
+                }
+                exportJobRepository.deleteById(job.getId());
+                purged++;
+            } catch (RuntimeException ex) {
+                // Log SANS PII (type d'exception uniquement) ; le job sera retenté au prochain tick.
+                log.warn("Skipping one expired export job during purge ({}), will retry next run",
+                        ex.getClass().getSimpleName());
+            }
+        }
+        if (purged > 0) {
+            log.info("Purged {} expired export job(s)", purged);
+        }
+    }
+}

--- a/backend/src/main/java/com/matimeline/eventmanager/application/services/ExportServiceImpl.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/application/services/ExportServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,7 +51,7 @@ public class ExportServiceImpl implements ExportService {
                              ExportRendererRegistry rendererRegistry,
                              ExportJobRepository jobRepository,
                              AsyncExportRunner asyncRunner,
-                             StoragePort storagePort,
+                             @Qualifier("exportStorage") StoragePort storagePort,
                              Clock clock) {
         this.assembler = assembler;
         this.rendererRegistry = rendererRegistry;

--- a/backend/src/main/java/com/matimeline/eventmanager/domain/ports/repositories/ExportJobRepository.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/domain/ports/repositories/ExportJobRepository.java
@@ -1,5 +1,7 @@
 package com.matimeline.eventmanager.domain.ports.repositories;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -25,4 +27,15 @@ public interface ExportJobRepository {
      * traduit en 404, anti-énumération — cf. convention 2 backend).
      */
     Optional<ExportJob> findByIdAndOwnerId(UUID id, UUID ownerId);
+
+    /**
+     * Jobs EXPIRÉS à purger (#267) : {@code expires_at IS NOT NULL AND expires_at < now}.
+     * {@code expires_at} n'est renseigné qu'à la complétion (COMPLETED) — un job PENDING/RUNNING
+     * ou COMPLETED non expiré ne remonte JAMAIS. Sert le scheduler de purge TTL 24h ; l'index
+     * {@code idx_export_jobs_expires_at} (V14) évite le seq scan.
+     */
+    List<ExportJob> findExpired(LocalDateTime now);
+
+    /** Supprime la ligne d'un job (#267), après suppression du fichier via {@code StoragePort}. */
+    void deleteById(UUID id);
 }

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/LocalStorageAdapter.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/LocalStorageAdapter.java
@@ -7,15 +7,16 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 import com.matimeline.eventmanager.domain.ports.services.StoragePort;
 
 /**
  * Adapter de stockage LOCAL PRIVÉ (#75, DÉCISION STOCKAGE ADR Sprint 21). Écrit les
- * blobs dans un répertoire HORS webroot, chemin configurable {@code app.storage.avatar-path}
- * (convention #34 : default dev seulement, aucun default en prod = fail-fast).
+ * blobs dans un répertoire HORS webroot, dont le chemin de base est PARAMÉTRÉ PAR USAGE
+ * (constructeur {@code basePath}). Une instance sert les avatars (bean {@code avatarStorage},
+ * {@code app.storage.avatar-path}), une autre les exports RGPD (bean {@code exportStorage},
+ * {@code app.storage.export-path}, #264) — répertoires DISTINCTS, aucune hypothèse partagée
+ * (rétention, taille max, backup). Les beans sont déclarés par {@code StorageConfig} ; chaque
+ * clé suit la convention #34 (default dev seulement, aucun default en prod = fail-fast).
  *
  * <p>Un swap futur vers S3/MinIO = nouvelle impl de {@link StoragePort}, sans toucher au
  * service ni au contrôleur. Aucun SDK vendor n'est câblé ici.
@@ -25,12 +26,16 @@ import com.matimeline.eventmanager.domain.ports.services.StoragePort;
  * séparateur de chemin est rejetée et le chemin résolu doit rester sous le répertoire de
  * base (défense en profondeur, même si la référence vient de notre propre base).
  */
-@Component
 public class LocalStorageAdapter implements StoragePort {
 
     private final Path baseDir;
 
-    public LocalStorageAdapter(@Value("${app.storage.avatar-path}") String basePath) {
+    /**
+     * @param basePath répertoire de base LOCAL PRIVÉ (hors webroot) où sont écrits les blobs
+     *                 de CET usage ; injecté par {@code StorageConfig} depuis la clé de config
+     *                 propre à l'usage (avatar-path OU export-path).
+     */
+    public LocalStorageAdapter(String basePath) {
         this.baseDir = Path.of(basePath).toAbsolutePath().normalize();
     }
 
@@ -46,7 +51,7 @@ public class LocalStorageAdapter implements StoragePort {
         } catch (IOException e) {
             // Ne PAS fuiter le chemin/stack au client (A4) : le controller/handler renvoie
             // un message générique. On enveloppe pour propager l'échec technique (500).
-            throw new UncheckedIOException("stockage avatar indisponible", e);
+            throw new UncheckedIOException("stockage indisponible", e);
         }
         return reference;
     }
@@ -60,7 +65,7 @@ public class LocalStorageAdapter implements StoragePort {
         try {
             return Optional.of(Files.readAllBytes(target));
         } catch (IOException e) {
-            throw new UncheckedIOException("lecture avatar impossible", e);
+            throw new UncheckedIOException("lecture impossible", e);
         }
     }
 
@@ -69,7 +74,7 @@ public class LocalStorageAdapter implements StoragePort {
         try {
             Files.deleteIfExists(resolveWithinBase(reference)); // idempotent
         } catch (IOException e) {
-            throw new UncheckedIOException("suppression avatar impossible", e);
+            throw new UncheckedIOException("suppression impossible", e);
         }
     }
 

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/repositories/jpa/ExportJobRepositoryJpaImpl.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/repositories/jpa/ExportJobRepositoryJpaImpl.java
@@ -1,5 +1,7 @@
 package com.matimeline.eventmanager.infrastructure.adapters.repositories.jpa;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -77,4 +79,24 @@ public class ExportJobRepositoryJpaImpl
                 .findFirst()
                 .map(mapper::toDomain);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ExportJob> findExpired(LocalDateTime now) {
+        // Balayage de purge (#267) : seuls les jobs AVEC un expires_at dépassé remontent.
+        // expires_at IS NOT NULL exclut PENDING/RUNNING ; < :now exclut les COMPLETED non expirés.
+        // Sert par l'index idx_export_jobs_expires_at (V14).
+        return entityManager.createQuery(
+                        "SELECT j FROM ExportJobEntity j "
+                                + "WHERE j.expiresAt IS NOT NULL AND j.expiresAt < :now",
+                        ExportJobEntity.class)
+                .setParameter("now", now)
+                .getResultList()
+                .stream()
+                .map(mapper::toDomain)
+                .toList();
+    }
+
+    // deleteById(UUID) : hérité de SimpleJpaRepository (findById().ifPresent(delete) -> idempotent,
+    // no-op si la ligne est déjà absente). Satisfait le port ExportJobRepository#deleteById.
 }

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/config/SchedulingConfig.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/config/SchedulingConfig.java
@@ -1,0 +1,20 @@
+package com.matimeline.eventmanager.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Active le support Spring {@code @Scheduled} pour l'application (issue #267 — 1er usage).
+ *
+ * <p>Vit côté INFRASTRUCTURE : {@code @EnableScheduling} est un stéréotype d'assemblage
+ * (comme {@code @EnableAsync}) au même titre que {@link AsyncConfig}, hors couche métier.
+ * Les tâches planifiées elles-mêmes ({@code ExportPurgeScheduler}) restent dans
+ * {@code application/services/} et ne dépendent que des ports du domaine.
+ *
+ * <p>Un unique scheduler mono-thread suffit (purge horaire, tâche brève) : on ne surcharge
+ * pas le {@code TaskScheduler} par défaut. Réutilisable par de futures tâches de fond.
+ */
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/config/StorageConfig.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/config/StorageConfig.java
@@ -1,0 +1,47 @@
+package com.matimeline.eventmanager.infrastructure.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.matimeline.eventmanager.domain.ports.services.StoragePort;
+import com.matimeline.eventmanager.infrastructure.adapters.LocalStorageAdapter;
+
+/**
+ * Câble les beans de stockage LOCAL PRIVÉ, un PAR USAGE, chacun sur un répertoire DISTINCT
+ * (#264). Découple sémantiquement les exports RGPD des avatars : plus de partage de
+ * répertoire ni d'hypothèses (rétention, taille max, backup) héritées de l'avatar.
+ *
+ * <ul>
+ *   <li>{@code avatarStorage} -> {@code app.storage.avatar-path} (#75) : avatars utilisateurs.</li>
+ *   <li>{@code exportStorage} -> {@code app.storage.export-path} (#264, ADR-003 §5) : dumps
+ *       d'export RGPD (ZIP/CSV), TTL 24h. Point d'accès dédié réutilisé par la purge (#267).</li>
+ * </ul>
+ *
+ * <p>Chaque clé suit la convention #34 (fail-fast) : aucun default en prod -> le boot échoue
+ * si {@code STORAGE_EXPORT_PATH} est absent. Les deux beans partagent la MÊME impl
+ * ({@link LocalStorageAdapter}, paramétrée par base-path) ; un swap S3/MinIO d'un seul usage
+ * = nouvelle impl derrière le bean concerné, sans toucher l'autre.
+ *
+ * <p>Deux beans du type {@link StoragePort} coexistent : chaque point d'injection DOIT être
+ * désambiguïsé par {@code @Qualifier("avatarStorage")} ou {@code @Qualifier("exportStorage")}.
+ */
+@Configuration
+public class StorageConfig {
+
+    /** Stockage des avatars utilisateurs (#75). Injecter via {@code @Qualifier("avatarStorage")}. */
+    @Bean
+    StoragePort avatarStorage(@Value("${app.storage.avatar-path}") String avatarPath) {
+        return new LocalStorageAdapter(avatarPath);
+    }
+
+    /**
+     * Stockage DÉDIÉ des exports RGPD (#264, ADR-003 §5). Injecter via
+     * {@code @Qualifier("exportStorage")}. Répertoire distinct des avatars : la purge TTL 24h
+     * (#267) opère sur CE base-path via {@code StoragePort.delete(storageRef)}.
+     */
+    @Bean
+    StoragePort exportStorage(@Value("${app.storage.export-path}") String exportPath) {
+        return new LocalStorageAdapter(exportPath);
+    }
+}

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/security/RateLimitingFilter.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/security/RateLimitingFilter.java
@@ -9,7 +9,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -25,17 +24,35 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
- * In-memory, per-IP rate limiting for the sensitive auth POST endpoints
- * (brute-force / credential-stuffing mitigation — issue #33, BR-AUT-002 family).
+ * In-memory, per-IP rate limiting for the sensitive / resource-heavy endpoints
+ * (brute-force / credential-stuffing mitigation — issue #33, BR-AUT-002 family ;
+ * resource-exhaustion mitigation for the RGPD export — issues #58, #265).
  *
- * <p>Only the POST endpoints listed in {@link #PATH_LIMITS} are throttled; every
- * other request (including {@code GET /api/auth/me}, {@code POST /api/auth/logout},
- * and the whole rest of the API) passes through untouched. On overflow the filter
- * short-circuits with HTTP 429 and a minimal JSON body — no stack trace, no
- * internal detail.
+ * <p>Only the {@code (method, exact-path)} pairs listed in {@link #LIMITS} are
+ * throttled; every other request (including {@code GET /api/auth/me},
+ * {@code POST /api/auth/logout}, and the whole rest of the API) passes through
+ * untouched. On overflow the filter short-circuits with HTTP 429 and a minimal
+ * JSON body — no stack trace, no internal detail.
+ *
+ * <p><b>Export endpoints (#265):</b> both {@code POST /api/export} (async job
+ * submission, #58) and {@code GET /api/export} (synchronous inline export —
+ * repeated User+Product+Category+Event DB reads per call) are throttled: they are
+ * the resource-heavy operations. The two other export GETs are DELIBERATELY left
+ * out of scope:
+ * <ul>
+ *   <li>{@code GET /api/export/job/{jobId}} — cheap status polling; a legitimate
+ *       client polls a running job several times and must not be penalised;</li>
+ *   <li>{@code GET /api/export/download/{jobId}} — re-download of an already
+ *       COMPLETED file (bytes read from a private blob, no export recomputation).</li>
+ * </ul>
+ * Both are strictly self-service (owner-scoped, job of another user → 404, no
+ * cross-user enumeration), so the abuse surface is bounded to a user hammering
+ * their own already-produced artefacts — an accepted residual, tracked in
+ * {@code docs/adr/ADR-003-export-rgpd-async-job.md} (§ Rate-limiting). Because the
+ * bucket key is exact-URI based, these two nested paths never match {@link #LIMITS}.
  *
  * <p><b>Scope of the limit:</b> buckets live in a {@link ConcurrentHashMap} inside
- * this single JVM, keyed by {@code clientIp + "|" + path}. The limits are therefore
+ * this single JVM, keyed by {@code clientIp + "|" + method + " " + path}. The limits are therefore
  * PER INSTANCE: behind a load balancer with N replicas the effective ceiling is
  * N x the configured rate. This is acceptable for the current single-instance
  * deployment; a distributed backend (Redis + bucket4j-redis) is required before
@@ -47,20 +64,32 @@ public class RateLimitingFilter extends OncePerRequestFilter {
 
     private static final Logger log = LoggerFactory.getLogger(RateLimitingFilter.class);
 
-    /** Requests per minute per IP, per throttled POST path. */
-    private static final Map<String, Integer> PATH_LIMITS = Map.of(
-            "/api/auth/login", 10,
-            "/api/auth/register", 5,
-            "/api/auth/refresh", 20,
+    /**
+     * Requests per minute per IP, per throttled {@code "METHOD /exact/path"} pair.
+     * The key embeds the HTTP method so a single URI can be throttled on some verbs
+     * only (e.g. {@code /api/export} is limited on both POST and GET, while a bare
+     * path is otherwise POST-only here).
+     */
+    private static final Map<String, Integer> LIMITS = Map.of(
+            "POST /api/auth/login", 10,
+            "POST /api/auth/register", 5,
+            "POST /api/auth/refresh", 20,
             // #49 : forgot-password est une cible d'abus (spam mail / énumération).
             // Throttle strict par IP, cohérent avec le slot reset-password (#33).
-            "/api/auth/forgot-password", 5,
-            "/api/auth/reset-password", 5,
+            "POST /api/auth/forgot-password", 5,
+            "POST /api/auth/reset-password", 5,
             // #58 : soumission de job d'export RGPD (POST /api/export) — opération lourde
             // (pool async borné + écriture fichier sur disque, aucun quota). Sans throttle un
             // user authentifié peut spammer les soumissions → épuisement du pool + accumulation
             // de fichiers. Limite basse (5/min/IP) alignée sur les slots coûteux forgot/reset.
-            "/api/export", 5
+            "POST /api/export", 5,
+            // #265 : export SYNCHRONE inline (GET /api/export?format=json|markdown) — recalcule
+            // l'export à chaque appel (requêtes DB User+Product+Category+Event répétées, rendu
+            // inline). Vecteur de DoS/consommation CPU-IO par un user authentifié. Même limite
+            // basse (5/min/IP) et bucket SÉPARÉ du POST (la clé inclut la méthode). Le polling
+            // /job et le re-download /download restent volontairement hors périmètre (cf. javadoc
+            // de classe + ADR-003 § Rate-limiting).
+            "GET /api/export", 5
     );
 
     private static final Duration WINDOW = Duration.ofMinutes(1);
@@ -122,7 +151,9 @@ public class RateLimitingFilter extends OncePerRequestFilter {
             return;
         }
 
-        String key = clientIp(request) + "|" + request.getRequestURI();
+        // Method is part of the key: GET and POST on the same URI (e.g. /api/export)
+        // get INDEPENDENT buckets, so their distinct limits never collide.
+        String key = clientIp(request) + "|" + request.getMethod() + " " + request.getRequestURI();
         Bucket bucket = buckets.computeIfAbsent(key, k -> newBucket(limit));
 
         if (bucket.tryConsume(1)) {
@@ -133,14 +164,13 @@ public class RateLimitingFilter extends OncePerRequestFilter {
     }
 
     /**
-     * @return the per-minute limit if this request targets a throttled POST path,
-     *         otherwise {@code null} (request must pass through).
+     * @return the per-minute limit if this request targets a throttled
+     *         {@code (method, exact-path)} pair, otherwise {@code null}
+     *         (request must pass through). Exact-URI match: nested export paths
+     *         ({@code /api/export/job/…}, {@code /api/export/download/…}) never match.
      */
     private Integer throttledLimitFor(HttpServletRequest request) {
-        if (!HttpMethod.POST.matches(request.getMethod())) {
-            return null;
-        }
-        return PATH_LIMITS.get(request.getRequestURI());
+        return LIMITS.get(request.getMethod() + " " + request.getRequestURI());
     }
 
     private Bucket newBucket(int permitsPerMinute) {

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/security/RateLimitingFilter.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/security/RateLimitingFilter.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.UrlPathHelper;
 
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
@@ -98,6 +99,23 @@ public class RateLimitingFilter extends OncePerRequestFilter {
     private final TimeMeter timeMeter;
 
     /**
+     * Decodes + normalises the request path before matching against {@link #LIMITS}.
+     *
+     * <p><b>Why (audit #265):</b> {@link HttpServletRequest#getRequestURI()} is the RAW,
+     * still-percent-encoded URI (Servlet contract). Matching {@code LIMITS} on it lets an
+     * attacker bypass the throttle with a trivially re-encoded path: {@code GET /api/%65xport}
+     * ({@code e} → {@code %65}) yields the raw string {@code "GET /api/%65xport"}, which does
+     * not equal {@code "GET /api/export"} → no bucket → unlimited hits, while Spring still
+     * decodes and routes the request to {@code ExportController} (the costly recompute). The
+     * default {@code StrictHttpFirewall} does not reject the encoding of an ordinary letter.
+     *
+     * <p>{@code getPathWithinApplication} URL-decodes and strips the context-path, so the
+     * encoded and canonical forms collapse to the same lookup/bucket key. The instance is
+     * stateless after construction and thread-safe.
+     */
+    private final UrlPathHelper pathHelper = new UrlPathHelper();
+
+    /**
      * When {@code true}, the first hop of {@code X-Forwarded-For} is used as the
      * rate-limit key. Defaults to {@code false} and MUST stay false unless the
      * service runs behind a trusted reverse proxy that overwrites the header.
@@ -145,7 +163,13 @@ public class RateLimitingFilter extends OncePerRequestFilter {
             return;
         }
 
-        Integer limit = throttledLimitFor(request);
+        // Decoded + context-path-stripped path: matching on the RAW getRequestURI() would let
+        // a re-encoded path (e.g. /api/%65xport) dodge the throttle while still routing to the
+        // controller (audit #265). Both lookup and bucket key are built from this canonical path.
+        String path = pathHelper.getPathWithinApplication(request);
+        String methodAndPath = request.getMethod() + " " + path;
+
+        Integer limit = LIMITS.get(methodAndPath);
         if (limit == null) {
             chain.doFilter(request, response);
             return;
@@ -153,7 +177,7 @@ public class RateLimitingFilter extends OncePerRequestFilter {
 
         // Method is part of the key: GET and POST on the same URI (e.g. /api/export)
         // get INDEPENDENT buckets, so their distinct limits never collide.
-        String key = clientIp(request) + "|" + request.getMethod() + " " + request.getRequestURI();
+        String key = clientIp(request) + "|" + methodAndPath;
         Bucket bucket = buckets.computeIfAbsent(key, k -> newBucket(limit));
 
         if (bucket.tryConsume(1)) {
@@ -161,16 +185,6 @@ public class RateLimitingFilter extends OncePerRequestFilter {
         } else {
             writeTooManyRequests(response);
         }
-    }
-
-    /**
-     * @return the per-minute limit if this request targets a throttled
-     *         {@code (method, exact-path)} pair, otherwise {@code null}
-     *         (request must pass through). Exact-URI match: nested export paths
-     *         ({@code /api/export/job/…}, {@code /api/export/download/…}) never match.
-     */
-    private Integer throttledLimitFor(HttpServletRequest request) {
-        return LIMITS.get(request.getMethod() + " " + request.getRequestURI());
     }
 
     private Bucket newBucket(int permitsPerMinute) {

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -36,3 +36,8 @@ app.storage.avatar-path=${STORAGE_AVATAR_PATH:./var/avatars-dev}
 # Stockage export RGPD (#264) — default LOCAL dev (répertoire jetable hors webroot),
 # DISTINCT des avatars. En prod, le profil prod impose STORAGE_EXPORT_PATH (aucun default).
 app.storage.export-path=${STORAGE_EXPORT_PATH:./var/exports-dev}
+
+# Purge TTL des exports expirés (#267) — dev : balayage plus fréquent (5 min) pour observer
+# la purge sans attendre 1h. Délai initial court (10 s) après le boot.
+app.export.purge.interval-ms=${EXPORT_PURGE_INTERVAL_MS:300000}
+app.export.purge.initial-delay-ms=${EXPORT_PURGE_INITIAL_DELAY_MS:10000}

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -32,3 +32,7 @@ app.cors.allowed-origins=http://localhost:3000
 # Stockage avatar (#75) — default LOCAL dev (répertoire jetable hors webroot).
 # En prod, le profil prod impose STORAGE_AVATAR_PATH via env (aucun default).
 app.storage.avatar-path=${STORAGE_AVATAR_PATH:./var/avatars-dev}
+
+# Stockage export RGPD (#264) — default LOCAL dev (répertoire jetable hors webroot),
+# DISTINCT des avatars. En prod, le profil prod impose STORAGE_EXPORT_PATH (aucun default).
+app.storage.export-path=${STORAGE_EXPORT_PATH:./var/exports-dev}

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -37,3 +37,8 @@ app.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:}
 # non servi statiquement (l'accès passe uniquement par GET /api/me/avatar authentifié).
 # Migration future S3/MinIO = nouvelle impl de StoragePort (pas de changement ici).
 app.storage.avatar-path=${STORAGE_AVATAR_PATH}
+
+# Stockage export RGPD (#264, ADR-003 §5) — répertoire LOCAL PRIVÉ hors webroot, DÉDIÉ
+# (distinct des avatars), OBLIGATOIRE via env, AUCUN default (fail-fast). Volume persistant
+# non servi statiquement ; téléchargement via endpoint token-gated GET /api/export/download.
+app.storage.export-path=${STORAGE_EXPORT_PATH}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -59,6 +59,13 @@ app.storage.avatar-path=${STORAGE_AVATAR_PATH}
 # impose STORAGE_EXPORT_PATH via env (fail-fast). Résolu par le bean exportStorage (StorageConfig).
 app.storage.export-path=${STORAGE_EXPORT_PATH}
 
+# Purge TTL des exports RGPD expirés (#267, ADR-003 §3). Scheduler @Scheduled (fixedDelay) :
+# balaye export_jobs WHERE expires_at < now -> supprime fichier (exportStorage) + ligne.
+# interval-ms : période entre deux balayages (défaut 1h). initial-delay-ms : délai avant le
+# 1er passage après le boot (défaut 5 min — évite un balayage au démarrage à froid).
+app.export.purge.interval-ms=${EXPORT_PURGE_INTERVAL_MS:3600000}
+app.export.purge.initial-delay-ms=${EXPORT_PURGE_INITIAL_DELAY_MS:300000}
+
 # Rate limiting (#33)
 # X-Forwarded-For is client-controllable. Keep this false unless the service is
 # deployed behind a TRUSTED reverse proxy that strips/overwrites client-supplied

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -51,6 +51,13 @@ app.storage.avatar-max-bytes=${AVATAR_MAX_BYTES:5242880}
 # Le profil dev fournit un default local ; le profil prod impose STORAGE_AVATAR_PATH
 # via env (fail-fast). Résolu par LocalStorageAdapter (répertoire créé au 1er upload).
 app.storage.avatar-path=${STORAGE_AVATAR_PATH}
+# Chemin de stockage LOCAL PRIVÉ DÉDIÉ aux exports RGPD (#264, ADR-003 §5 — hors webroot).
+# DÉCOUPLÉ des avatars : répertoire distinct, hypothèses propres (rétention TTL 24h, backup).
+# NE réutilise PAS app.storage.avatar-max-bytes ni la validation d'image (aucune contrainte
+# de type/taille avatar héritée). Convention #34 (comme avatar-path/JWT_SECRET) : AUCUN default
+# ici -> boot ÉCHOUE sans la valeur. Le profil dev fournit un default local ; le profil prod
+# impose STORAGE_EXPORT_PATH via env (fail-fast). Résolu par le bean exportStorage (StorageConfig).
+app.storage.export-path=${STORAGE_EXPORT_PATH}
 
 # Rate limiting (#33)
 # X-Forwarded-For is client-controllable. Keep this false unless the service is

--- a/backend/src/main/resources/db/migration/V14__idx_export_jobs_expires_at.sql
+++ b/backend/src/main/resources/db/migration/V14__idx_export_jobs_expires_at.sql
@@ -1,0 +1,23 @@
+-- =============================================================
+-- V14__idx_export_jobs_expires_at.sql — Index de purge TTL des exports RGPD (issue #267)
+--
+-- Contexte : les exports RGPD asynchrones (#58, V13) déposent un fichier sur disque avec
+-- une durée de vie de 24h (`export_jobs.expires_at`). Le scheduler de purge (#267) balaye
+-- périodiquement `export_jobs WHERE expires_at IS NOT NULL AND expires_at < now()` pour
+-- supprimer fichier + ligne (RGPD minimisation, coût disque).
+--
+-- Sans index, ce balayage = SEQ SCAN de toute la table à chaque tick (horaire). `expires_at`
+-- est NULLABLE (renseigné SEULEMENT à la complétion) : Postgres indexe aussi les NULL en
+-- b-tree, mais le prédicat `expires_at < now()` élimine naturellement les NULL. L'index sert
+-- exclusivement la requête de purge (aucun autre accès par expiration).
+--
+-- Ne modifie AUCUN mapping entité (un index n'est pas une colonne) -> `ddl-auto=validate`
+-- reste vert, pas de changement d'ExportJobEntity. NE PAS éditer V1..V13 (checksum Flyway).
+-- =============================================================
+
+create index idx_export_jobs_expires_at on export_jobs (expires_at);
+
+-- =============================================================
+-- ROLLBACK (manuel — Flyway Community ne rejoue pas les undo) :
+--   drop index if exists idx_export_jobs_expires_at;
+-- =============================================================

--- a/backend/src/test/java/com/matimeline/eventmanager/application/services/ExportPurgeSchedulerIntegrationTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/application/services/ExportPurgeSchedulerIntegrationTest.java
@@ -1,0 +1,135 @@
+package com.matimeline.eventmanager.application.services;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.matimeline.eventmanager.domain.models.export.ExportFormat;
+import com.matimeline.eventmanager.domain.models.export.ExportJob;
+import com.matimeline.eventmanager.domain.models.export.ExportJobStatus;
+import com.matimeline.eventmanager.domain.ports.repositories.ExportJobRepository;
+import com.matimeline.eventmanager.domain.ports.services.StoragePort;
+import com.matimeline.eventmanager.infrastructure.entities.UserEntity;
+import com.matimeline.eventmanager.support.AbstractPostgresIntegrationTest;
+
+/**
+ * #267 — purge TTL des exports RGPD expirés. Parcourt la VRAIE chaîne Postgres (Testcontainers,
+ * migrations V1..V14 incl. l'index de purge) + stockage local réel ({@code exportStorage}).
+ *
+ * <p>Couvre :
+ * <ul>
+ *   <li>job COMPLETED expiré -> fichier supprimé (exportStorage) + ligne purgée ;</li>
+ *   <li>job COMPLETED NON expiré -> intact (fichier ET ligne conservés) ;</li>
+ *   <li>idempotence : fichier déjà absent -> purge no-op (ligne purgée, aucune exception).</li>
+ * </ul>
+ *
+ * <p>Le tick {@code @Scheduled} est neutralisé pendant le test (initial-delay très long) : on
+ * invoque {@link ExportPurgeScheduler#purgeExpired()} directement pour un contrôle déterministe.
+ */
+@SpringBootTest(properties = {
+        "jwt.secret=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+        // Empêche le tick automatique d'interférer avec les assertions (on appelle purgeExpired() nous-mêmes).
+        "app.export.purge.initial-delay-ms=3600000",
+        "app.export.purge.interval-ms=3600000"
+})
+class ExportPurgeSchedulerIntegrationTest extends AbstractPostgresIntegrationTest {
+
+    @Autowired
+    private ExportPurgeScheduler scheduler;
+
+    @Autowired
+    private ExportJobRepository exportJobRepository;
+
+    @Autowired
+    @Qualifier("exportStorage")
+    private StoragePort exportStorage;
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private PlatformTransactionManager txManager;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    /** Crée un utilisateur (FK export_jobs.user_id -> users) et renvoie son id. */
+    private UUID seedUser() {
+        String username = "u" + UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+        return new TransactionTemplate(txManager).execute(status -> {
+            UserEntity user = new UserEntity();
+            user.setName("PurgeTest");
+            user.setUsername(username);
+            user.setEmail(username + "@example.test");
+            user.setPassword(passwordEncoder.encode("secret6"));
+            user.setRole("ROLE_USER");
+            em.persist(user);
+            em.flush();
+            return user.getId();
+        });
+    }
+
+    /** Persiste un job COMPLETED pointant {@code storageRef}, expirant à {@code expiresAt}. */
+    private UUID seedCompletedJob(UUID ownerId, String storageRef, LocalDateTime expiresAt) {
+        LocalDateTime createdAt = expiresAt.minusHours(24);
+        ExportJob job = new ExportJob(null, ownerId, ExportFormat.ZIP, ExportJobStatus.COMPLETED,
+                storageRef, null, createdAt, createdAt, expiresAt);
+        return exportJobRepository.save(job).getId();
+    }
+
+    @Test
+    void expiredCompletedJob_fileAndRowPurged() {
+        UUID ownerId = seedUser();
+        String ref = exportStorage.store("expired-dump".getBytes(StandardCharsets.UTF_8), "zip");
+        UUID jobId = seedCompletedJob(ownerId, ref, LocalDateTime.now().minusHours(1));
+
+        assertTrue(exportStorage.load(ref).isPresent(), "précondition : fichier présent avant purge");
+        assertTrue(exportJobRepository.findDomainById(jobId).isPresent(), "précondition : ligne présente");
+
+        scheduler.purgeExpired();
+
+        assertTrue(exportStorage.load(ref).isEmpty(), "fichier supprimé via exportStorage");
+        assertTrue(exportJobRepository.findDomainById(jobId).isEmpty(), "ligne export_jobs purgée");
+    }
+
+    @Test
+    void nonExpiredCompletedJob_leftIntact() {
+        UUID ownerId = seedUser();
+        String ref = exportStorage.store("fresh-dump".getBytes(StandardCharsets.UTF_8), "zip");
+        UUID jobId = seedCompletedJob(ownerId, ref, LocalDateTime.now().plusHours(2));
+
+        scheduler.purgeExpired();
+
+        assertTrue(exportStorage.load(ref).isPresent(), "fichier non expiré conservé");
+        assertTrue(exportJobRepository.findDomainById(jobId).isPresent(), "ligne non expirée conservée");
+    }
+
+    @Test
+    void expiredJob_fileAlreadyAbsent_idempotentNoOp() {
+        UUID ownerId = seedUser();
+        // Réf plausible mais aucun fichier associé (jamais stocké) : delete = no-op.
+        String danglingRef = "export-" + UUID.randomUUID() + ".zip";
+        UUID jobId = seedCompletedJob(ownerId, danglingRef, LocalDateTime.now().minusHours(1));
+
+        assertTrue(exportStorage.load(danglingRef).isEmpty(), "précondition : fichier absent");
+
+        assertDoesNotThrow(scheduler::purgeExpired, "purge idempotente sur fichier absent");
+
+        assertFalse(exportJobRepository.findDomainById(jobId).isPresent(),
+                "ligne purgée malgré fichier déjà absent");
+    }
+}

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/config/StorageConfigTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/config/StorageConfigTest.java
@@ -1,0 +1,75 @@
+package com.matimeline.eventmanager.infrastructure.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import com.matimeline.eventmanager.domain.ports.services.StoragePort;
+
+/**
+ * Issue #264 — chemin de stockage DÉDIÉ aux exports RGPD. Vérifie que {@code StorageConfig}
+ * câble deux beans {@link StoragePort} DISTINCTS, chacun sur SON répertoire, et que la clé
+ * {@code app.storage.export-path} suit la convention #34 (fail-fast : aucun default en prod).
+ *
+ * <p>Test de tranche léger ({@link ApplicationContextRunner}) : ni Postgres ni contexte web,
+ * on n'exerce que le câblage de stockage.
+ */
+class StorageConfigTest {
+
+    // PropertyPlaceholderAutoConfiguration -> PropertySourcesPlaceholderConfigurer avec
+    // ignoreUnresolvablePlaceholders=false (comme un vrai boot Spring Boot). Sans lui, le
+    // resolver par défaut du contexte IGNORE les placeholders non résolus (ne reproduit pas
+    // le fail-fast prod). Avec lui, un ${app.storage.export-path} absent fait échouer le boot.
+    private final ApplicationContextRunner runner =
+            new ApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(PropertyPlaceholderAutoConfiguration.class))
+                    .withUserConfiguration(StorageConfig.class);
+
+    @Test
+    void exportAndAvatarStorage_useDistinctDirectories(@TempDir Path avatarDir,
+                                                       @TempDir Path exportDir) {
+        runner.withPropertyValues(
+                        "app.storage.avatar-path=" + avatarDir,
+                        "app.storage.export-path=" + exportDir)
+                .run(context -> {
+                    StoragePort avatarStorage = context.getBean("avatarStorage", StoragePort.class);
+                    StoragePort exportStorage = context.getBean("exportStorage", StoragePort.class);
+                    assertNotSame(avatarStorage, exportStorage, "deux beans de stockage distincts");
+
+                    // L'export écrit dans SON base-path dédié, JAMAIS dans le répertoire avatar.
+                    String ref = exportStorage.store(new byte[] {1, 2, 3}, "zip");
+                    assertTrue(Files.exists(exportDir.resolve(ref)),
+                            "le fichier d'export est écrit sous export-path");
+                    assertTrue(isEmpty(avatarDir),
+                            "aucun fichier d'export ne fuit dans le répertoire avatar");
+                });
+    }
+
+    @Test
+    void missingExportPath_failsFast_perConvention34() {
+        // Aucun default en prod : sans app.storage.export-path, le placeholder ne se résout pas
+        // et le contexte échoue au démarrage (fail-fast, cohérent avatar-path/JWT_SECRET).
+        runner.withPropertyValues("app.storage.avatar-path=/tmp/mytimeline-avatars-test")
+                .run(context -> assertTrue(context.getStartupFailure() != null,
+                        "le boot doit échouer si app.storage.export-path est absent"));
+    }
+
+    private static boolean isEmpty(Path dir) {
+        try (Stream<Path> entries = Files.list(dir)) {
+            return entries.findAny().isEmpty();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/security/RateLimitingAndHeadersIntegrationTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/security/RateLimitingAndHeadersIntegrationTest.java
@@ -186,8 +186,9 @@ class RateLimitingAndHeadersIntegrationTest extends AbstractPostgresIntegrationT
      * Elle DOIT être throttlée (limite 5/min/IP). Le RateLimitingFilter est placé avant
      * l'AuthorizationFilter (addFilterBefore UsernamePasswordAuthenticationFilter), donc le
      * 429 court-circuite même sans JWT valide : les 5 premières passent (rejetées plus loin
-     * par l'authz), la 6e depuis la même IP est throttlée. Les GET (téléchargement / statut /
-     * json|markdown) ne passent PAS par ce throttle — c'est attendu, hors périmètre du MAJEUR.
+     * par l'authz), la 6e depuis la même IP est throttlée. Depuis #265 le GET synchrone inline
+     * (json|markdown) est LUI AUSSI throttlé (bucket séparé, cf. exportInlineGet_* ci-dessous) ;
+     * seuls le polling /job et le re-download /download restent hors périmètre.
      */
     @Test
     void exportSubmission_sixthWithinWindow_returns429() throws Exception {
@@ -203,6 +204,84 @@ class RateLimitingAndHeadersIntegrationTest extends AbstractPostgresIntegrationT
                 .andExpect(status().is(429))
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.error").value("too_many_requests"));
+    }
+
+    /**
+     * #265 : l'export SYNCHRONE inline (GET /api/export?format=json) recalcule l'export à chaque
+     * appel (requêtes DB répétées) → vecteur de DoS. Il DOIT être throttlé (5/min/IP), au même
+     * titre que la soumission POST. Le filtre court-circuite avant l'authz : les 5 premières
+     * passent (rejetées plus loin faute de JWT), la 6e depuis la même IP est 429 + JSON propre.
+     */
+    @Test
+    void exportInlineGet_sixthWithinWindow_returns429() throws Exception {
+        String ip = "10.2.0.1";
+        for (int i = 1; i <= 5; i++) {
+            int sc = mockMvc.perform(get("/api/export").param("format", "json")
+                            .with(req -> { req.setRemoteAddr(ip); return req; }))
+                    .andReturn().getResponse().getStatus();
+            assertNotEquals(429, sc, "GET inline #" + i + " sous la limite ne doit pas être throttlé");
+        }
+        mockMvc.perform(get("/api/export").param("format", "json")
+                        .with(req -> { req.setRemoteAddr(ip); return req; }))
+                .andExpect(status().is(429))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value("too_many_requests"));
+    }
+
+    /**
+     * #265 : GET et POST /api/export ont des buckets INDÉPENDANTS (la clé inclut la méthode).
+     * Épuiser le quota GET (5) depuis une IP ne doit PAS consommer le quota POST de la même IP :
+     * la 1re soumission POST juste après doit passer (jamais 429).
+     */
+    @Test
+    void exportGetAndPost_haveIndependentBuckets() throws Exception {
+        String ip = "10.2.0.2";
+        for (int i = 1; i <= 5; i++) {
+            mockMvc.perform(get("/api/export").param("format", "json")
+                    .with(req -> { req.setRemoteAddr(ip); return req; }));
+        }
+        // GET épuisé -> 429, mais le POST garde son propre quota intact.
+        assertEquals(429, mockMvc.perform(get("/api/export").param("format", "json")
+                        .with(req -> { req.setRemoteAddr(ip); return req; }))
+                .andReturn().getResponse().getStatus());
+        assertNotEquals(429, mockMvc.perform(post("/api/export")
+                        .with(req -> { req.setRemoteAddr(ip); return req; }))
+                .andReturn().getResponse().getStatus(),
+                "le bucket POST doit être indépendant du bucket GET épuisé");
+    }
+
+    /**
+     * #265 (décision tracée, ADR-003 § Rate-limiting) : le polling de statut
+     * GET /api/export/job/{jobId} est LÉGER et volontairement HORS rate-limit — un client
+     * légitime interroge un job en cours de nombreuses fois et ne doit jamais être throttlé.
+     */
+    @Test
+    void exportJobPolling_isNotRateLimited() throws Exception {
+        String ip = "10.2.0.3";
+        String jobUrl = "/api/export/job/00000000-0000-0000-0000-000000000265";
+        for (int i = 1; i <= 30; i++) {
+            int sc = mockMvc.perform(get(jobUrl)
+                            .with(req -> { req.setRemoteAddr(ip); return req; }))
+                    .andReturn().getResponse().getStatus();
+            assertNotEquals(429, sc, "le polling /job ne doit jamais être throttlé (requête #" + i + ")");
+        }
+    }
+
+    /**
+     * #265 (décision tracée, ADR-003 § Rate-limiting) : le re-téléchargement d'un fichier déjà
+     * COMPLETED GET /api/export/download/{jobId} lit des octets d'un blob privé (aucun recalcul)
+     * et reste volontairement HORS rate-limit — self-service borné, pas d'énumération cross-user.
+     */
+    @Test
+    void exportDownload_isNotRateLimited() throws Exception {
+        String ip = "10.2.0.4";
+        String dlUrl = "/api/export/download/00000000-0000-0000-0000-000000000265";
+        for (int i = 1; i <= 30; i++) {
+            int sc = mockMvc.perform(get(dlUrl).param("token", "irrelevant")
+                            .with(req -> { req.setRemoteAddr(ip); return req; }))
+                    .andReturn().getResponse().getStatus();
+            assertNotEquals(429, sc, "le re-download /download ne doit jamais être throttlé (requête #" + i + ")");
+        }
     }
 
     /**

--- a/backend/src/test/java/com/matimeline/eventmanager/infrastructure/security/RateLimitingAndHeadersIntegrationTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/infrastructure/security/RateLimitingAndHeadersIntegrationTest.java
@@ -229,6 +229,34 @@ class RateLimitingAndHeadersIntegrationTest extends AbstractPostgresIntegrationT
     }
 
     /**
+     * #265 (audit sécurité — bypass MAJEUR) : {@code getRequestURI()} n'est PAS décodé
+     * (contrat Servlet). Un chemin ré-encodé — {@code GET /api/%65xport} ({@code e} → {@code %65})
+     * — routait quand même vers {@code ExportController} (Spring décode l'URI), mais échappait
+     * TOTALEMENT au throttle car la clé brute {@code "GET /api/%65xport"} ne matchait pas
+     * {@code "GET /api/export"} dans LIMITS. Depuis la normalisation (UrlPathHelper) la clé est
+     * calculée sur le chemin DÉCODÉ : le chemin encodé retombe dans le même bucket que la forme
+     * canonique → la 6e requête est 429, plus de bypass. {@code setRequestURI} force l'URI brute
+     * encodée telle qu'un client la poserait.
+     */
+    @Test
+    void exportInlineGet_percentEncodedPath_isThrottled_noBypass() throws Exception {
+        String ip = "10.2.0.5";
+        String encodedUri = "/api/%65xport"; // "e" de "export" encodé -> /api/export après décodage
+        for (int i = 1; i <= 5; i++) {
+            int sc = mockMvc.perform(get("/api/export").param("format", "json")
+                            .with(req -> { req.setRemoteAddr(ip); req.setRequestURI(encodedUri); return req; }))
+                    .andReturn().getResponse().getStatus();
+            assertNotEquals(429, sc, "GET encodé #" + i + " sous la limite ne doit pas être throttlé");
+        }
+        // 6e requête sur le MÊME chemin encodé -> throttlée : le bypass par ré-encodage est fermé.
+        mockMvc.perform(get("/api/export").param("format", "json")
+                        .with(req -> { req.setRemoteAddr(ip); req.setRequestURI(encodedUri); return req; }))
+                .andExpect(status().is(429))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value("too_many_requests"));
+    }
+
+    /**
      * #265 : GET et POST /api/export ont des buckets INDÉPENDANTS (la clé inclut la méthode).
      * Épuiser le quota GET (5) depuis une IP ne doit PAS consommer le quota POST de la même IP :
      * la 1re soumission POST juste après doit passer (jamais 429).

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -31,3 +31,6 @@ jwt.secret=dGVzdC1vbmx5LWluc2VjdXJlLWp3dC1zZWNyZXQtY2hhbmdlLW1lLXBlci1wb3N0IQ==
 # (aucun STORAGE_AVATAR_PATH en env CI). LocalStorageAdapter crée le sous-dossier
 # au 1er upload ; réclamé par l'OS à l'arrêt.
 app.storage.avatar-path=${java.io.tmpdir}/mytimeline-avatars-test
+
+# Stockage export RGPD (#264) — répertoire temporaire jetable, DISTINCT des avatars.
+app.storage.export-path=${java.io.tmpdir}/mytimeline-exports-test

--- a/docs/adr/ADR-003-export-rgpd-async-job.md
+++ b/docs/adr/ADR-003-export-rgpd-async-job.md
@@ -79,9 +79,37 @@ Exclus, avec justification tracée :
 ### 5. Stockage des fichiers async
 
 Réutilise `StoragePort` (store/load/delete blob privé hors webroot). Les extensions
-`zip`/`csv` passent le `sanitizeExtension` existant (`[a-z0-9]{1,5}`). **Dette** : le port
-est aujourd'hui paramétré par `app.storage.avatar-path` ; exports et avatars partagent le
-répertoire privé. Un préfixe/bucket dédié aux exports est un follow-up.
+`zip`/`csv` passent le `sanitizeExtension` existant (`[a-z0-9]{1,5}`). **Dette RÉSOLUE (#264)** :
+un chemin DÉDIÉ `app.storage.export-path` (bean `exportStorage`, `StorageConfig`) découple
+désormais les exports des avatars — répertoire distinct, convention #34 (fail-fast prod),
+sans hériter des hypothèses avatar (taille max, rétention). La purge TTL 24h de ce base-path
+reste le follow-up #267 (voir §3).
+
+### 6. Rate-limiting des endpoints export (DoS / consommation de ressources — #58, #265)
+
+`RateLimitingFilter` (Bucket4j, in-memory, **par IP**, cf. `infrastructure/security/`) throttle
+les opérations d'export **lourdes** :
+
+- `POST /api/export` (soumission de job async) — **5/min/IP** (#58) : pool async borné + écriture
+  fichier, sans quota → risque d'épuisement du pool / accumulation de fichiers.
+- `GET /api/export?format=json|markdown` (export **synchrone inline**) — **5/min/IP** (#265) :
+  recalcule l'export à chaque appel (requêtes DB User+Product+Category+Event répétées). Bucket
+  **séparé** du POST (la clé de bucket inclut la méthode HTTP).
+
+**Hors périmètre (décision tracée, #265)** — volontairement NON rate-limités :
+
+- `GET /api/export/job/{jobId}` — polling de statut **léger** ; un client légitime interroge un
+  job en cours plusieurs fois et ne doit pas être pénalisé.
+- `GET /api/export/download/{jobId}?token=…` — re-téléchargement d'un fichier **déjà** COMPLETED
+  (lecture d'octets d'un blob privé, aucun recalcul d'export).
+
+Justification de l'acceptation du résidu : ces deux endpoints sont **strictement self-service**
+(scopés au propriétaire ; job d'autrui → 404, pas d'énumération cross-user). La surface d'abus se
+borne à un utilisateur qui martèle ses **propres** artefacts déjà produits — coût faible, pas de
+faille d'accès. Si un abus réel émerge, les ajouter à `LIMITS` est une extension d'une ligne
+(le mécanisme est déjà méthode+chemin). Contrat verrouillé par
+`RateLimitingAndHeadersIntegrationTest` (429 sur GET/POST `/api/export` ; 200 non pénalisé sur
+`/job` et `/download`).
 
 ## Conséquences
 

--- a/docs/memory/audits/sprint-36-test-coverage.md
+++ b/docs/memory/audits/sprint-36-test-coverage.md
@@ -1,0 +1,32 @@
+# Audit tests — Sprint 36 (Export RGPD hardening)
+
+> Généré en fin de Phase 6. Aucun `[MISSING]` → Phase 9 PR débloquée.
+> Sprint 100% backend (aucun changement frontend/.tsx) → pas de nouveau data-testid, pas d'E2E requis.
+
+## Couverture par issue / BR
+
+| Issue | Objet | Cross-system flow | Unit/Slice backend | Integration (Testcontainers) | E2E |
+|-------|-------|:---:|:---:|:---:|:---:|
+| #264 | Chemin stockage dédié export (app.storage.export-path, beans qualifiés) | NON | ✅ | ✅ StorageConfigTest (découplage répertoires + fail-fast prod) ; ExportEndpointsIntegrationTest (flux async via exportStorage) | N/A (backend) |
+| #265 | Rate-limit GET /api/export synchrone (+ fix bypass encodage URL) | NON | ✅ | ✅ RateLimitingAndHeadersIntegrationTest (429 après limite, buckets GET/POST séparés, /job + /download exemptés, bypass %65xport throttlé) | N/A (backend) |
+| #267 | Scheduler purge exports expirés (V14 + @EnableScheduling) | NON | ✅ | ✅ ExportPurgeSchedulerIntegrationTest (expiré→purgé fichier+ligne ; non-expiré→intact ; idempotence fichier absent) | N/A (backend) |
+
+Cross-system flow = NON pour les 3 (backend interne / self-service owner-scoped, pas de flux multi-systèmes/rôles) → E2E métier non requis.
+
+## Tests créés / étendus
+- `backend/.../infrastructure/config/StorageConfigTest.java` (#264, nouveau)
+- `backend/.../infrastructure/security/RateLimitingAndHeadersIntegrationTest.java` (#265, +6 tests dont non-régression bypass encodé)
+- `backend/.../application/services/ExportPurgeSchedulerIntegrationTest.java` (#267, nouveau, 3 tests Testcontainers)
+
+## Résultats runs
+- **Backend : 384 tests, 384 passed, 0 failed, 0 errors — BUILD SUCCESS** (test-runner isolé, ~101s, Testcontainers Postgres 16).
+- Frontend : aucun changement (N/A).
+- E2E : aucun testid nouveau (N/A).
+
+## Audits spécialistes
+- security-expert (#265) : MAJEUR bypass rate-limit par encodage URL → **CORRIGÉ** (commit 4ad929e, UrlPathHelper.getPathWithinApplication + test régression). MINEUR /download non borné → accepté MVP, tracé ADR-003 §6.
+- db-expert (V14) : **APPROUVE**. MINEUR index partiel `WHERE expires_at IS NOT NULL` → follow-up optionnel.
+- reviewer batch : **APPROUVE**. MINEUR dead-letter/compteur d'échecs répétés purge → follow-up optionnel.
+
+## Conclusion
+Prêt pour PR. Aucun blocage. Suite verte, 3 audits résolus/approuvés.

--- a/docs/memory/sprint-history.md
+++ b/docs/memory/sprint-history.md
@@ -791,14 +791,14 @@
 **Note tooling :** `detect-domain.sh` re-confirmé bloquant (zombies >1h en background) → domaines mappés à la main (`auth`). `check-sprint-completeness.sh` absent de ce projet (vérif complétude faite à la main).
 **Status :** Terminé (clôturé 2026-07-12)
 
-## Sprint 36 — 2026-07-12 (PLANIFIE — cohésion 0.72, Export RGPD hardening)
+## Sprint 36 — 2026-07-12 (En cours — cohésion 0.72, Export RGPD hardening)
 **Objectif :** Chemin de stockage dédié export + rate-limit GET export + scheduler de purge des exports expirés (index V14).
 **Milestone GitHub :** #36
 **Issues :** #264, #265, #267
 **Vagues :** V1 = #264 (storage) ∥ #265 (rate-limit) | V2 = #267 (purge via port de #264 ; introduit @EnableScheduling)
 **Migrations Flyway :** V14 (idx_export_jobs_expires_at)
 **Dépend de :** aucune (mais introduit le scheduling réutilisé en S37)
-**Status :** Planifie
+**Status :** En cours
 
 ## Sprint 37 — 2026-07-12 (PLANIFIE — cohésion 0.80, Reset-password hardening)
 **Objectif :** Durcir le flux reset-password : E2E Playwright, rate-limit/lockout par token, verrou anti-TOCTOU (@Version, V15), purge TTL des tokens.

--- a/docs/memory/sprints/sprint-36/db-review-v14.md
+++ b/docs/memory/sprints/sprint-36/db-review-v14.md
@@ -1,0 +1,13 @@
+# Review DB V14 (db-expert) — Sprint 36 #267
+
+Verdict : **APPROUVE** (aucun CRITIQUE/MAJEUR).
+
+- [OK] nommage idx_export_jobs_expires_at cohérent V13/V5 ; index != colonne → ddl-auto=validate non impacté ;
+  rollback commenté correct/idempotent ; pas d'édition V1..V13 (checksum préservé) ; balayage horaire sain à
+  l'échelle MVP (FK CASCADE, autovacuum suffit).
+- [MINEUR / optionnel] index full b-tree sur colonne NULLABLE : expires_at est NULL pour PENDING/RUNNING/FAILED.
+  Un index partiel `WHERE expires_at IS NOT NULL` serait plus fin (index plus petit, maintenance moindre).
+  NON bloquant MVP (le planner utilise l'index full). → RECOMMAND_FOLLOWUP [triage XS | domaine transversal]
+  (issue-267) : passer V-future ou éditer V14 en index partiel si volume de jobs non-expirables croît.
+- [MINEUR / note] requête purge filtre expires_at seul (pas status) : OK via invariant (seuls COMPLETED ont
+  expires_at). Ne PAS coupler l'index à l'enum status en MVP.

--- a/docs/memory/sprints/sprint-36/issue-264-done.md
+++ b/docs/memory/sprints/sprint-36/issue-264-done.md
@@ -1,0 +1,50 @@
+# issue-264-done
+
+- commits: [4dd436c44a126b23977a16f45cc002caf9b7c490]
+
+- resume:
+  Objectif: découpler le stockage des exports RGPD (ZIP/CSV) des avatars.
+  - Nouvelle clé `app.storage.export-path` déclinée sur les 4 profils, pattern avatar-path
+    (convention #34): default dev (`./var/exports-dev`), aucun default prod (fail-fast),
+    tmpdir en test. AUCUNE migration (config/stockage uniquement).
+  - `LocalStorageAdapter` généralisé: retrait `@Component`/`@Value`, base-path paramétré par
+    constructeur, messages d'erreur génériques (plus "avatar"). Impl réutilisable par usage.
+  - `StorageConfig` (@Configuration) déclare 2 beans `StoragePort`: `avatarStorage`
+    (avatar-path) + `exportStorage` (export-path) sur répertoires DISTINCTS.
+  - Injections désambiguïsées par `@Qualifier`: AvatarServiceImpl -> avatarStorage;
+    ExportServiceImpl + AsyncExportRunner -> exportStorage. `exportStorage` = point d'accès
+    dédié réutilisable par la purge #267.
+  - N'hérite PAS de `app.storage.avatar-max-bytes` ni de la validation d'image.
+  - Fichiers clés: infrastructure/config/StorageConfig.java (new),
+    infrastructure/adapters/LocalStorageAdapter.java, application/services/{ExportServiceImpl,
+    AsyncExportRunner,AvatarServiceImpl}.java, resources/application*.properties,
+    test/.../config/StorageConfigTest.java (new).
+  - BR touchées: ADR-003 §5 (dette stockage export résolue). Hexagonal OK (ArchUnit vert,
+    @Qualifier = même catégorie Spring que @Value déjà présent en couche application).
+  - Pitfall évité: bare ApplicationContextRunner IGNORE les placeholders non résolus
+    (ignoreUnresolvablePlaceholders=true) -> le test fail-fast ne déclenchait pas. Corrigé en
+    ajoutant PropertyPlaceholderAutoConfiguration (comme un vrai boot Boot).
+  - Tests: StorageConfigTest 2/2 PASSED (découpling répertoires + fail-fast export-path absent),
+    ExportEndpointsIntegrationTest 11/11 PASSED (flux async réel via exportStorage),
+    EventmanagerApplicationTests 1/1 (contexte boote avec 2 beans qualifiés),
+    AvatarServiceImplTest 12, LocalStorageAdapterTest 6, ArchitectureTest 5 — total 35 PASSED,
+    0 failed.
+
+- [MEMORY:*] signaux:
+  - [MEMORY:pattern] Problem: fail-fast d'une clé sans default à tester hors @SpringBootTest.
+    Solution: ApplicationContextRunner + AutoConfigurations.of(PropertyPlaceholderAutoConfiguration)
+    pour obtenir ignoreUnresolvablePlaceholders=false. Anti-pattern: bare ApplicationContextRunner
+    (resolver Environment par défaut ignore les placeholders manquants -> faux vert).
+  - [MEMORY:pattern] Problem: 2 beans même type StoragePort. Solution: @Configuration avec beans
+    nommés + @Qualifier au point d'injection; impl unique paramétrée par base-path (réutilisable
+    S3-swap par usage). Anti-pattern: @Primary (masque un oubli de qualifier -> mauvais répertoire).
+
+- recommandations suite:
+  - #267 (purge TTL 24h): injecter `@Qualifier("exportStorage") StoragePort` pour
+    `delete(storageRef)`; itérer le base-path export via une nouvelle méthode de port si besoin
+    de lister les fichiers expirés (le port actuel n'expose pas de list()).
+  - NOTE worktree partagé: mon édition doc ADR-003 §5 (dette résolue) est laissée NON committée
+    car le fichier est entrelacé avec le §6 rate-limiting de #265 (+ RateLimitingFilter, réservé
+    #265). Le lead/#265 committera l'ADR; ne PAS l'attribuer à mon commit.
+
+STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-36/issue-265-done.md
+++ b/docs/memory/sprints/sprint-36/issue-265-done.md
@@ -1,0 +1,24 @@
+# issue-265-done
+
+[OPTION] 1 (+ 2 en complément) — throttle GET /api/export synchrone + trace décision hors-scope
+
+[CHANGE] RateLimitingFilter.java - PATH_LIMITS (path->limit, POST-only) => LIMITS (clé "METHOD path")
+[CHANGE] RateLimitingFilter.java - ajout "GET /api/export"=5/min/IP ; bucket key inclut méthode (GET/POST buckets séparés)
+[CHANGE] RateLimitingFilter.java - throttledLimitFor sans check POST ; match exact URI => /job + /download jamais matchés
+[CHANGE] RateLimitingFilter.java - import HttpMethod retiré (inutilisé) ; javadoc classe MAJ (scope export, exclusions tracées)
+[CHANGE] ADR-003 - §6 Rate-limiting : GET+POST /api/export throttlés ; /job + /download hors-scope + justif self-service borné
+[CHANGE] RateLimitingAndHeadersIntegrationTest - +4 tests, comment POST test MAJ
+
+[DECISION] GET /api/export = 5/min/IP (aligné POST/forgot/reset, opération lourde). Bucket séparé du POST via méthode dans la clé.
+[DECISION] /job (polling léger) + /download (re-download COMPLETED, aucun recalcul) volontairement NON throttlés — self-service owner-scoped (autrui->404), résidu accepté, extension = 1 ligne si abus réel.
+
+[TEST] exportInlineGet_sixthWithinWindow_returns429 - GET 6e => 429 JSON
+[TEST] exportGetAndPost_haveIndependentBuckets - GET épuisé n'entame pas quota POST
+[TEST] exportJobPolling_isNotRateLimited - GET /job x30, jamais 429
+[TEST] exportDownload_isNotRateLimited - GET /download x30, jamais 429
+[TEST] suite backend complète : 380 run, 0 fail, ~29s (classe ciblée : 12 run, 0 fail)
+
+[REGRESSION] risque throttle polling/download écarté : match EXACT URI, /job + /download hors LIMITS. Test existant POST inchangé (comment MAJ).
+[PII] aucun log ajouté ; corps 429 générique {"error":"too_many_requests"} (pas de path/IP/jobId).
+
+STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-36/issue-265fix-done.md
+++ b/docs/memory/sprints/sprint-36/issue-265fix-done.md
@@ -1,0 +1,14 @@
+# #265 fix — bypass rate-limit par chemin encodé (audit sécurité)
+
+- commits: [SHA1 — voir git log]
+- resume:
+  - Défaut MAJEUR: `RateLimitingFilter` construisait la clé lookup LIMITS + clé bucket sur `request.getRequestURI()` BRUT (non décodé, contrat Servlet). `GET /api/%65xport` → clé `"GET /api/%65xport"` ≠ `"GET /api/export"` → throttle bypassé, alors que Spring décode et route vers `ExportController.exportInline` (recompute DB coûteux).
+  - Méthode de normalisation: `org.springframework.web.util.UrlPathHelper` (champ stateless/thread-safe) → `getPathWithinApplication(request)` décode l'URL + retire le context-path. Calcul UNE fois dans `doFilterInternal`, réutilisé pour lookup LIMITS ET clé bucket (`ip | METHOD path_décodé`). Séparation GET/POST préservée (méthode dans la clé).
+  - `throttledLimitFor()` supprimé (logique inline). Match reste EXACT: `/api/export/job/{id}` et `/download/{id}` décodés ≠ `/api/export` → toujours hors périmètre. POST auth protégés en bonus (même normalisation), limites inchangées.
+  - Test non-régression ajouté: `exportInlineGet_percentEncodedPath_isThrottled_noBypass` — `GET /api/%65xport?format=json` (via `setRequestURI` forçant l'URI brute) répété → 6e = 429 + JSON propre. Sans fix: passerait (bypass), donc échouerait.
+  - Périmètre inchangé, aucune migration, `ddl-auto=validate`. Fix confiné à `infrastructure/security/`.
+  - Tests: `./scripts/test-quiet.sh backend` → 384 passed / 0 failed. Suite complète verte.
+- [MEMORY:*] signaux:
+  - [MEMORY:pitfall] Context: matching de sécurité sur chemin HTTP. Solution: `getRequestURI()` n'est PAS décodé (contrat Servlet) → matcher sur `UrlPathHelper.getPathWithinApplication()` (décodé + context-path retiré). Prevention: toute décision (throttle/authz/allowlist) basée sur un path doit utiliser le chemin normalisé, jamais l'URI brute — sinon bypass par ré-encodage (`%65`=e), non bloqué par StrictHttpFirewall pour une lettre ordinaire.
+- recommandations suite: aucune
+- STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-36/issue-267-done.md
+++ b/docs/memory/sprints/sprint-36/issue-267-done.md
@@ -1,0 +1,30 @@
+# issue-267-done — scheduler purge exports RGPD expirés
+
+commits: [00dc7ca5480987e27e8cab6b045dd5b4bb66004f]
+
+resume:
+- OBJECTIF: purge TTL 24h des exports RGPD (fichier disque + ligne export_jobs) ; lève dette ADR-003 §3.
+- V14: `V14__idx_export_jobs_expires_at.sql` = index seul `idx_export_jobs_expires_at (expires_at)` + rollback commenté. ddl-auto=validate reste vert (index != colonne, pas de modif entité). Flyway a appliqué V14 (log "now at version v14").
+- FICHIERS CLES:
+  - port `ExportJobRepository`: + `findExpired(LocalDateTime now)` + `deleteById(UUID)`.
+  - impl `ExportJobRepositoryJpaImpl`: `findExpired` JPQL bindé (`expires_at IS NOT NULL AND < :now`, @Transactional(readOnly)); `deleteById` hérité de SimpleJpaRepository (idempotent, findById().ifPresent(delete)).
+  - `infrastructure/config/SchedulingConfig` @Configuration @EnableScheduling (1er usage projet).
+  - `application/services/ExportPurgeScheduler` @Component @Scheduled(fixedDelayString interval-ms:1h, initialDelayString:5min) @Transactional; inject `@Qualifier("exportStorage") StoragePort` + `Clock` + port repo; ordre fichier PUIS ligne; try/catch par job; log compte only (sans PII).
+  - `application.properties` + `application-dev.properties`: props `app.export.purge.interval-ms` / `initial-delay-ms` (dev: 5min/10s).
+- PITFALLS:
+  - initialDelay 5min (default) empêche l'auto-tick @Scheduled d'interférer avec les 383 tests (finissent < 5min); test dédié force initial-delay=1h.
+  - StoragePort.delete idempotent (contrat #264) -> pas de test d'existence avant delete.
+  - deleteById hérité satisfait le port sans override (erasure UUID identique).
+  - @Qualifier("exportStorage") obligatoire (2 beans StoragePort depuis #264, sinon ambiguïté au boot).
+- TESTS: `ExportPurgeSchedulerIntegrationTest` (Testcontainers, V1..V14) — 3 tests PASSED:
+  expiré COMPLETED -> fichier supprimé via exportStorage + ligne purgée ;
+  non expiré -> intact ; idempotence fichier absent -> no-op sans exception, ligne purgée.
+  Suite backend complète: Tests run 383, Failures 0, Errors 0 — BUILD SUCCESS.
+
+[MEMORY:*] signaux:
+- [MEMORY:pattern] Problem: 1er scheduler du projet. Solution: @EnableScheduling en infrastructure/config (SchedulingConfig, à côté d'AsyncConfig), tâches @Scheduled en application/services dépendant des ports; initialDelay long par défaut pour ne pas faire feu pendant la suite de tests. Anti-pattern: @EnableScheduling dans application/ ou tâche touchant l'impl JPA.
+- [MEMORY:decision] Context: purge TTL exports. Decision: ordre delete fichier PUIS ligne (crash entre les 2 = fichier orphelin traçable via ligne restante, retenté au tick suivant), try/catch par job pour isolation. Why: éviter orphelins silencieux + un job KO ne bloque pas le batch.
+
+recommandations suite: aucune (review db-expert attendue sur V14/index/balayage — déjà soignés: index dédié, rollback commenté, JPQL bindé, volume purge horaire faible).
+
+STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-36/security-audit-265.md
+++ b/docs/memory/sprints/sprint-36/security-audit-265.md
@@ -1,0 +1,25 @@
+# Audit sécurité #265 (security-expert) — Sprint 36
+
+Verdict : **CORRECTIONS_REQUISES**
+
+## [MAJEUR] Bypass rate-limit par encodage URL — RateLimitingFilter.throttledLimitFor()
+`throttledLimitFor()` compare `request.getMethod()+" "+request.getRequestURI()` littéralement.
+`getRequestURI()` n'est PAS décodé (contrat Servlet). `GET /api/%65xport?format=json` → URI brute
+`"GET /api/%65xport"` ne matche pas `"GET /api/export"` dans LIMITS → **throttle bypass total**, alors
+que Spring décode et route vers `ExportController.exportInline` (recalcul DB). StrictHttpFirewall par
+défaut ne bloque pas l'encodage d'une lettre ordinaire. Même faiblesse préexistante sur POST auth,
+mais ce commit l'étend à l'endpoint coûteux visé par #265.
+→ FIX : matcher sur chemin décodé/normalisé (UrlPathHelper.getPathWithinApplication ou décoder avant
+  lookup), PAS getRequestURI() brut. + test de non-régression path encodé.
+→ STATUT : à corriger (fullstack-dev dispatché après #267).
+
+## [MINEUR] /download non borné (ADR-003 §6) — accepté MVP
+Re-download en boucle d'un ZIP volumineux par le propriétaire : résidu IO/bande passante. Acceptable
+(dette tracée, extension 1-ligne). À monitorer en prod.
+
+## [OK] vérifiés
+- trailing slash / casse → 404 (non exploitable)
+- query string exclue de getRequestURI, bucket json/markdown partagé (testé)
+- clé bucket = ip|method path, XFF ignoré (trust-forwarded-header=false confirmé) → non spoofable
+- buckets GET/POST séparés (testé), POST forgot/reset inchangés
+- corps 429 générique, aucun log PII


### PR DESCRIPTION
## Sprint 36 — Export RGPD hardening

Durcissement de la fonctionnalité d'export RGPD asynchrone (suite de #58 / Sprint 32) : stockage dédié, rate-limit du GET coûteux, et purge TTL des exports expirés. Cohésion 0.72. **100% backend**, 4 commits fonctionnels + 1 commit artefacts.

### Issues livrées (3)

| # | Objet | Commit |
|---|-------|--------|
| #264 | Chemin de stockage dédié à l'export (`app.storage.export-path`) | `4dd436c` |
| #265 | Rate-limit du `GET /api/export` synchrone (+ fix bypass encodage URL) | `d8d0462` + `4ad929e` |
| #267 | Scheduler de purge des exports expirés (rétention 24h, V14) | `00dc7ca` |

### Changements clés

**#264 — Stockage dédié export.** Découplage des fichiers d'export des avatars : nouvelle clé `app.storage.export-path` (default dev only, **fail-fast prod** convention #34), `StorageConfig` déclare 2 beans `StoragePort` (`avatarStorage` / `exportStorage`) sur répertoires distincts, `LocalStorageAdapter` généralisé (base-path paramétré), injections désambiguïsées par `@Qualifier`. N'hérite plus des hypothèses avatar (taille max, validation image). Lève la dette ADR-003 §5.

**#265 — Rate-limit GET export.** `RateLimitingFilter` étendu du POST-only au `GET /api/export` synchrone (5/min/IP), le vecteur coûteux (requêtes DB répétées inline). Clé de bucket = `ip | METHOD path` → buckets GET/POST indépendants. Polling `/job` et re-download `/download` volontairement hors périmètre (self-service owner-scoped, tracé ADR-003 §6). **Fix sécurité** (audit) : matching sur chemin **décodé/normalisé** (`UrlPathHelper.getPathWithinApplication`) au lieu de `getRequestURI()` brut → ferme le bypass par ré-encodage (`GET /api/%65xport`).

**#267 — Scheduler de purge.** Migration **V14** `idx_export_jobs_expires_at` ; `@EnableScheduling` (1er usage projet, `SchedulingConfig`) ; `ExportPurgeScheduler` `@Scheduled` (fréquence configurable, default 1h, initialDelay 5min) balaie `export_jobs WHERE expires_at < now` → `exportStorage.delete()` **puis** suppression de la ligne (ordre anti-orphelin), try/catch par job, log sans PII. Port `ExportJobRepository.findExpired/deleteById` + impl JPA. Lève la dette ADR-003 §3.

### BR / dette impactées
- ADR-003 §3 (purge TTL) et §5 (bucket stockage dédié) : **résolues**. §6 (décision GET rate-limit) : **tracée**.
- Migrations Flyway : **V14** (index seul, `ddl-auto=validate` préservé).

### Audit tests
- **Backend : 384/384 verts, 0 failed — BUILD SUCCESS** (Testcontainers Postgres 16).
- Nouveaux tests : `StorageConfigTest` (#264), `RateLimitingAndHeadersIntegrationTest` +6 dont non-régression bypass (#265), `ExportPurgeSchedulerIntegrationTest` (#267, expiré/non-expiré/idempotence).
- Détail : `docs/memory/audits/sprint-36-test-coverage.md`.

### Revues (résolues)
- **security-expert** (#265) : MAJEUR bypass rate-limit par encodage URL → **corrigé** (`4ad929e`). MINEUR `/download` non borné → accepté MVP (ADR-003 §6).
- **db-expert** (V14) : **APPROUVE**. MINEUR index partiel → follow-up optionnel.
- **reviewer batch** : **APPROUVE**. MINEUR dead-letter purge → follow-up optionnel.

### Follow-ups proposés (arbitrage au /sprint end)
- Index partiel `idx_export_jobs_expires_at WHERE expires_at IS NOT NULL` [XS | transversal] (db-expert).
- Compteur d'échecs répétés / dead-letter pour la purge [S | transversal] (reviewer).

### Notes
- Sprint 100% backend → aucun `data-testid` nouveau, pas d'E2E requis (Phase 8 OK).
- Quirk worktree partagé : l'édition ADR-003 §5 (#264) a été committée dans `d8d0462` (#265) — contenu intact, attribution cosmétique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
