### PR TITLE
Sprint 41 — UX & a11y Timeline (accordéon produit + cibles tactiles + clavier)

### DIFF
--- a/.claude/rules-jit/ux-patterns.md
+++ b/.claude/rules-jit/ux-patterns.md
@@ -97,7 +97,7 @@ ne sont pas couverts par un test unitaire dédié.
 
 ---
 
-## 5. Raccourcis clavier globaux — [LIVRÉ] (sauf `?`)
+## 5. Raccourcis clavier globaux — [LIVRÉ]
 
 Handler `keydown` sur `window`. Gardes :
 - ignore si un champ a le focus (`INPUT` / `TEXTAREA` / `isContentEditable`) ;
@@ -114,13 +114,12 @@ Handler `keydown` sur `window`. Gardes :
 | `-` | zoom arrière | [LIVRÉ] |
 | `F` / `f` | plein écran (toggle) | [LIVRÉ] |
 | `Échap` | ferme le drawer (priorité), sinon sort du plein écran | [LIVRÉ] |
-| `?` | ouvrir l'aide raccourcis | **[PRÉVU]** — voir ci-dessous |
 
-**`?` (aide) — [PRÉVU / NON IMPLÉMENTÉ AU CLAVIER]** :
-il n'existe PAS de `case '?'` dans le handler global. L'aide est un **tooltip**
+**Aide raccourcis — hover/focus-only PAR DÉCISION (option B, S41 #227)** :
+`?` n'est **PAS** un raccourci clavier et il n'existe volontairement PAS de
+`case '?'` dans le handler global. La surface d'aide est un **tooltip**
 (`.mt-tlv__help-pop`, `role="tooltip"`) affiché au **hover/focus** du bouton `?`
-de la toolbar — pas de dialog déclenché par la touche `?`. Écart formel avec le
-Sprint 17 (raccourci `?` listé). Suivi : cf. §9 (RECOMMAND_FOLLOWUP).
+de la toolbar. Ce choix est acté (pas d'écart, pas de dialog déclenché au clavier).
 
 Réf. code : `TimelineView.tsx` `useEffect(onKey …)` + bloc `.mt-tlv__help`.
 Réf. test : « le raccourci "+" zoome », « le raccourci "F" ne hijacke pas Cmd/Ctrl+F ».
@@ -168,10 +167,10 @@ Réf. test : « le bloc event expose un aria-label riche », bloc « garde-fou c
 
 ## 9. Écarts connus vs code livré #81 & suivi
 
-- **`?` non câblé au clavier** (§5) : aide en tooltip hover/focus uniquement.
-  → RECOMMAND_FOLLOWUP : câbler `case '?'` (ouvrir le pop d'aide) OU acter
-    officiellement l'aide « hover/focus only » et retirer `?` de la liste des
-    raccourcis annoncés.
+- **Aide `?` — TRANCHÉ (option B actée, S41 #227)** : l'aide reste en tooltip
+  hover/focus uniquement (`.mt-tlv__help-pop`) PAR DÉCISION. `?` n'est pas un
+  raccourci clavier et a été retiré de la liste des raccourcis (§5). Pas de
+  `case '?'` à câbler, pas de follow-up ouvert.
 - **`EventPill.tsx:100`** — `<span aria-hidden="true">{event.title}</span>` reste
   `aria-hidden` **même quand c'est le seul texte visible** (cas contraste OK, pas
   de libellé extérieur). Aujourd'hui inoffensif : l'`aria-label` du bouton couvre

--- a/docs/memory/audits/sprint-41-test-coverage.md
+++ b/docs/memory/audits/sprint-41-test-coverage.md
@@ -1,0 +1,33 @@
+# Audit tests — Sprint 41
+
+> Généré en fin de Phase 6 (test-runner). Un marqueur de gap non couvert bloquerait la Phase 9 PR.
+> Sprint UX & a11y Timeline — **aucune BR métier nouvelle** (complète BR-EVE d'affichage, cf. issues). La matrice porte donc sur les **critères d'acceptation a11y/UX** plutôt que des BR-XX.
+
+## Couverture par critère (a11y/UX Timeline)
+
+| Issue | Critère | Cross-system flow | Unit frontend | E2E parcours | E2E métier |
+|-------|---------|:---:|:---:|:---:|:---:|
+| #226 | Cible tactile `.mt-zoom__btn` ≥44×44px mobile, desktop inchangé | NON | ⚠ N/A (pseudo `::before` non testable jsdom, PAT-S24-002) — vérif inspection CSS | ⊘ non requis | N/A |
+| #228 | `aria-hidden` conditionnel EventPill (retiré si `readableInside`) | NON | ✅ EventPill.test.tsx (+2 : démasque si contraste AA, garde sinon) | ⊘ | N/A |
+| #228 | Couverture clavier §9 (←/→ inter-lanes, trap Tab drawer + restauration focus, `T`/`[`/`]`/`-`) | NON | ✅ TimelineView.test.tsx (+5, §9) | ⊘ | N/A |
+| #195 | Accordéon collapse par produit (indépendance, scroll conservé, clavier/focus cohérent) | NON | ✅ TimelineView.test.tsx (+3 : indépendance, scroll, clavier) | ⚠ nouveau testid `timeline-resource-head` sans spec E2E → Phase 8 | N/A |
+| #227 | Option B actée : `?` retiré du référentiel, aide hover/focus-only | NON | ⊘ (doc-only) | ⊘ | N/A |
+
+Cross-system flow=NON pour tout le sprint (100% frontend/doc, aucun flux 2+ systèmes/rôles) → **E2E métier non requis** (règle : obligatoire seulement si cross-system flow=OUI).
+
+## Tests créés
+- `frontend/src/components/timeline/EventPill.test.tsx` — +2 tests (aria-hidden conditionnel, #228)
+- `frontend/src/components/timeline/TimelineView.test.tsx` — +5 tests clavier §9 (#228) + 3 tests accordéon produit (#195)
+- #226 : pas de test unitaire (pseudo-élément non testable jsdom, PAT-S24-002 — vérif par inspection CSS)
+- #227 : aucun test (doc-only)
+
+## Résultats runs (test-runner Phase 6, depuis worktree sprint/41)
+- Frontend (Vitest) : **62 fichiers / 456 tests, 456 passed, 0 failed**, 0 erreur TypeScript
+- Backend : non lancé (aucun changement backend ce sprint)
+- E2E Playwright : non lancé (nécessite stack complète ; couverture des nouveaux testid → Phase 8 post-merge)
+- Régression ciblée : tests clavier §9 (#228) = 31/31 ✓ ; accordéon produit (#195) ✓
+- Warning stderr non bloquant : `Missing aria-describedby on DialogContent` — pré-existant, hors scope Sprint 41.
+
+## Conclusion
+**Prêt pour PR.** Suite frontend verte, aucune BR métier impactée, aucun gap de couverture bloquant.
+Follow-up non bloquant : couverture E2E du nouveau `data-testid="timeline-resource-head"` (#195) → `/create-e2e` post-merge (Phase 8).

--- a/docs/memory/sprint-history.md
+++ b/docs/memory/sprint-history.md
@@ -889,14 +889,14 @@
 **Saturation contexte lead (mesure) :** non instrumentée cette session (orchestration + 2 tours review + CI dans une seule session lead).
 **Status :** Terminé.
 
-## Sprint 41 — 2026-07-13 (PLANIFIÉ — cohésion 0.66, UX & a11y Timeline)
+## Sprint 41 — 2026-07-13 (EN COURS — cohésion 0.66, UX & a11y Timeline)
 **Objectif :** UX timeline (accordéon collapse par produit) + a11y (cibles tactiles, aria, clavier).
 **Milestone GitHub :** #41
 **Issues :** #195, #226, #228, #227
 **Vagues :** V1 = #226 ∥ #228 | V2 = #195 → #227 (convergent sur handler clavier TimelineView.tsx)
 **Migrations :** aucune
 **Dépend de :** aucune (S40 shell recommandé, non bloquant)
-**Status :** Planifié — #227 : dev a tranché **option B** (aide hover-only, retirer le raccourci `?` du référentiel ux-patterns.md, pas de code timeline). #227 = tooltip d'aide déjà existant (possibly_done partiel).
+**Status :** En cours (démarré 2026-07-13, branche `sprint/41`) — #227 : dev a tranché **option B** (aide hover-only, retirer le raccourci `?` du référentiel ux-patterns.md, pas de code timeline). #227 = tooltip d'aide déjà existant (possibly_done partiel).
 
 ## Sprint 42 — 2026-07-13 (PLANIFIÉ — cohésion 0.60, Modale conflit 409)
 **Objectif :** Modale de conflit comparative sur 409 optimistic-lock (corps backend enrichi + diff serveur/local) + E2E.

--- a/docs/memory/sprints/sprint-41/issue-195-done.md
+++ b/docs/memory/sprints/sprint-41/issue-195-done.md
@@ -1,0 +1,16 @@
+# Issue #195 — accordéon collapse par produit
+
+RETOUR :
+- commits: [deabd414749018e5111546c503d6545db746abe3]
+- resume: >
+    2e niveau accordéon (produit) imbriqué dans collapse catégorie.
+    Fichiers: TimelineView.tsx (état+rendu), timeline.css (styles toggle), TimelineView.test.tsx (+3 tests).
+    État: `collapsedResources: Record<resource.id, boolean>` indépendant de `collapsed` (catégorie) et des autres produits.
+    Rendu: label produit sticky `<span>` → `<button.mt-tlv__lane-label.mt-tlv__lane-head>` mirror de `mt-tlv__group-head` (chevron `mt-tlv__chev`/`--open`, aria-expanded, clavier natif bouton). testid `timeline-resource-head` sur bouton, `timeline-resource-title` conservé sur span interne. Pastilles non rendues si produit replié (label+toggle restent).
+    Nav/focus: `navLanes` saute aussi les ressources repliées (comme catégories) → ←→↑↓ + roving resource-keyé cohérents, tabIndex=0 unique.
+    Scroll: aucun mécanisme explicite (parité catégorie) — pur re-rendu React, conteneur garde scrollLeft/Top.
+    Tests: collapse produit indépendant / scroll conservé / clavier-focus cohérent. Suite frontend 456/456 verte. tsc --noEmit clean.
+- [MEMORY:*] signaux:
+    [MEMORY:pattern] Problem: 2e niveau accordéon imbriqué timeline. Solution: réutiliser STRICTEMENT le pattern catégorie (bouton natif aria-expanded + chevron DS + exclusion de la liste de nav clavier `navLanes`), état keyé par resource.id. Anti-pattern: état keyé par index de lane (glisse au collapse — cf MAJEUR-2 #81) ; hook scroll custom (inutile, le re-rendu React préserve le scroll comme pour la catégorie).
+- recommandations suite: aucune
+- STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-41/issue-195-fix-reviewpr-done.md
+++ b/docs/memory/sprints/sprint-41/issue-195-fix-reviewpr-done.md
@@ -1,0 +1,12 @@
+# Issue #195 — Fix review-pr PR #303 (2 MINEUR)
+
+RETOUR :
+- commits: bf30779b4c869a779e693f087e9c0156d9f19568
+- resume:
+  - [FIX-1] timeline.css:123 `.mt-tlv__lane-head-text` — ajout `min-width:0; flex:1 1 auto;`. Flex item ne rétrécit pas sous largeur contenu (min-width:auto défaut) → ellipsis jamais déclenchée, titre long hard-clippé par parent max-width:160px. Grep : 2 usages seulement (CSS + 1 span TSX l.633), aucun autre cassé.
+  - [FIX-2] TimelineView.tsx — `npx prettier --write` (script `format` = prettier). Ré-indentation pure corps callback `laneEvents.map` sous wrap `{!isResCollapsed && ...}`. Diff 24/24 lignes, zéro changement fonctionnel (vérifié).
+  - [TESTS] `./scripts/test-quiet.sh frontend` depuis worktree → 456/456 VERT (62 fichiers). Pas de régression.
+- [MEMORY:pitfall] Context: flex item avec overflow:hidden+text-overflow:ellipsis dans conteneur inline-flex/flex. Solution: ajouter `min-width:0` (défaut min-width:auto empêche rétrécissement sous largeur contenu). Prevention: tout enfant flex qui doit tronquer en ellipsis exige min-width:0 (piège récurrent flexbox).
+- recommandations suite: aucune (E2E timeline-resource-head = follow-up post-merge déjà arbitré par lead).
+
+STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-41/issue-226-done.md
+++ b/docs/memory/sprints/sprint-41/issue-226-done.md
@@ -1,0 +1,16 @@
+# Issue #226 — a11y cible tactile ≥44px zoom mobile
+
+RETOUR :
+- commits: [85d1d30e6cf6f53caf57afec3a81df99054a358b]
+- resume:
+  - Objectif: `.mt-zoom__btn` cible tactile ≥44×44px WCAG 2.5.5 sur mobile touch, desktop inchangé.
+  - Fichier clé REEL: `frontend/src/styles/ds/components/timeline.css` (~l.172, section #63 mobile). NB: chemin briefing `components/timeline/timeline.css` PERIME.
+  - Approche CSS: override scoped `.mt-tlm .mt-zoom__btn{position:relative; min-height:44px;}` + `::before` 44×44 centré hors flux (PAT-S24-002). Icône font-size inchangée, flex du groupe intact.
+  - Portée: `.mt-tlm` = racine portrait ET paysage (`TimelineMobileLandscape` = `class="mt-tlm mt-tlm--landscape"`) → couvre les 2 vues mobiles d'une seule règle.
+  - Desktop inchangé: `TimelineView` (desktop) n'a AUCUN ancêtre `.mt-tlm`; `.mt-zoom__btn` global (l.58) reste 30px. Vérifié par lecture des 3 composants.
+  - Non-chevauchement: les 2 hitboxes 44px séparées par `.mt-zoom__level` (centres ~15px et ~95px → gap ~36px, pas d'overlap mutuel). Débord latéral ~7px dans padding toolbar (espace vide, non interactif).
+  - Tests: `./scripts/test-quiet.sh frontend` → 62 fichiers / 446 tests OK. Pseudo-élément non testable jsdom (vérif par inspection CSS, conforme note PAT-S24-002).
+- [MEMORY:*] signaux:
+  - [MEMORY:pitfall] Context: briefing #226 pointait `frontend/src/components/timeline/timeline.css`. Solution: fichier réel = `frontend/src/styles/ds/components/timeline.css`. Prevention: le CSS timeline vit dans le DS (`src/styles/ds/components/`), pas à côté des .tsx.
+- recommandations suite: aucune
+- STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-41/issue-226-fix-review-done.md
+++ b/docs/memory/sprints/sprint-41/issue-226-fix-review-done.md
@@ -1,0 +1,42 @@
+# S41 — Correction review (#226 MAJEUR + #228 #195 MINEURs)
+
+RETOUR :
+
+- commits: 8de39ce95d0e1170cbd8975fad9773b37920aa41
+
+- resume:
+  - [MAJEUR #226] `timeline.css` l.180-206. BUG confirmé : `::before` 44×44 centré
+    sur bouton 30px déborde de 7px/côté ; le groupe `.mt-zoom` a `overflow:hidden`
+    (arrondi desktop) → 7px extérieurs des boutons de BORD (1er=gauche, dernier=droit)
+    clippés → cible réelle ~37×44px. Fix retenu : `.mt-tlm .mt-zoom{overflow:visible}`
+    (scopé mobile uniquement, desktop reste `overflow:hidden`) + réarrondi
+    `:first-child`/`:last-child` à `--radius-md` (7px) pour préserver silhouette
+    (sinon fond hover carré déborde). `::before` transparent → aucun rendu nouveau.
+    Vérif géométrique : bouton W=30, `::before` W=44 → +7px/côté = 44px pleine
+    largeur des DEUX boutons libérée. Bord gauche : `::before` left ≈ tlm_inner
+    + padding `--space-3`(12) + border groupe(1) − 7 = tlm_inner + 6px → reste
+    DANS `.mt-tlm` → pas de re-clip par `overflow:hidden` de `.mt-tlm`. Bord droit :
+    groupe `inline-flex` (largeur contenu), loin du bord droit de `.mt-tlm` → OK.
+    Commentaire trompeur "les deux hitboxes ne se chevauchent pas" remplacé par la
+    vraie cause (clip extérieur) + note PIT.
+  - [MINEUR #228] `EventPill.tsx` l.98-107. Commentaire réécrit : l'`aria-label` du
+    bouton prime TOUJOURS → démasquer le span ne change pas l'annonce (pas de double
+    lecture dans les 2 cas) ; la bascule sert la cohérence sémantique DOM (texte
+    visible non masqué à tort) + Label-in-Name WCAG 2.5.3. Code inchangé.
+  - [MINEUR #195] `TimelineView.tsx` l.629. Chevron produit `size={12}` → `size={13}`
+    (= chevron catégorie, cohérence accordéon mirroré).
+
+- Tests : `./scripts/test-quiet.sh frontend` → 62 fichiers, 456/456 verts (0 régression).
+  `::before` non calculable jsdom → MAJEUR vérifié par inspection CSS/géométrie ci-dessus.
+
+- [MEMORY:pitfall] Context: PAT-S24-002 (hitbox a11y `::before` 44×44 hors flux).
+  Solution: un ancêtre avec `overflow:hidden` (ex `.mt-zoom` arrondi) CLIPPE le
+  débordement du `::before` sur les éléments de bord → cible tactile réelle < 44px.
+  Prevention: quand PAT-S24-002 s'applique dans un conteneur clippé, passer le
+  conteneur en `overflow:visible` (scopé) + réarrondir les coins des enfants de bord
+  pour garder l'arrondi visuel ; vérifier géométriquement que le débordement tient
+  dans le padding des ancêtres clippants restants.
+
+- recommandations suite: aucune.
+
+STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-41/issue-227-done.md
+++ b/docs/memory/sprints/sprint-41/issue-227-done.md
@@ -1,0 +1,10 @@
+# Issue #227 — RETOUR
+
+RETOUR :
+- commits: [0a0d1c3caf77783a3f0fbacb2ed4dedbf176b1ef]
+- resume: Option B actée (aide timeline hover/focus-only). `.claude/rules-jit/ux-patterns.md` modifié — §5 titre (retiré `(sauf ?)`), ligne table `| ? | ... [PRÉVU] |` supprimée, paragraphe `?` reformulé en décision actée (tooltip `.mt-tlv__help-pop` = surface d'aide, `?` PAS un raccourci), §9 entrée reformulée RÉSOLU (plus de RECOMMAND_FOLLOWUP, plus de "câbler OU acter"). Mentions `aria-describedby`/`#timeline-region-desc` (§1) INTACTES. AUCUN code timeline touché.
+- confirmation UI: grep `frontend/src/components/timeline/` — 0 `aria-keyshortcuts`, 0 `case '?'`. `shortcuts[]` (TimelineView.tsx:415) = [T, [ ], + −, F, Échap], PAS de `?`. Le bouton `?` toolbar est un trigger tooltip hover/focus, pas un raccourci clavier. Doc↔code↔UI cohérents. Rien à changer côté UI.
+- [MEMORY:decision] DEC-S41-227: Contexte=raccourci `?` listé mais jamais câblé (écart doc↔code). Décision=OPTION B — aide frise reste hover/focus-only via tooltip `.mt-tlv__help-pop` (role=tooltip, aria-describedby). Why=`?` non implémenté au clavier, tooltip déjà fonctionnel et conforme ; on aligne le référentiel sur le code plutôt que d'ajouter un handler. `?` retiré de la liste des raccourcis.
+- recommandations suite: aucune
+
+STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-41/issue-228-done.md
+++ b/docs/memory/sprints/sprint-41/issue-228-done.md
@@ -1,0 +1,38 @@
+# Issue #228 — RETOUR
+
+RETOUR :
+- commits: [à compléter après commit]
+- resume:
+  - Objectif: a11y EventPill (aria-hidden conditionnel) + combler 3 lacunes clavier §9.
+  - Fichiers clés:
+    - `frontend/src/components/timeline/EventPill.tsx` (l.100 span titre).
+    - `frontend/src/components/timeline/EventPill.test.tsx` (+2 tests aria-hidden).
+    - `frontend/src/components/timeline/TimelineView.test.tsx` (+5 tests §9).
+  - Décision aria-hidden vs aria-label:
+    - `aria-hidden={readableInside ? undefined : true}`.
+    - readableInside vrai → span titre DÉMASQUÉ (seul rendu visible). PAS de double
+      annonce: l'`aria-label` du bouton prime sur le sous-arbre (nom accessible) ET
+      contient le titre → Label-in-Name (WCAG 2.5.3) satisfait, lisibilité améliorée.
+    - readableInside faux → titre répété dehors (garde-fou #81) → span interne
+      décoratif → aria-hidden conservé.
+  - Tests ajoutés:
+    - EventPill: démasque si contraste AA dedans; garde aria-hidden sinon.
+    - TimelineView §9: ←/→ inter-lanes; Tab/Shift+Tab trap drawer + restauration
+      focus déclencheur; raccourci "-" (zoom); "["/"]" (offset scroll 360/0); "T"
+      (recentrage today, scroll 420).
+  - INTERDICTION respectée: TimelineView.tsx SOURCE non modifié (réservé #195).
+    Tests reflètent le comportement clavier ACTUEL (garde-fou non-régression).
+  - Suite frontend worktree: 62 fichiers / 453 tests VERTS.
+- [MEMORY:*] signaux:
+  - [MEMORY:pattern] Problem: bouton a11y avec aria-label agrégé + texte visible.
+    Solution: aria-hidden conditionnel sur le texte — le masquer SEULEMENT s'il est
+    redondant (dupliqué ailleurs). aria-label prime → pas de double annonce, et
+    Label-in-Name exige que l'aria-label contienne le texte visible.
+    Anti-pattern: aria-hidden permanent sur l'unique rendu visible du libellé.
+  - [MEMORY:pitfall] Context: full suite lancée depuis repo principal (cwd) au lieu
+    du worktree → faux échec (eslint-plugin-storybook absent des node_modules du
+    repo principal). Prevention: toujours ./scripts/test-quiet.sh depuis le worktree.
+- recommandations suite: aucune (TimelineView.tsx SOURCE inchangé; #195 pourra
+  s'appuyer sur ces tests clavier comme garde-fou de non-régression).
+
+STATUS: COMPLETED

--- a/frontend/src/components/timeline/EventPill.test.tsx
+++ b/frontend/src/components/timeline/EventPill.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { EventPill } from './EventPill'
@@ -82,5 +82,43 @@ describe('EventPill', () => {
     )
     const pill = screen.getByTestId('timeline-event')
     expect(pill.style.getPropertyValue('--mt-evt-ink')).toBe(INK_LIGHT)
+  })
+
+  // ==================== #228 — aria-hidden conditionnel ====================
+  // Le span titre interne ne doit PAS rester masqué aux lecteurs d'écran quand
+  // il est le SEUL rendu visible du titre (readableInside). Il ne redevient
+  // décoratif (aria-hidden) que lorsque le titre est répété en libellé extérieur.
+  describe('#228 aria-hidden conditionnel sur le span titre', () => {
+    it('DÉMASQUE le span titre quand le contraste passe AA dedans (readableInside)', () => {
+      // #3B62D4 → contraste ≥ 4.5:1 dedans → titre lisible DANS la barre, seul visible.
+      render(
+        <EventPill
+          event={makePositionedEvent({ color: '#3B62D4' })}
+          ariaLabel="x"
+          onSelect={() => {}}
+        />,
+      )
+      const pill = screen.getByTestId('timeline-event')
+      const titleSpan = within(pill).getByText('Péremption')
+      expect(titleSpan).not.toHaveAttribute('aria-hidden')
+      // Pas de libellé extérieur : le titre tient (lisible) dans la barre.
+      expect(screen.queryByTestId('timeline-event-outside-label')).not.toBeInTheDocument()
+    })
+
+    it('GARDE aria-hidden sur le span titre quand le contraste échoue dedans (libellé répété dehors)', () => {
+      // #6366f1 → max 4.47:1 < AA → titre répété DEHORS → span interne décoratif.
+      render(
+        <EventPill
+          event={makePositionedEvent({ color: '#6366f1' })}
+          ariaLabel="x"
+          onSelect={() => {}}
+        />,
+      )
+      const pill = screen.getByTestId('timeline-event')
+      const titleSpan = within(pill).getByText('Péremption')
+      expect(titleSpan).toHaveAttribute('aria-hidden', 'true')
+      // Libellé extérieur présent (garde-fou #81) → titre non perdu visuellement.
+      expect(screen.getByTestId('timeline-event-outside-label')).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/components/timeline/EventPill.tsx
+++ b/frontend/src/components/timeline/EventPill.tsx
@@ -95,13 +95,16 @@ export const EventPill: React.FC<EventPillProps> = ({
           style={{ background: statusVar }}
           aria-hidden="true"
         />
-        {/* Titre interne. `aria-hidden` CONDITIONNEL (#228) :
+        {/* Titre interne. `aria-hidden` CONDITIONNEL (#228). Le nom accessible du
+            bouton vient TOUJOURS de son `aria-label` (il prime sur le sous-arbre) →
+            démasquer ce span ne change PAS l'annonce vocale : pas de double lecture
+            dans les deux cas. La bascule sert la COHÉRENCE sémantique du DOM (le
+            texte visible n'est pas masqué à tort), pas le rendu lecteur d'écran :
             - `readableInside` vrai → ce span est le SEUL rendu visible du titre →
-              on le DÉMASQUE aux lecteurs d'écran. Pas de double annonce : l'`aria-label`
-              du bouton fournit le nom accessible (il PRIME sur le sous-arbre) et
-              contient déjà le titre → Label-in-Name (WCAG 2.5.3) satisfait.
+              on le laisse non masqué (aria-hidden absent). Le texte visible est
+              inclus dans l'`aria-label` du bouton → Label-in-Name (WCAG 2.5.3) OK.
             - `readableInside` faux → le titre est répété DEHORS (garde-fou contraste
-              #81) → ce span interne est purement décoratif → `aria-hidden`. */}
+              #81) → ce span interne devient purement décoratif → `aria-hidden`. */}
         <span aria-hidden={readableInside ? undefined : true}>{event.title}</span>
       </button>
       {/* #81 point 6 — libellé extérieur de secours si contraste < 4.5:1 dedans.

--- a/frontend/src/components/timeline/EventPill.tsx
+++ b/frontend/src/components/timeline/EventPill.tsx
@@ -95,9 +95,14 @@ export const EventPill: React.FC<EventPillProps> = ({
           style={{ background: statusVar }}
           aria-hidden="true"
         />
-        {/* Titre interne : masqué aux lecteurs d'écran (l'aria-label du bouton
-            porte déjà le titre) ; décoratif si illisible (garde-fou dehors). */}
-        <span aria-hidden="true">{event.title}</span>
+        {/* Titre interne. `aria-hidden` CONDITIONNEL (#228) :
+            - `readableInside` vrai → ce span est le SEUL rendu visible du titre →
+              on le DÉMASQUE aux lecteurs d'écran. Pas de double annonce : l'`aria-label`
+              du bouton fournit le nom accessible (il PRIME sur le sous-arbre) et
+              contient déjà le titre → Label-in-Name (WCAG 2.5.3) satisfait.
+            - `readableInside` faux → le titre est répété DEHORS (garde-fou contraste
+              #81) → ce span interne est purement décoratif → `aria-hidden`. */}
+        <span aria-hidden={readableInside ? undefined : true}>{event.title}</span>
       </button>
       {/* #81 point 6 — libellé extérieur de secours si contraste < 4.5:1 dedans.
           Décoratif (aria-hidden) : le bouton porte déjà l'annonce vocale complète. */}

--- a/frontend/src/components/timeline/TimelineView.test.tsx
+++ b/frontend/src/components/timeline/TimelineView.test.tsx
@@ -457,7 +457,6 @@ describe('TimelineView', () => {
     })
 
     it('raccourcis "[" / "]" décalent la fenêtre (période précédente / suivante)', async () => {
-      const user = userEvent.setup()
       setup()
       const scroll = screen.getByTestId('timeline-scroll')
       // ] = NEXT_PERIOD : offsetDays += 30 (niveau month) → scrollLeft = 30 × 12px = 360.

--- a/frontend/src/components/timeline/TimelineView.test.tsx
+++ b/frontend/src/components/timeline/TimelineView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import type { FullCalendarEvent } from '@/types/event'
@@ -397,6 +397,87 @@ describe('TimelineView', () => {
     it('ne rend PAS de libellé extérieur quand le contraste passe AA dedans', () => {
       setup() // events #3B62D4 (5.41) et #4FA459 → lisibles dedans
       expect(screen.queryByTestId('timeline-event-outside-label')).not.toBeInTheDocument()
+    })
+  })
+
+  // ==================== #228 — couverture clavier §9 ====================
+  // Compléments de couverture repérés en ux-patterns.md §9. Ces tests reflètent
+  // le comportement clavier ACTUEL (garde-fou de non-régression avant #195) :
+  //  1. ← / → navigation INTER-lanes (débordement en bord de lane) ;
+  //  2. cyclage Tab/Shift+Tab dans le drawer + restauration du focus déclencheur ;
+  //  3. raccourcis globaux T / [ / ] / -.
+  describe('#228 couverture clavier §9', () => {
+    it('← / → naviguent ENTRE les lanes (débordement en bord de lane)', async () => {
+      const user = userEvent.setup()
+      setup()
+      const pills = screen.getAllByTestId('timeline-event')
+      // 2 lanes, 1 pastille chacune (e1 lane0, e2 lane1). En bord de lane, → passe
+      // à la 1re pastille de la lane suivante ; ← revient à la dernière précédente.
+      pills[0].focus()
+      await user.keyboard('{ArrowRight}')
+      expect(pills[1]).toHaveFocus()
+      await user.keyboard('{ArrowLeft}')
+      expect(pills[0]).toHaveFocus()
+    })
+
+    it('drawer : Tab/Shift+Tab piègent le focus + restauration du focus déclencheur à la fermeture', async () => {
+      const user = userEvent.setup()
+      setup()
+      const trigger = screen.getAllByTestId('timeline-event')[0]
+      // Ouvre le drawer au clavier depuis la pastille (elle devient le déclencheur).
+      trigger.focus()
+      await user.keyboard('{Enter}')
+      await screen.findByTestId('timeline-drawer')
+
+      // Focus initial déplacé sur le 1er focusable du panneau (bouton fermer).
+      const close = screen.getByTestId('timeline-drawer-close')
+      expect(close).toHaveFocus()
+
+      // Trap : le bouton fermer est le SEUL focusable du drawer → Tab et Shift+Tab
+      // bouclent et gardent le focus dans le panneau (jamais sur la frise derrière).
+      await user.keyboard('{Tab}')
+      expect(close).toHaveFocus()
+      await user.keyboard('{Shift>}{Tab}{/Shift}')
+      expect(close).toHaveFocus()
+
+      // Fermeture (Échap) → le focus revient sur la pastille déclencheuse.
+      await user.keyboard('{Escape}')
+      await waitFor(() => expect(screen.queryByTestId('timeline-drawer')).not.toBeInTheDocument())
+      expect(trigger).toHaveFocus()
+    })
+
+    it('raccourci "-" dézoome (change le niveau affiché)', async () => {
+      const user = userEvent.setup()
+      setup()
+      const level = screen.getByTestId('timeline-zoom-level')
+      const before = level.textContent // niveau initial = "month"
+      await user.keyboard('-')
+      // ZOOM_OUT : month → quarter → le libellé de niveau change.
+      await waitFor(() => expect(level.textContent).not.toBe(before))
+    })
+
+    it('raccourcis "[" / "]" décalent la fenêtre (période précédente / suivante)', async () => {
+      const user = userEvent.setup()
+      setup()
+      const scroll = screen.getByTestId('timeline-scroll')
+      // ] = NEXT_PERIOD : offsetDays += 30 (niveau month) → scrollLeft = 30 × 12px = 360.
+      fireEvent.keyDown(window, { key: ']' })
+      await waitFor(() => expect(scroll.scrollLeft).toBe(360))
+      // [ = PREV_PERIOD : offsetDays revient à 0 → scrollLeft = 0.
+      fireEvent.keyDown(window, { key: '[' })
+      await waitFor(() => expect(scroll.scrollLeft).toBe(0))
+    })
+
+    it('raccourci "T" recentre la fenêtre sur aujourd’hui', async () => {
+      const user = userEvent.setup()
+      setup()
+      const scroll = screen.getByTestId('timeline-scroll')
+      // On éloigne d'abord la vue (] → offset 30 → scrollLeft 360).
+      fireEvent.keyDown(window, { key: ']' })
+      await waitFor(() => expect(scroll.scrollLeft).toBe(360))
+      // T = GO_TO_TODAY : offset = jours(rangeStart→today) = 35 → scrollLeft = 35 × 12 = 420.
+      await user.keyboard('t')
+      await waitFor(() => expect(scroll.scrollLeft).toBe(420))
     })
   })
 })

--- a/frontend/src/components/timeline/TimelineView.test.tsx
+++ b/frontend/src/components/timeline/TimelineView.test.tsx
@@ -480,4 +480,86 @@ describe('TimelineView', () => {
       await waitFor(() => expect(scroll.scrollLeft).toBe(420))
     })
   })
+
+  // ==================== #195 — accordéon collapse produit ====================
+  // 2e niveau d'accordéon imbriqué dans le collapse catégorie. Critères
+  // d'acceptation : collapse produit indépendant ; scroll conservé ; clavier/focus
+  // cohérent avec le pattern accordéon catégorie déjà en place.
+  describe('#195 accordéon collapse produit', () => {
+    it('replie un produit indépendamment (masque ses events, sans toucher les autres produits ni la catégorie)', async () => {
+      const user = userEvent.setup()
+      setup() // p1 (cat Frais) + p2 (cat Boulangerie), 1 event chacun
+      expect(screen.getAllByTestId('timeline-event')).toHaveLength(2)
+
+      const heads = screen.getAllByTestId('timeline-resource-head')
+      expect(heads).toHaveLength(2)
+      // État initial : les deux produits sont dépliés.
+      expect(heads[0]).toHaveAttribute('aria-expanded', 'true')
+      expect(heads[1]).toHaveAttribute('aria-expanded', 'true')
+
+      // Replie le 1er produit (p1 → event e1 masqué).
+      await user.click(heads[0])
+      await waitFor(() => expect(screen.getAllByTestId('timeline-event')).toHaveLength(1))
+
+      // Le produit replié : aria-expanded=false, mais son label/toggle reste rendu.
+      expect(screen.getAllByTestId('timeline-resource-head')[0]).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      )
+      expect(screen.getAllByTestId('timeline-resource-row')).toHaveLength(2)
+      // L'autre produit N'est PAS affecté (toujours déplié, son event visible).
+      expect(screen.getAllByTestId('timeline-resource-head')[1]).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      )
+      const remaining = screen.getAllByTestId('timeline-event')
+      expect(remaining[0]).toHaveAttribute('data-event-title', 'Livraison pain')
+      // La catégorie parente reste dépliée (accordéon catégorie inchangé).
+      screen
+        .getAllByTestId('timeline-group-head')
+        .forEach((h) => expect(h).toHaveAttribute('aria-expanded', 'true'))
+    })
+
+    it('conserve la position de scroll après un collapse produit (parité collapse catégorie)', async () => {
+      const user = userEvent.setup()
+      setup()
+      const scroll = screen.getByTestId('timeline-scroll')
+      // Simule un défilement horizontal utilisateur.
+      scroll.scrollLeft = 360
+      expect(scroll.scrollLeft).toBe(360)
+
+      // Le collapse produit est un pur re-rendu (aucun reset de scroll, comme la
+      // catégorie) → le conteneur scrollable garde sa position.
+      await user.click(screen.getAllByTestId('timeline-resource-head')[0])
+      await waitFor(() => expect(screen.getAllByTestId('timeline-event')).toHaveLength(1))
+      expect(scroll.scrollLeft).toBe(360)
+    })
+
+    it('clavier/focus cohérent : la lane produit repliée est exclue de la nav, roving unique préservé', async () => {
+      const user = userEvent.setup()
+      setup()
+      const pills = screen.getAllByTestId('timeline-event')
+      // Active la pastille de la 2e lane (p2) au clavier → activeNav suit p2.
+      pills[0].focus()
+      await user.keyboard('{ArrowDown}')
+      expect(pills[1]).toHaveFocus()
+
+      // Replie le produit p2 (la lane active) : sa pastille disparaît → le roving
+      // retombe sur la 1re pastille visible restante (e1), tabIndex=0 reste unique.
+      await user.click(screen.getAllByTestId('timeline-resource-head')[1])
+      await waitFor(() => {
+        const visible = screen.getAllByTestId('timeline-event')
+        expect(visible).toHaveLength(1)
+        expect(visible[0]).toHaveAttribute('data-event-title', 'Péremption lait')
+        expect(visible.filter((p) => p.getAttribute('tabindex') === '0')).toHaveLength(1)
+      })
+
+      // Nav clavier depuis la seule lane restante : ArrowDown ne cible PAS la lane
+      // repliée (elle n'est plus focusable) → le focus reste sur e1.
+      const only = screen.getAllByTestId('timeline-event')[0]
+      only.focus()
+      await user.keyboard('{ArrowDown}')
+      expect(only).toHaveFocus()
+    })
+  })
 })

--- a/frontend/src/components/timeline/TimelineView.tsx
+++ b/frontend/src/components/timeline/TimelineView.tsx
@@ -77,6 +77,12 @@ export const TimelineView: React.FC<TimelineViewProps> = ({ events, resources, l
   const t = useTranslations()
   const [zoom, dispatch] = useReducer(zoomReducer, initialZoomState)
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
+  // #195 — Accordéon de 2e niveau : état collapse par PRODUIT (lane), keyé par
+  // `resource.id`. Indépendant de `collapsed` (catégorie) : replier un produit
+  // n'affecte ni les autres produits ni la catégorie parente. Même préservation
+  // de scroll que le collapse catégorie (aucun mécanisme explicite — le conteneur
+  // scrollable garde son scrollLeft/Top au re-rendu React).
+  const [collapsedResources, setCollapsedResources] = useState<Record<string, boolean>>({})
   const [selected, setSelected] = useState<PositionedEvent | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const rootRef = useRef<HTMLDivElement>(null)
@@ -111,11 +117,15 @@ export const TimelineView: React.FC<TimelineViewProps> = ({ events, resources, l
     for (const [category, resList] of Object.entries(resourcesByCategory)) {
       if (collapsed[category] ?? false) continue
       for (const resource of resList) {
+        // #195 — Une lane produit collapsée n'a plus de pastilles rendues → on
+        // l'exclut aussi de la nav clavier (comme les catégories collapsées),
+        // sinon ←→↑↓ cibleraient des pastilles masquées (bug focus).
+        if (collapsedResources[resource.id] ?? false) continue
         lanes.push({ resourceId: resource.id, events: eventsByResource.get(resource.id) || [] })
       }
     }
     return lanes
-  }, [resourcesByCategory, collapsed, eventsByResource])
+  }, [resourcesByCategory, collapsed, collapsedResources, eventsByResource])
 
   // #81 — Roving tabindex : la pastille active (celle qui porte tabIndex=0) est
   // repérée par sa RESSOURCE (`resourceId`) + son index d'event, PAS par un index
@@ -585,6 +595,7 @@ export const TimelineView: React.FC<TimelineViewProps> = ({ events, resources, l
 
                 {!isCollapsed &&
                   resList.map((resource) => {
+                    const isResCollapsed = collapsedResources[resource.id] ?? false
                     const laneEvents = eventsByResource.get(resource.id) || []
                     return (
                       <div
@@ -593,16 +604,41 @@ export const TimelineView: React.FC<TimelineViewProps> = ({ events, resources, l
                         style={{ backgroundSize: `${dayWidth}px 100%` }}
                         data-testid="timeline-resource-row"
                       >
-                        {/* Label produit sticky à gauche : reste visible pendant le
-                            scroll horizontal de la frise (identifie la lane). */}
-                        <span
-                          className="mt-tlv__lane-label"
-                          data-testid="timeline-resource-title"
+                        {/* #195 — Accordéon de 2e niveau : le label produit sticky
+                            devient un bouton toggle (mirror de `mt-tlv__group-head`).
+                            Bouton natif → clavier Enter/Espace + `aria-expanded`
+                            cohérents avec l'accordéon catégorie. Reste visible même
+                            collapsé (identifie la lane pendant le scroll horizontal). */}
+                        <button
+                          type="button"
+                          className="mt-tlv__lane-label mt-tlv__lane-head"
+                          aria-expanded={!isResCollapsed}
+                          onClick={() =>
+                            setCollapsedResources((prev) => ({
+                              ...prev,
+                              [resource.id]: !isResCollapsed,
+                            }))
+                          }
                           title={resource.title}
+                          data-testid="timeline-resource-head"
                         >
-                          {resource.title}
-                        </span>
-                        {laneEvents.map((event, evtIdx) => {
+                          <ChevronRight
+                            className={
+                              isResCollapsed ? 'mt-tlv__chev' : 'mt-tlv__chev mt-tlv__chev--open'
+                            }
+                            size={12}
+                            strokeWidth={1.5}
+                            aria-hidden="true"
+                          />
+                          <span
+                            className="mt-tlv__lane-head-text"
+                            data-testid="timeline-resource-title"
+                          >
+                            {resource.title}
+                          </span>
+                        </button>
+                        {!isResCollapsed &&
+                          laneEvents.map((event, evtIdx) => {
                           const laneIdx = laneIndexByResource.get(resource.id) ?? -1
                           const isRoving =
                             rovingNav !== null &&

--- a/frontend/src/components/timeline/TimelineView.tsx
+++ b/frontend/src/components/timeline/TimelineView.tsx
@@ -639,30 +639,30 @@ export const TimelineView: React.FC<TimelineViewProps> = ({ events, resources, l
                         </button>
                         {!isResCollapsed &&
                           laneEvents.map((event, evtIdx) => {
-                          const laneIdx = laneIndexByResource.get(resource.id) ?? -1
-                          const isRoving =
-                            rovingNav !== null &&
-                            rovingNav.lane === laneIdx &&
-                            rovingNav.evt === evtIdx
-                          const key = navKeyOf(laneIdx, evtIdx)
-                          return (
-                            <EventPill
-                              key={event.id}
-                              event={event}
-                              ariaLabel={buildEventAriaLabel(event, locale, t)}
-                              onSelect={setSelected}
-                              tabIndex={isRoving ? 0 : -1}
-                              navKey={key}
-                              onKeyDown={(e) => onPillKeyDown(e, laneIdx, evtIdx)}
-                              pillRef={(node) => {
-                                // Indexe le node pour `.focus()` défensif ; nettoie
-                                // à l'unmount (évite les refs pendantes au collapse).
-                                if (node) pillNodes.current.set(key, node)
-                                else pillNodes.current.delete(key)
-                              }}
-                            />
-                          )
-                        })}
+                            const laneIdx = laneIndexByResource.get(resource.id) ?? -1
+                            const isRoving =
+                              rovingNav !== null &&
+                              rovingNav.lane === laneIdx &&
+                              rovingNav.evt === evtIdx
+                            const key = navKeyOf(laneIdx, evtIdx)
+                            return (
+                              <EventPill
+                                key={event.id}
+                                event={event}
+                                ariaLabel={buildEventAriaLabel(event, locale, t)}
+                                onSelect={setSelected}
+                                tabIndex={isRoving ? 0 : -1}
+                                navKey={key}
+                                onKeyDown={(e) => onPillKeyDown(e, laneIdx, evtIdx)}
+                                pillRef={(node) => {
+                                  // Indexe le node pour `.focus()` défensif ; nettoie
+                                  // à l'unmount (évite les refs pendantes au collapse).
+                                  if (node) pillNodes.current.set(key, node)
+                                  else pillNodes.current.delete(key)
+                                }}
+                              />
+                            )
+                          })}
                       </div>
                     )
                   })}

--- a/frontend/src/components/timeline/TimelineView.tsx
+++ b/frontend/src/components/timeline/TimelineView.tsx
@@ -626,7 +626,7 @@ export const TimelineView: React.FC<TimelineViewProps> = ({ events, resources, l
                             className={
                               isResCollapsed ? 'mt-tlv__chev' : 'mt-tlv__chev mt-tlv__chev--open'
                             }
-                            size={12}
+                            size={13}
                             strokeWidth={1.5}
                             aria-hidden="true"
                           />

--- a/frontend/src/styles/ds/components/timeline.css
+++ b/frontend/src/styles/ds/components/timeline.css
@@ -120,7 +120,7 @@
    à gauche, cible cliquable (pointer-events réactivés). */
 .mt-tlv__lane-head{gap:6px; border-top:0; border-bottom:0; border-left:0; padding-left:8px; cursor:pointer; text-align:left; pointer-events:auto;}
 .mt-tlv__lane-head:focus-visible{outline:2px solid var(--color-focus); outline-offset:-2px;}
-.mt-tlv__lane-head-text{overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
+.mt-tlv__lane-head-text{min-width:0; flex:1 1 auto; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
 .mt-tlv__evt{position:absolute; top:9px; height:26px; display:flex; align-items:center; gap:6px; padding:0 10px; border-radius:6px; background:var(--mt-evt, var(--color-accent)); color:var(--mt-evt-ink, #fff); font-size:12px; font-weight:var(--weight-semibold); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; cursor:pointer; box-shadow:var(--shadow-sm); transition:filter var(--dur-micro), box-shadow var(--dur-micro);}
 .mt-tlv__evt:hover{box-shadow:var(--shadow-md); filter:brightness(1.04);}
 /* #81 — Focus ring (point 5). ÉCART INTENTIONNEL de token : les pastilles

--- a/frontend/src/styles/ds/components/timeline.css
+++ b/frontend/src/styles/ds/components/timeline.css
@@ -177,13 +177,27 @@
 .mt-tlm{position:relative; display:flex; flex-direction:column; width:100%; border:1px solid var(--color-rule); border-radius:var(--radius-md); background:var(--color-surface); overflow:hidden;}
 .mt-tlm__toolbar{display:flex; align-items:center; gap:var(--space-2); padding:var(--space-2) var(--space-3); border-bottom:1px solid var(--color-rule); background:var(--color-surface-2);}
 
-/* #226 — a11y WCAG 2.5.5 : cible tactile ≥44×44px pour le zoom sur surfaces
-   touch mobile. Scope `.mt-tlm` (couvre portrait + paysage `.mt-tlm--landscape`) :
-   le bouton desktop `.mt-zoom__btn` (hors `.mt-tlm`) reste 30px, hauteur dérivée
-   du groupe. La hitbox s'étend hors flux via `::before` (PAT-S24-002) : n'altère
-   ni l'icône (font-size inchangée) ni le flex du groupe. Les deux hitboxes ne se
-   chevauchent pas (séparées par `.mt-zoom__level`). */
+/* #226 — a11y WCAG 2.5.5 : cible tactile RÉELLE ≥44×44px pour le zoom sur
+   surfaces touch mobile. Scope `.mt-tlm` (couvre portrait + paysage
+   `.mt-tlm--landscape`) : le bouton desktop `.mt-zoom__btn` (hors `.mt-tlm`)
+   reste 30px + groupe `overflow:hidden` inchangé. La hitbox s'étend hors flux
+   via `::before` 44×44px centré (PAT-S24-002) : n'altère ni l'icône (font-size
+   inchangée) ni le flex du groupe.
+   ⚠ PIT PAT-S24-002 : le `::before` déborde de (44-30)/2 = 7px de chaque côté du
+   bouton. Le groupe `.mt-zoom` a `overflow:hidden` (arrondi desktop) → sur le
+   1er (bord gauche) et le dernier (bord droit) bouton, ces 7px extérieurs
+   étaient CLIPPÉS → cible réelle ~37×44px sur les bords extrêmes. Fix : passer le
+   groupe en `overflow:visible` UNIQUEMENT en contexte `.mt-tlm` pour libérer la
+   hitbox. Le `::before` est transparent → aucun rendu n'apparaît. On réarrondit
+   les coins extérieurs des boutons de bord (`:first-child` / `:last-child`) à
+   `--radius-md` pour préserver la silhouette arrondie du groupe (sans le clip, le
+   fond hover carré déborderait de l'arrondi). Les 7px libérés côté gauche
+   tiennent dans le padding `--space-3` (12px) de la toolbar → aucun re-clip par
+   le `overflow:hidden` de `.mt-tlm`. */
+.mt-tlm .mt-zoom{overflow:visible;}
 .mt-tlm .mt-zoom__btn{position:relative; min-height:44px;}
+.mt-tlm .mt-zoom__btn:first-child{border-top-left-radius:var(--radius-md); border-bottom-left-radius:var(--radius-md);}
+.mt-tlm .mt-zoom__btn:last-child{border-top-right-radius:var(--radius-md); border-bottom-right-radius:var(--radius-md);}
 .mt-tlm .mt-zoom__btn::before{content:""; position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); width:44px; height:44px;}
 
 /* Frise scrollable horizontale. `touch-action:pan-x` : autorise le scroll

--- a/frontend/src/styles/ds/components/timeline.css
+++ b/frontend/src/styles/ds/components/timeline.css
@@ -115,6 +115,12 @@
    scroll horizontal. Fond opaque + z-index pour passer au-dessus des event bars
    sans casser leur positionnement absolu (left:leftPx). */
 .mt-tlv__lane-label{position:sticky; left:0; z-index:var(--z-sticky); display:inline-flex; align-items:center; max-width:var(--lane-header-w, 160px); height:100%; padding:0 12px; background:var(--color-surface-2); border-right:1px solid var(--color-rule); font-family:var(--font-display); font-size:13px; font-weight:var(--weight-semibold); color:var(--color-ink); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; pointer-events:none;}
+/* #195 — Accordéon de 2e niveau (produit) : le label sticky devient un bouton
+   toggle, mirror de .mt-tlv__group-head. Reset des styles bouton natifs, chevron
+   à gauche, cible cliquable (pointer-events réactivés). */
+.mt-tlv__lane-head{gap:6px; border-top:0; border-bottom:0; border-left:0; padding-left:8px; cursor:pointer; text-align:left; pointer-events:auto;}
+.mt-tlv__lane-head:focus-visible{outline:2px solid var(--color-focus); outline-offset:-2px;}
+.mt-tlv__lane-head-text{overflow:hidden; text-overflow:ellipsis; white-space:nowrap;}
 .mt-tlv__evt{position:absolute; top:9px; height:26px; display:flex; align-items:center; gap:6px; padding:0 10px; border-radius:6px; background:var(--mt-evt, var(--color-accent)); color:var(--mt-evt-ink, #fff); font-size:12px; font-weight:var(--weight-semibold); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; cursor:pointer; box-shadow:var(--shadow-sm); transition:filter var(--dur-micro), box-shadow var(--dur-micro);}
 .mt-tlv__evt:hover{box-shadow:var(--shadow-md); filter:brightness(1.04);}
 /* #81 — Focus ring (point 5). ÉCART INTENTIONNEL de token : les pastilles

--- a/frontend/src/styles/ds/components/timeline.css
+++ b/frontend/src/styles/ds/components/timeline.css
@@ -171,6 +171,15 @@
 .mt-tlm{position:relative; display:flex; flex-direction:column; width:100%; border:1px solid var(--color-rule); border-radius:var(--radius-md); background:var(--color-surface); overflow:hidden;}
 .mt-tlm__toolbar{display:flex; align-items:center; gap:var(--space-2); padding:var(--space-2) var(--space-3); border-bottom:1px solid var(--color-rule); background:var(--color-surface-2);}
 
+/* #226 — a11y WCAG 2.5.5 : cible tactile ≥44×44px pour le zoom sur surfaces
+   touch mobile. Scope `.mt-tlm` (couvre portrait + paysage `.mt-tlm--landscape`) :
+   le bouton desktop `.mt-zoom__btn` (hors `.mt-tlm`) reste 30px, hauteur dérivée
+   du groupe. La hitbox s'étend hors flux via `::before` (PAT-S24-002) : n'altère
+   ni l'icône (font-size inchangée) ni le flex du groupe. Les deux hitboxes ne se
+   chevauchent pas (séparées par `.mt-zoom__level`). */
+.mt-tlm .mt-zoom__btn{position:relative; min-height:44px;}
+.mt-tlm .mt-zoom__btn::before{content:""; position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); width:44px; height:44px;}
+
 /* Frise scrollable horizontale. `touch-action:pan-x` : autorise le scroll
    horizontal natif mais laisse le composant gérer le pinch (2 doigts). */
 .mt-tlm__scroll{position:relative; overflow-x:auto; overflow-y:hidden; touch-action:pan-x; -webkit-overflow-scrolling:touch;}


### PR DESCRIPTION
## Sprint 41 — UX & a11y Timeline

Cohésion 0.66 · epic `events` · aucune migration · aucune BR métier nouvelle.

### Objectif
Améliorer l'UX de la frise (accordéon collapse par produit) et son accessibilité (cibles tactiles WCAG 2.5.5, `aria-hidden`, couverture clavier, cohérence référentiel).

### Issues traitées

| # | Titre | Taille | Commit |
|---|-------|--------|--------|
| #226 | a11y : cible tactile `.mt-zoom__btn` ≥44px sur touch mobile | S | `85d1d30` |
| #228 | a11y : `aria-hidden` conditionnel EventPill + tests clavier §9 | S | `ff18e17` |
| #195 | Timeline : accordéon collapse par produit | M | `deabd41` |
| #227 | a11y : statuer sur le raccourci `?` (option B — hover/focus-only) | XS | `0a0d1c3` |

### Vagues d'exécution
- **V1** (parallèle, fichiers disjoints) : #226 (`timeline.css`) ∥ #228 (`EventPill.tsx`)
- **V2** (séquentiel) : #195 (`TimelineView.tsx`) → #227 (`ux-patterns.md`)

### Changements clés
- **#226** — override mobile-scopé `.mt-tlm .mt-zoom__btn` : `min-height:44px` + hitbox `::before` 44×44 (PAT-S24-002). Desktop `.mt-zoom__btn` inchangé (30px).
- **#228** — `aria-hidden` du span titre EventPill devient conditionnel (retiré quand `readableInside`, cohérence Label-in-Name WCAG 2.5.3). +5 tests clavier §9 (flèches inter-lanes, trap Tab drawer + restauration focus, `T`/`[`/`]`/`-`) + 2 tests aria.
- **#195** — 2e niveau d'accordéon collapse par **produit** imbriqué dans le collapse catégorie : état `collapsedResources` keyé `resource.id` (indépendant), bouton `.mt-tlv__lane-head` mirror du pattern catégorie, exclusion des ressources repliées de la nav clavier (`navLanes`), scroll préservé (pur re-rendu). +3 tests.
- **#227** — décision **option B** actée : l'aide reste hover/focus-only (tooltip `.mt-tlv__help-pop`), `?` retiré du référentiel `ux-patterns.md` (§5/§9). Doc-only, aucun code timeline.

### Review (batch, 1 cycle)
- 🔴 **1 MAJEUR** résolu (`8de39ce`) : la hitbox `::before` de #226 était clippée aux bords extrêmes par `overflow:hidden` du groupe `.mt-zoom` → cible réelle ~37px. Fix : `.mt-tlm .mt-zoom{overflow:visible}` (scopé mobile) + réarrondi des coins de bord. Cible ≥44×44px garantie, desktop inchangé.
- 🟡 **2 MINEUR** résolus (`8de39ce`) : commentaire aria-hidden clarifié (#228) ; chevron produit harmonisé `size={13}` (#195).
- 🟢 OK : nav clavier/focus #195, Label-in-Name #228, scoping mobile #226, tokens DS / TS strict / i18n.

### Audit tests
- Frontend (Vitest) : **456/456 verts**, 0 erreur TypeScript, 62 fichiers.
- Backend : non impacté (aucun changement). E2E : non lancé (traité post-merge).
- Détail : `docs/memory/audits/sprint-41-test-coverage.md`.

### Follow-up non bloquant
- **Coverage E2E** : le nouveau `data-testid="timeline-resource-head"` (#195) n'a pas de spec Playwright → `/create-e2e` après merge (`golden-path.spec.ts` couvre déjà `timeline-resource-title`). À arbitrer en Phase 4 triage de `/sprint end`.

### Notes techniques (mémoire)
- PIT : le pattern hitbox `::before` (PAT-S24-002) casse silencieusement si un ancêtre a `overflow:hidden` → cible < 44px aux bords. Vérifier les ancêtres `overflow` avant de l'appliquer.
- PIT : le CSS timeline vit dans `frontend/src/styles/ds/components/timeline.css` (DS), pas à côté des `.tsx`.
- DEC-S41-227 : aide frise = hover/focus-only par décision (option B).
