### PR TITLE
chore(sprint-53) : passe le sprint en Terminé après merge

### DIFF
--- a/docs/memory/sprint-history.md
+++ b/docs/memory/sprint-history.md
@@ -1734,7 +1734,9 @@ démasquée par #346 · `9350a77` échec CI révélé par le test neuf de #347) 
 **Tests :** Frontend **836/836** · Backend **452/452** · **CI 4/4 verts** (dont `e2e`, 5m51s)
 **Reviews :** reviewer batch — **0 CRITIQUE / 0 MAJEUR / 1 MINEUR**
 **Nouveaux artefacts mémoire :** `PIT-S53-001` à `PIT-S53-006` · `PAT-S53-001`, `PAT-S53-002` · `DEC-S53-001` à `DEC-S53-004`
-**Status :** En cours — PR #382 ouverte, CI verte, en attente de `/sprint end 53`
+**Status :** **Terminé** — PR #382 mergée dans `dev` le 2026-07-29 (commit de merge `b0b2f19`).
+Milestone #53 fermé (2 issues, 0 ouverte — 9 issues de backlog **détachées** avant fermeture, elles n'ont
+jamais fait partie du périmètre). Issues #339 et #340 fermées.
 
 **Follow-ups arbitrés (Phase 4 triage — 6 items, 3 issues, 2 discard, 1 déjà résolu) :**
   - `:focus-visible` hors layer : annule `outline-none` sur ~14 sites + impose un `border-radius`


### PR DESCRIPTION
Correctif de suivi, **documentation seule**.

`docs/memory/sprint-history.md` indiquait encore `Status : En cours — PR #382 ouverte` alors que le Sprint 53 est mergé dans `dev` (commit `b0b2f19`).

**Pourquoi ça n'a pas pu être fait dans la PR du sprint :** la consolidation de clôture (mémoire + bilan du triage) a été poussée **avant** le merge pour partir avec la PR #382 — la ligne de statut ne pouvait donc pas encore refléter un merge qui n'avait pas eu lieu. `dev` étant protégée, ce solde passe par une PR dédiée.

**Pourquoi ça compte :** `/sprint plan` lit ce fichier pour déduire le dernier sprint terminé. Le laisser « En cours » aurait faussé la planification du Sprint 55.

Aucun code touché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)