### PR TITLE
:wheelchair: fix(timeline): role=presentation sur les cales des vues mobiles

### DIFF
--- a/frontend/src/components/timeline/TimelineMobileLandscape.tsx
+++ b/frontend/src/components/timeline/TimelineMobileLandscape.tsx
@@ -211,6 +211,7 @@ export const TimelineMobileLandscape: React.FC<TimelineMobileLandscapeProps> = (
                 <div role="list" aria-label={category} data-testid="timeline-lane-list">
                   {laneWindow.topSpacerPx > 0 && (
                     <div
+                      role="presentation"
                       aria-hidden="true"
                       data-testid="timeline-lane-spacer"
                       style={{ height: `${laneWindow.topSpacerPx}px` }}
@@ -289,6 +290,7 @@ export const TimelineMobileLandscape: React.FC<TimelineMobileLandscapeProps> = (
                   })}
                   {laneWindow.bottomSpacerPx > 0 && (
                     <div
+                      role="presentation"
                       aria-hidden="true"
                       data-testid="timeline-lane-spacer"
                       style={{ height: `${laneWindow.bottomSpacerPx}px` }}

--- a/frontend/src/components/timeline/TimelineMobilePortrait.tsx
+++ b/frontend/src/components/timeline/TimelineMobilePortrait.tsx
@@ -198,6 +198,7 @@ export const TimelineMobilePortrait: React.FC<TimelineMobilePortraitProps> = ({
                 <div role="list" aria-label={category} data-testid="timeline-lane-list">
                   {laneWindow.topSpacerPx > 0 && (
                     <div
+                      role="presentation"
                       aria-hidden="true"
                       data-testid="timeline-lane-spacer"
                       style={{ height: `${laneWindow.topSpacerPx}px` }}
@@ -276,6 +277,7 @@ export const TimelineMobilePortrait: React.FC<TimelineMobilePortraitProps> = ({
                   })}
                   {laneWindow.bottomSpacerPx > 0 && (
                     <div
+                      role="presentation"
                       aria-hidden="true"
                       data-testid="timeline-lane-spacer"
                       style={{ height: `${laneWindow.bottomSpacerPx}px` }}


### PR DESCRIPTION
## Contexte

L'issue #351 a corrigé côté bureau (`TimelineView.tsx`) un défaut `aria-required-children` : les deux cales de virtualisation (`data-testid="timeline-lane-spacer"`), enfants directs d'un conteneur `role="list"`, ne portaient qu'un `aria-hidden="true"`.

Le même défaut existe encore à quatre endroits, hors périmètre de #351 parce que ces deux fichiers appartenaient alors à #328 :

- `TimelineMobilePortrait.tsx` — cale haute et cale basse
- `TimelineMobileLandscape.tsx` — cale haute et cale basse

Dans les deux fichiers les cales sont enfants directs de `<div role="list" aria-label={category} data-testid="timeline-lane-list">`.

## Changement

Ajout de `role="presentation"` sur les quatre cales, placé avant `aria-hidden="true"` — ordre d'attributs identique au correctif bureau (commit `c75efd7`). Aucun autre changement : 4 lignes ajoutées, 0 supprimée.

## Vérifications

- `./scripts/test-quiet.sh frontend` — 88 fichiers, 806 tests, tous verts
- `cd frontend && npm run typecheck` — propre (tsc sans sortie)

## Ce qui n'est PAS vérifié

- **La règle `aria-required-children` elle-même.** Le dépôt n'embarque aucun outil d'audit d'accessibilité (ni axe, ni pa11y, ni lighthouse dans `frontend/package.json`) : le correctif est juste à la lecture de la spec ARIA, mais rien ici ne l'atteste automatiquement.
- **Aucun test unitaire ajouté.** Sous jsdom `clientWidth` vaut 0, la virtualisation retombe en fenêtre non bornée, `topSpacerPx`/`bottomSpacerPx` restent à 0 et les cales ne sont jamais montées — une assertion sur le rôle n'est pas directe.
- **Aucune vérification navigateur.** Le changement est purement attributaire, sans effet visuel.

## Réserve sur la base

Le correctif bureau de #351 n'est **pas** sur `dev` : il vit sur `origin/sprint/51` (commit `c75efd7`), non fusionné. Sur cette base, `TimelineView.tsx:756` et `:849` portent donc toujours le défaut. Cette PR ne touche pas `TimelineView.tsx` pour éviter un conflit avec #351 lors de sa fusion — mais si sprint-51 ne fusionne jamais, les cales du bureau restent à corriger.

Pas de mot-clé de fermeture : la base est `dev`, où GitHub ne ferme pas les issues automatiquement. #351 et #328 restent ouvertes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
