### PR TITLE
:bug: Fix 401 trompeur sur input event invalide (422 + /error public)

### DIFF
--- a/backend/src/main/java/com/matimeline/eventmanager/application/services/EventServiceImpl.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/application/services/EventServiceImpl.java
@@ -43,6 +43,10 @@ public class EventServiceImpl implements EventService {
         Product product = productRepository.findDomainProductById(command.productId())
             .orElseThrow(() -> new ProductNotFoundException(command.productId()));
 
+        // BR-EVE-002 : type ∈ {duration, single} validé côté appli -> 422 propre, plutôt
+        // que de laisser la contrainte DB ck_events_type lever une violation masquée en 401.
+        Utils.validateEventType(command.type());
+
         LocalDate startDate = (command.date() != null) ? command.date() : LocalDate.now();
 
         // PIT-S10-003 / convention create : id NULL à la création. EventEntity porte
@@ -87,6 +91,9 @@ public class EventServiceImpl implements EventService {
             event.setTitle(command.title());
         }
         if (command.type() != null) {
+            // BR-EVE-002 : même garde qu'au create — un PATCH ne peut pas basculer le type
+            // vers une valeur hors {duration, single} (sinon violation ck_events_type -> 401).
+            Utils.validateEventType(command.type());
             event.setType(command.type());
         }
         if (command.durationValue() != null) {

--- a/backend/src/main/java/com/matimeline/eventmanager/domain/exceptions/InvalidEventTypeException.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/domain/exceptions/InvalidEventTypeException.java
@@ -1,0 +1,19 @@
+package com.matimeline.eventmanager.domain.exceptions;
+
+/**
+ * Levée quand le {@code type} d'un événement n'appartient pas aux valeurs autorisées
+ * ({@code duration} / {@code single}, contrainte DB {@code ck_events_type}).
+ *
+ * <p>Symétrique de {@link InvalidDurationUnitException} : la donnée est syntaxiquement
+ * recevable (le corps JSON a bien été désérialisé, {@code @NotBlank} passe) mais
+ * sémantiquement invalide -> HTTP 422 Unprocessable Entity (mappé par
+ * {@code GlobalExceptionHandler}). Sans cette validation applicative, un {@code type}
+ * inconnu atteignait la contrainte DB et remontait en {@code DataIntegrityViolationException}
+ * non gérée, masquée en 401 par le dispatch {@code /error} (fix worktree S31).
+ */
+public class InvalidEventTypeException extends RuntimeException {
+    public InvalidEventTypeException(String type) {
+        super("Type d'événement invalide (attendu 'duration' ou 'single') : "
+                + (type == null ? "null" : type));
+    }
+}

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/GlobalExceptionHandler.java
@@ -23,6 +23,7 @@ import com.matimeline.eventmanager.domain.exceptions.ExportFormatNotSupportedExc
 import com.matimeline.eventmanager.domain.exceptions.InvalidAvatarException;
 import com.matimeline.eventmanager.domain.exceptions.InvalidCredentialsException;
 import com.matimeline.eventmanager.domain.exceptions.InvalidDurationUnitException;
+import com.matimeline.eventmanager.domain.exceptions.InvalidEventTypeException;
 import com.matimeline.eventmanager.domain.exceptions.InvalidPasswordResetTokenException;
 import com.matimeline.eventmanager.domain.exceptions.ProductNotFoundException;
 import com.matimeline.eventmanager.domain.exceptions.RecurrenceEndDateBeforeStartException;
@@ -143,6 +144,17 @@ public class GlobalExceptionHandler {
     // un message trompeur. La protection anti-race d'unicité est désormais SCOPÉE au save
     // dans CategoryServiceImpl (try/catch -> CategoryNameConflictException). Les autres
     // violations remontent normalement (500 générique) sans être masquées.
+
+    @ExceptionHandler(InvalidEventTypeException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidEventType(InvalidEventTypeException ex) {
+        // BR-EVE-002 : type hors {duration, single}. Symétrique de InvalidDurationUnit -> 422
+        // Unprocessable Entity (corps bien formé mais valeur métier invalide). Sans ce handler,
+        // la violation ck_events_type remontait en DataIntegrityViolationException non gérée,
+        // masquée en 401 par le dispatch /error.
+        return ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(buildBody(HttpStatus.UNPROCESSABLE_ENTITY, ErrorCode.UNPROCESSABLE_ENTITY, ex.getMessage()));
+    }
 
     @ExceptionHandler(InvalidDurationUnitException.class)
     public ResponseEntity<Map<String, Object>> handleInvalidDurationUnit(InvalidDurationUnitException ex) {

--- a/backend/src/main/java/com/matimeline/eventmanager/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/infrastructure/security/SecurityConfig.java
@@ -136,6 +136,11 @@ public class SecurityConfig {
                 // Seul /actuator/health est whitelisté (les autres endpoints actuator
                 // ne sont pas exposés sur le web par défaut, et resteraient authenticated).
                 .requestMatchers("/actuator/health").permitAll()
+                // Dispatch d'erreur Spring : DOIT être public. Les OncePerRequestFilter (dont
+                // jwtFilter) sautent le dispatch ERROR par défaut -> contexte de sécurité vide.
+                // Sans permitAll, TOUTE exception non gérée (500) se redispatche sur /error,
+                // échoue l'auth et ressort en 401 « unauthorized » trompeur (masque l'erreur réelle).
+                .requestMatchers("/error").permitAll()
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers("/api/users/{userId}/products/**").hasAuthority("ROLE_USER")
                 .requestMatchers("/api/products/**").hasAuthority("ROLE_USER")

--- a/backend/src/main/java/com/matimeline/eventmanager/utils/Utils.java
+++ b/backend/src/main/java/com/matimeline/eventmanager/utils/Utils.java
@@ -1,11 +1,31 @@
 package com.matimeline.eventmanager.utils;
 
 import java.time.LocalDate;
+import java.util.Set;
 
 import com.matimeline.eventmanager.application.dtos.EventCreationRequest;
 import com.matimeline.eventmanager.domain.exceptions.InvalidDurationUnitException;
+import com.matimeline.eventmanager.domain.exceptions.InvalidEventTypeException;
 
 public class Utils {
+
+    /** Valeurs de {@code type} autorisées (contrainte DB {@code ck_events_type}, V4). */
+    private static final Set<String> ALLOWED_EVENT_TYPES = Set.of("duration", "single");
+
+    /**
+     * Valide le {@code type} d'un événement AVANT la persistance (BR-EVE-002).
+     *
+     * <p>Symétrique de la validation {@code durationUnit} de {@link #calculateEndDate}. Un
+     * {@code type} null ou hors {@code duration/single} lève une {@link InvalidEventTypeException}
+     * (mappée en 422), au lieu de laisser la contrainte DB {@code ck_events_type} produire une
+     * {@code DataIntegrityViolationException} non gérée — cette dernière étant masquée en 401 par
+     * le dispatch {@code /error} (voir SecurityConfig). Appelée au create ET au PATCH (si fourni).
+     */
+    public static void validateEventType(String type) {
+        if (type == null || !ALLOWED_EVENT_TYPES.contains(type)) {
+            throw new InvalidEventTypeException(type);
+        }
+    }
 
     /**
      * Calcule l'{@code endDate} à partir d'un {@link EventCreationRequest} (façade création).

--- a/backend/src/test/java/com/matimeline/eventmanager/application/services/EventServiceImplTest.java
+++ b/backend/src/test/java/com/matimeline/eventmanager/application/services/EventServiceImplTest.java
@@ -22,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.matimeline.eventmanager.domain.exceptions.EndDateBeforeStartException;
 import com.matimeline.eventmanager.domain.exceptions.EventNotFoundException;
+import com.matimeline.eventmanager.domain.exceptions.InvalidEventTypeException;
 import com.matimeline.eventmanager.domain.exceptions.RecurrenceEndDateBeforeStartException;
 import com.matimeline.eventmanager.domain.exceptions.RecurrenceUnitRequiredException;
 import com.matimeline.eventmanager.domain.models.Event;
@@ -477,6 +478,34 @@ class EventServiceImplTest {
         Event result = eventService.createEvent(request);
 
         assertThat(result.getColor()).isNull();
+    }
+
+    // ---- BR-EVE-002 : type ∈ {duration, single} validé côté appli (422, pas 401) ----
+
+    @Test
+    void createEvent_invalidType_throwsInvalidEventType_beforePersist() {
+        // Garde-fou applicatif : un type hors {duration, single} est rejeté AVANT la contrainte
+        // DB ck_events_type. Sans lui, la DataIntegrityViolationException non gérée ressortait
+        // en 401 « unauthorized » (dispatch /error). save() ne doit jamais être atteint.
+        EventCreateCommand request = new EventCreateCommand(
+                "Bad", "pouet", 1, "days", false, null, null, null, null, productId);
+        when(productRepository.findDomainProductById(productId))
+                .thenReturn(Optional.of(new Product(productId, "P", null, null, null)));
+
+        assertThatThrownBy(() -> eventService.createEvent(request))
+                .isInstanceOf(InvalidEventTypeException.class);
+        verify(eventRepository, never()).save(any(Event.class));
+    }
+
+    @Test
+    void updateEvent_invalidType_throwsInvalidEventType() {
+        // Même garde au PATCH : impossible de basculer un event vers un type invalide.
+        EventUpdateCommand request = upd().type("pouet").build();
+        when(eventRepository.findEventById(eventId)).thenReturn(Optional.of(existingEvent));
+
+        assertThatThrownBy(() -> eventService.updateEvent(eventId, request))
+                .isInstanceOf(InvalidEventTypeException.class);
+        verify(eventRepository, never()).save(any(Event.class));
     }
 
     // ---- BR-EVE-012 (#168) : recurrenceEndDate < startDate rejetée (422) ----


### PR DESCRIPTION
## Contexte

Découvert en lançant la stack pour la **première fois** (smoke test du parcours cœur : register → login → produit → event → timeline). Le parcours fonctionne end-to-end, mais un `type` d'event invalide renvoyait **HTTP 401 `unauthorized`** au lieu d'un 4xx métier — un client croirait sa session expirée sur une simple faute de saisie.

## Deux causes

- **Cause A** — `type` validé seulement `@NotBlank` côté appli (aucun contrôle contre l'enum `{duration, single}`). La contrainte DB `ck_events_type` était le seul garde-fou → `DataIntegrityViolationException` non gérée.
- **Cause B** (systémique) — `.anyRequest().authenticated()` couvre aussi `/error` ; les `OncePerRequestFilter` (dont `jwtFilter`) sautent le dispatch ERROR → contexte de sécurité vide → **toute exception non gérée ressort en 401** au lieu de son vrai statut. Masquait potentiellement toutes les erreurs serveur.

## Fix

| Fichier | Changement |
|---|---|
| `InvalidEventTypeException` *(nouveau)* | exception domaine, miroir de `InvalidDurationUnitException` |
| `Utils.validateEventType()` | rejette hors `{duration, single}` |
| `EventServiceImpl` | validation au create **et** au PATCH |
| `GlobalExceptionHandler` | handler → **422** `unprocessable_entity` |
| `SecurityConfig` | `/error` en `permitAll` (fix B) |
| `EventServiceImplTest` | 2 tests de régression |

## Vérification

- ✅ **Runtime** (stack Docker live) : `type` invalide → **422** (message clair), `type` valide → **201**
- ✅ **Unit** : EventServiceImplTest **27/27**, UtilsTest **7/7**, GlobalExceptionHandler **3/3**
- ✅ **Non-régression** : chaîne register→login→me→category→product→event aux bons codes après le changement SecurityConfig
- ⚠️ Suite backend complète (~400 tests, intégration Testcontainers) **non jouée en local** → laissée à la CI
- ⚠️ Fix B non déclenché en isolation (le fix A court-circuite le chemin event) ; validité par mécanisme + non-régression de la chaîne auth

## Notes

- Choix **422** (vs 400) aligné sur le sibling `durationUnit`. Discutable pour un enum invalide.
- Follow-up possible : test dédié « endpoint qui throw → 500 (pas 401) » pour couvrir le fix B directement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)