### PR TITLE
Sprint 60 — signal CI security exploitable : scan de secrets, nanoid HIGH, préflight node_modules

### DIFF
--- a/.ai-env/context-packs/pit-backend.md
+++ b/.ai-env/context-packs/pit-backend.md
@@ -207,6 +207,69 @@ règle injectée n'était simplement pas dans le CSS servi. `touch` et rechargem
 un redémarrage du serveur dev** a compilé la règle. Prévention : avant de conclure « le défaut injecté n'est
 pas vu », `curl` le chunk CSS servi et vérifier que l'injection y figure. (Corollaire de [[PIT-S52-002]].)
 
+
+## PIT-S60-001 — Une allowlist de scanner combine ses critères en OU : elle blanchit plus large qu'elle n'en a l'air
+Un bloc `[[allowlists]]` gitleaks avec `paths` **et** `regexes` mais **sans `condition = "AND"`** blanchit la
+valeur **partout dans le dépôt**, pas seulement dans le chemin visé. La lecture du bloc suggère l'inverse : les
+deux critères juxtaposés se lisent comme un ET. Trouvé à l'écriture de `.gitleaks.toml` (#362), la première
+version blanchissait `EXPORT_TOKEN_SECRET` y compris dans un fichier de prod. **Prévention : toute allowlist de
+scanner se teste dans les DEUX sens** — le cas attendu est tu, ET un cas voisin (même valeur hors chemin, autre
+secret dans le chemin) reste détecté. Rejouer la variante buggée pour voir le trou est ce qui l'a prouvé.
+
+
+## PIT-S60-002 — Une empreinte de baseline épinglée sur une ligne encore au HEAD masque à VIE, sans jamais rougir
+`.gitleaksignore` (format `commit:fichier:règle:ligne`) épinglait le fixture `SECRET` d'`ExportTokenServiceTest`,
+**toujours présent au HEAD**. La règle écrite en tête du fichier l'interdit — au motif que l'empreinte
+changerait au prochain commit touchant le fichier. Le mode d'échec réel est **l'inverse et bien plus discret** :
+la ligne n'ayant jamais été retouchée depuis son commit d'introduction, l'empreinte reste valide indéfiniment,
+donc le masquage devient **permanent** au lieu de rougir. Trouvé par l'audit sécurité de fin de sprint, pas à
+l'écriture. Remède : exclusion **durable** ancrée sur un marqueur de la VALEUR (`test-only-insecure`) + le
+chemin, `condition = "AND"` ; `.gitleaksignore` réservé aux occurrences **absentes du HEAD**, à vérifier une
+par une. Cf. [[PIT-S60-001]].
+
+
+## PIT-S60-003 — `gitleaks dir` ignore `.gitignore` : un gate CI doit être en mode `git`
+Mesuré : `gitleaks dir` scanne 214 Mo et remonte 25 détections, dont **20 dans `frontend/.next/`,
+`backend/target/`, `frontend/e2e/.auth/`** — des artefacts de build non versionnés. `gitleaks git` ne voit que
+le contenu suivi (21 détections). Un job bâti sur `dir` rougit donc pour des fichiers qui ne sont pas dans le
+dépôt, et sera désactivé après deux faux positifs. **Mode `git` pour tout gate CI.**
+
+
+## PIT-S60-004 — Un scan vert AVANT le commit ne prouve rien sur l'état APRÈS (le scanner peut se détecter lui-même)
+Un fichier de baseline listant des empreintes `commit:fichier:generic-api-key:ligne` aligne un SHA 40-hex à
+forte entropie et le mot « api-key » sur la même ligne : le scanner peut se déclencher **sur sa propre
+configuration**. Vérifié négatif ici, mais le piège général demeure — un scan pré-commit ne voit pas les
+fichiers non encore committés. **Rejouer le scan dans un dépôt jetable contenant les fichiers committés** avant
+de conclure. Corollaire : `--baseline-path` avec rapport JSON committé est un anti-pattern sur dépôt public —
+le rapport **contient les valeurs en clair**.
+
+
+## PIT-S60-005 — Un sous-agent qui casse l'environnement pour reproduire un cas dégradé peut caler avant de le restaurer
+Sprint 60 #308 : l'agent a renommé `frontend/node_modules/eslint-plugin-storybook` en
+`.eslint-plugin-storybook.S60-308-bak` pour prouver son garde-fou, puis a calé (watchdog 600 s) **avant la
+restauration**. Le worktree est resté dans l'état dégradé — et **`git status` était propre**, `node_modules`
+n'étant pas suivi. Un lead qui vérifie l'état d'un sprint sur le seul `git status` ne le voit pas ; l'échec
+suivant accuserait le code. **Après tout arrêt anormal d'un sous-agent, vérifier l'ENVIRONNEMENT** (résolution
+des paquets, processus laissés, ports tenus), pas seulement l'arbre git. Ici :
+`node -e "require.resolve('eslint-plugin-storybook')"`. Le répertoire de sauvegarde se retrouve par
+`find node_modules -maxdepth 2 -iname '*<paquet>*'` — le préfixe `.` le cache d'un `ls` ordinaire.
+
+
+## PIT-S60-008 — Le squatteur de port peut être un AUTRE worktree DU MÊME projet
+Variante de [[PIT-S56-004]] : `:3100` était tenu par un `next-server` de
+`worktrees/new-feature-2347-14cb9a/frontend` (up 21 h), rendant **500 sur `/fr/register`**. Le réflexe « c'est
+un autre projet du poste » ne suffit donc pas — même nom de projet, même app, mais **code d'une autre branche**.
+`lsof -a -p <pid> -d cwd` identifie le propriétaire réel. Prendre un port libre plutôt que tuer le process d'une
+autre session.
+
+
+## PIT-S60-009 — `test-quiet.sh frontend` ne lance QUE Vitest, contrairement à ce que disent le README et les briefings
+`run_frontend` exécute un seul `npm test --silent` : ni `build`, ni `typecheck`, ni `lint`. La description
+« vitest + build + typecheck + lint » circulait dans les briefings de sprint et le README. **Anti-pattern :
+conclure « frontend vert » sur ce seul scope.** Corrigé au S60 (README §Tests + piège 4). Voisin de
+[[PIT-S58-004]] : une garantie décrite mais inexistante dissuade d'en écrire une vraie.
+
+
 ---
 
 ## §2 — Index historique (titre = règle ; détail dans docs/memory/pitfalls.md)

--- a/.ai-env/context-packs/pit-frontend.md
+++ b/.ai-env/context-packs/pit-frontend.md
@@ -376,6 +376,92 @@ règle injectée n'était simplement pas dans le CSS servi. `touch` et rechargem
 un redémarrage du serveur dev** a compilé la règle. Prévention : avant de conclure « le défaut injecté n'est
 pas vu », `curl` le chunk CSS servi et vérifier que l'injection y figure. (Corollaire de [[PIT-S52-002]].)
 
+
+## PIT-S60-001 — Une allowlist de scanner combine ses critères en OU : elle blanchit plus large qu'elle n'en a l'air
+Un bloc `[[allowlists]]` gitleaks avec `paths` **et** `regexes` mais **sans `condition = "AND"`** blanchit la
+valeur **partout dans le dépôt**, pas seulement dans le chemin visé. La lecture du bloc suggère l'inverse : les
+deux critères juxtaposés se lisent comme un ET. Trouvé à l'écriture de `.gitleaks.toml` (#362), la première
+version blanchissait `EXPORT_TOKEN_SECRET` y compris dans un fichier de prod. **Prévention : toute allowlist de
+scanner se teste dans les DEUX sens** — le cas attendu est tu, ET un cas voisin (même valeur hors chemin, autre
+secret dans le chemin) reste détecté. Rejouer la variante buggée pour voir le trou est ce qui l'a prouvé.
+
+
+## PIT-S60-002 — Une empreinte de baseline épinglée sur une ligne encore au HEAD masque à VIE, sans jamais rougir
+`.gitleaksignore` (format `commit:fichier:règle:ligne`) épinglait le fixture `SECRET` d'`ExportTokenServiceTest`,
+**toujours présent au HEAD**. La règle écrite en tête du fichier l'interdit — au motif que l'empreinte
+changerait au prochain commit touchant le fichier. Le mode d'échec réel est **l'inverse et bien plus discret** :
+la ligne n'ayant jamais été retouchée depuis son commit d'introduction, l'empreinte reste valide indéfiniment,
+donc le masquage devient **permanent** au lieu de rougir. Trouvé par l'audit sécurité de fin de sprint, pas à
+l'écriture. Remède : exclusion **durable** ancrée sur un marqueur de la VALEUR (`test-only-insecure`) + le
+chemin, `condition = "AND"` ; `.gitleaksignore` réservé aux occurrences **absentes du HEAD**, à vérifier une
+par une. Cf. [[PIT-S60-001]].
+
+
+## PIT-S60-003 — `gitleaks dir` ignore `.gitignore` : un gate CI doit être en mode `git`
+Mesuré : `gitleaks dir` scanne 214 Mo et remonte 25 détections, dont **20 dans `frontend/.next/`,
+`backend/target/`, `frontend/e2e/.auth/`** — des artefacts de build non versionnés. `gitleaks git` ne voit que
+le contenu suivi (21 détections). Un job bâti sur `dir` rougit donc pour des fichiers qui ne sont pas dans le
+dépôt, et sera désactivé après deux faux positifs. **Mode `git` pour tout gate CI.**
+
+
+## PIT-S60-004 — Un scan vert AVANT le commit ne prouve rien sur l'état APRÈS (le scanner peut se détecter lui-même)
+Un fichier de baseline listant des empreintes `commit:fichier:generic-api-key:ligne` aligne un SHA 40-hex à
+forte entropie et le mot « api-key » sur la même ligne : le scanner peut se déclencher **sur sa propre
+configuration**. Vérifié négatif ici, mais le piège général demeure — un scan pré-commit ne voit pas les
+fichiers non encore committés. **Rejouer le scan dans un dépôt jetable contenant les fichiers committés** avant
+de conclure. Corollaire : `--baseline-path` avec rapport JSON committé est un anti-pattern sur dépôt public —
+le rapport **contient les valeurs en clair**.
+
+
+## PIT-S60-005 — Un sous-agent qui casse l'environnement pour reproduire un cas dégradé peut caler avant de le restaurer
+Sprint 60 #308 : l'agent a renommé `frontend/node_modules/eslint-plugin-storybook` en
+`.eslint-plugin-storybook.S60-308-bak` pour prouver son garde-fou, puis a calé (watchdog 600 s) **avant la
+restauration**. Le worktree est resté dans l'état dégradé — et **`git status` était propre**, `node_modules`
+n'étant pas suivi. Un lead qui vérifie l'état d'un sprint sur le seul `git status` ne le voit pas ; l'échec
+suivant accuserait le code. **Après tout arrêt anormal d'un sous-agent, vérifier l'ENVIRONNEMENT** (résolution
+des paquets, processus laissés, ports tenus), pas seulement l'arbre git. Ici :
+`node -e "require.resolve('eslint-plugin-storybook')"`. Le répertoire de sauvegarde se retrouve par
+`find node_modules -maxdepth 2 -iname '*<paquet>*'` — le préfixe `.` le cache d'un `ls` ordinaire.
+
+
+## PIT-S60-006 — `npm audit fix` échoue tant qu'un `overrides` auto-référentiel existe
+`frontend/package.json` déclare `overrides: { "postcss": "$postcss" }` ; l'arbre virtuel d'`audit fix` ne résout
+pas la référence → `npm error Unable to resolve reference $postcss`, sur **toute** invocation. L'issue #422
+affirmait pourtant que `npm audit fix` était « confirmé suffisant ». Solution retenue : `npm update <transitif>`
+quand la version corrigée tient dans la plage semver du parent (lire la plage **dans le lock** avant). **Ne pas
+glisser vers `--force`** : il accepte les bumps majeurs. Prévention : ne jamais écrire dans une issue qu'une
+commande est confirmée sans l'avoir lancée.
+
+
+## PIT-S60-007 — `npm run typecheck` rouge sur une route FANTÔME : `.next/types` d'un build antérieur
+`tsconfig.json:26` inclut `.next/types/**/*.ts`, donc `tsc` type-checke les artefacts d'un build précédent —
+au S60, une erreur citant `app/[locale]/settings/page.js`, route disparue au passage en route group. Solution :
+rebuild puis re-typecheck. **Prévention : une erreur `tsc` qui ne cite QUE `.next/**` n'est pas imputable à son
+propre diff.**
+
+
+## PIT-S60-008 — Le squatteur de port peut être un AUTRE worktree DU MÊME projet
+Variante de [[PIT-S56-004]] : `:3100` était tenu par un `next-server` de
+`worktrees/new-feature-2347-14cb9a/frontend` (up 21 h), rendant **500 sur `/fr/register`**. Le réflexe « c'est
+un autre projet du poste » ne suffit donc pas — même nom de projet, même app, mais **code d'une autre branche**.
+`lsof -a -p <pid> -d cwd` identifie le propriétaire réel. Prendre un port libre plutôt que tuer le process d'une
+autre session.
+
+
+## PIT-S60-009 — `test-quiet.sh frontend` ne lance QUE Vitest, contrairement à ce que disent le README et les briefings
+`run_frontend` exécute un seul `npm test --silent` : ni `build`, ni `typecheck`, ni `lint`. La description
+« vitest + build + typecheck + lint » circulait dans les briefings de sprint et le README. **Anti-pattern :
+conclure « frontend vert » sur ce seul scope.** Corrigé au S60 (README §Tests + piège 4). Voisin de
+[[PIT-S58-004]] : une garantie décrite mais inexistante dissuade d'en écrire une vraie.
+
+
+## PIT-S60-010 — Un commentaire de test peut annoncer une isolation que le test ne respecte pas
+`console-error-guard.test.ts:20-21` annonce que son lint de fixtures reste « isolé des plugins next/storybook ».
+Vrai pour le volet 2 (config minimale), **faux pour le volet 1**, qui appelle
+`new ESLint().calculateConfigForFile(...)` — donc charge `eslint.config.mjs` et **tous** ses imports. C'est ce
+qui rend ce fichier, et lui seul, sensible à un `node_modules` incomplet. Le commentaire a probablement orienté
+#308 vers la déclaration de dépendance plutôt que vers le cwd. Cf. [[PIT-S41-004]], [[PIT-S53-006]].
+
 ---
 
 ## §2 — Index historique (titre = règle ; détail dans docs/memory/pitfalls.md)

--- a/.ai-env/tools/pit-classification.tsv
+++ b/.ai-env/tools/pit-classification.tsv
@@ -203,3 +203,13 @@ PIT-S59-001	frontend
 PIT-S59-002	frontend
 PIT-S59-003	frontend
 PIT-S59-004	tooling
+PIT-S60-001	tooling
+PIT-S60-002	tooling
+PIT-S60-003	tooling
+PIT-S60-004	tooling
+PIT-S60-005	tooling
+PIT-S60-006	frontend
+PIT-S60-007	frontend
+PIT-S60-008	tooling
+PIT-S60-009	tooling
+PIT-S60-010	frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@
 #   `e2e` a été ajouté après constat de 2 runs consécutifs 100% verts — un job E2E
 #   instable rendu requis bloque les merges légitimes.
 #   `flyway-smoke` (#356) tourne mais n'est PAS requis : trop peu d'historique.
+#   `secret-scan` (#362) tourne mais n'est PAS requis : introduit au sprint 60, à rendre requis
+#   après un premier run vert (c'est le job dont la mise en requis a le plus de valeur : sur un
+#   dépôt PUBLIC, un secret mergé est compromis à la seconde où il atterrit sur `dev`).
 #
 # AJOUTER un check requis (PATCH ciblé — ne touche QUE les status checks, laisse
 # intacts enforce_admins / reviews / restrictions, contrairement à un PUT global) :
@@ -534,6 +537,116 @@ jobs:
           severity: CRITICAL
           exit-code: "1"
           ignore-unfixed: true
+
+  # ---------------------------------------------------------------------------
+  # Secret-scan (#362) — empêche la RÉINTRODUCTION d'un secret dans le dépôt.
+  #
+  # POURQUOI CE JOB EXISTE. Le dépôt est PUBLIC. L'audit #249 (sprint 50,
+  # `docs/memory/audits/secret-exposure-audit.md`) a mesuré qu'un mot de passe DB et un secret JWT
+  # y ont été lisibles par n'importe qui pendant ~16 mois ; ils sont compromis sans réserve, et
+  # aucune purge d'historique n'y changera rien (§6 : forks et clones tiers). Jusqu'ici RIEN
+  # n'empêchait un futur commit de recommencer. C'est la recommandation R6 de l'audit.
+  #
+  # POURQUOI UN JOB DÉDIÉ, ET PAS UNE ÉTAPE DE `security`. Trois raisons, la dernière étant
+  # dirimante :
+  #   1. Signal. `security` mélange du BLOQUANT et de l'INFORMATIF (`continue-on-error` sur
+  #      l'audit dev+prod, dont la chaîne eslint est rouge de façon connue et non corrigeable —
+  #      cf. commentaire du job). Une détection de secret ne doit pas se lire dans ce bruit.
+  #   2. Nature. `security` audite des DÉPENDANCES (CVE amont, rien à corriger dans notre code) ;
+  #      ici c'est notre propre contenu, et l'action à prendre est immédiate.
+  #   3. `fetch-depth`. Ce scan a besoin de TOUT l'historique (`fetch-depth: 0`) ; `security` se
+  #      contente du checkout superficiel par défaut. Fusionner les deux ralentirait l'audit de
+  #      dépendances sans aucune contrepartie.
+  #
+  # POURQUOI LE BINAIRE ÉPINGLÉ, ET PAS `gitleaks/gitleaks-action@v2`. L'action officielle exige
+  # un `GITLEAKS_LICENSE` pour les comptes d'organisation. `LeenVandelied` est un compte
+  # personnel, donc elle FONCTIONNERAIT aujourd'hui — mais le dépôt n'a AUCUN secret Actions
+  # configuré (audit §5 : `gh secret list` vide, 0 environnement), et faire dépendre le garde-fou
+  # d'un secret qu'il faudrait provisionner le jour où le dépôt migre vers une organisation, c'est
+  # programmer sa propre panne. Le binaire épinglé + vérification SHA-256 ne dépend de rien.
+  #
+  # PORTÉE : tout l'historique atteignable depuis HEAD, sur PR ET sur push.
+  # Le critère de l'issue est « échouer si un secret est détecté DANS LE DIFF ». Sur un événement
+  # `pull_request`, actions/checkout place HEAD sur le commit de fusion : les commits de la PR sont
+  # donc DANS l'ensemble scanné — le critère est satisfait a fortiori, sans plomberie de plage de
+  # SHA (`base.sha..head.sha`) ni son mode d'échec silencieux quand un des deux bouts n'est pas
+  # atteignable. Le coût mesuré est négligeable : 766 commits / 11,73 Mo en 1,3 s. Le scan sur
+  # `push` vers dev/main tient le rôle du « scan périodique de l'historique » du 2e critère, à la
+  # cadence des merges et sans ajouter de déclencheur `schedule` (qui rejouerait AUSSI backend,
+  # frontend et e2e, soit ~20 min de runner par semaine pour rien).
+  # Conséquence à assumer : une détection non baselinée fait rougir TOUTES les PR, pas seulement
+  # celle qui l'introduit. C'est voulu — sur un dépôt public, un secret sur `dev` est déjà perdu.
+  #
+  # ⚠ `--redact=100` est OBLIGATOIRE, pas une préférence. Les logs de ce job sont PUBLICS comme le
+  # dépôt : sans redaction, gitleaks imprimerait la valeur détectée en clair dans la sortie CI et
+  # PUBLIERAIT lui-même le secret qu'il vient de trouver — en le rendant au passage indexable hors
+  # de git, donc survivant à toute purge. Le fichier, la ligne, la règle et le commit suffisent
+  # pour agir. Pour la même raison, aucun rapport n'est uploadé en artefact.
+  #
+  # EXCLUSIONS : `.gitleaks.toml` (durables, par chemin+nom de clé) et `.gitleaksignore`
+  # (empreintes épinglées à un commit, pour l'historique déjà exposé). Chaque entrée est adossée à
+  # un § de l'audit ; les deux fichiers portent la règle de maintenance en en-tête.
+  #
+  # CE QUE CE JOB N'ATTRAPE PAS (mesuré, cf. PIT-S58-004 : un garde-fou décrit mais fictif est pire
+  # que pas de garde-fou). gitleaks ne détecte PAS le `DB_PASSWORD` de l'audit §3.1 : 10 caractères
+  # alphabétiques purs, entropie trop basse pour la règle `generic-api-key`. Vérifié en rejouant le
+  # scan sur l'historique complet — sur les deux secrets historiques, seul le `jwt.secret` (hex 128)
+  # remonte. Ce job couvre les secrets à forte entropie et les préfixes connus (`xkeysib-`,
+  # `sk_live_`, `AKIA…`, clés privées PEM, JWT) ; il ne remplace pas la revue.
+  #
+  # Tourne en parallèle (aucun `needs:`) et n'active AUCUNE branch protection.
+  # `permissions: contents: read` hérité du niveau workflow (non élargi : un scan ne fait que lire).
+  # ---------------------------------------------------------------------------
+  secret-scan:
+    name: secret-scan
+    runs-on: ubuntu-latest
+    steps:
+      # `fetch-depth: 0` : le défaut (1) ne donnerait qu'un seul commit à scanner — le job
+      # passerait au VERT sans avoir rien examiné. Ne pas le retirer.
+      - name: Checkout (historique complet)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Version ÉPINGLÉE + SHA-256 vérifié : c'est exactement la version avec laquelle les
+      # exclusions ont été calibrées en local. Un `latest` flottant changerait le jeu de règles
+      # sous nos pieds et ferait rougir la CI sur un commit qui ne touche à rien.
+      # `--fail-with-body` (curl) : sans lui, un 404 GitHub produirait un tarball HTML et une
+      # erreur de décompression illisible.
+      - name: Install gitleaks (version épinglée, checksum vérifié)
+        env:
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          set -euo pipefail
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSL --fail-with-body --retry 3 \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}" \
+            -o "$tarball"
+          echo "${GITLEAKS_SHA256}  ${tarball}" | sha256sum --check --strict
+          tar -xzf "$tarball" gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          rm -f "$tarball" gitleaks
+          gitleaks version
+
+      # `gitleaks git` (et NON `gitleaks dir`) : le mode git ne voit que le contenu SUIVI par git.
+      # `dir` scanne le système de fichiers sans respecter `.gitignore` — mesuré en local, il
+      # remontait 20 faux positifs supplémentaires depuis `frontend/.next/`, `backend/target/` et
+      # `frontend/e2e/.auth/`, tous des artefacts de build/local jamais committés. Un job qui
+      # rougit pour du contenu non versionné est un job qu'on finit par désactiver.
+      #
+      # L'ÉCHEC EST LE DÉFAUT : gitleaks sort en code 1 dès la 1re détection, `set -euo pipefail`
+      # ne la rattrape pas, le job rougit. Aucun `continue-on-error` ici — c'est tout l'objet du job.
+      - name: Scan des secrets (historique atteignable depuis HEAD)
+        run: |
+          set -euo pipefail
+          gitleaks git \
+            --config .gitleaks.toml \
+            --redact=100 \
+            --no-banner \
+            --verbose \
+            .
 
   # ---------------------------------------------------------------------------
   # ai-env-packs — garde-fou de péremption des artefacts générés du Layer B.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -64,6 +64,26 @@ paths = [
 #     couvrirait la règle `private-key` dans TOUT le fichier — donc une VRAIE clé privée collée ici
 #     passerait inaperçue. Testé : avec le critère, un bloc PEM authentique dans ce fichier est
 #     bien détecté ; sans lui, il ne l'était pas.
+# --- 3. Fixture `SECRET` d'ExportTokenServiceTest — audit §4.2, même famille que le bloc 1.
+#
+# La constante s'appelle `SECRET` et non `EXPORT_TOKEN_SECRET` : le bloc 1, qui filtre par NOM de
+# clé, ne la couvre donc pas. Elle était initialement épinglée dans `.gitleaksignore`, ce qui
+# violait la règle de ce fichier (« ne jamais y épingler une occurrence encore au HEAD ») —
+# détecté par l'audit sécurité de fin de sprint. Une empreinte `commit:fichier:règle:ligne` sur
+# une ligne jamais retouchée ne rougit jamais : le masquage devenait permanent et silencieux.
+#
+# Ancrage retenu : le marqueur `test-only-insecure` porté par la VALEUR elle-même, en base64
+# (`dGVzdC1vbmx5LWluc2VjdXJl` décode « test-only-insecure »), ET ce seul fichier de test.
+# `condition = "AND"` pour la même raison qu'au bloc 1 — sans lui, le marqueur blanchirait cette
+# valeur partout dans le dépôt. Vérifié empiriquement dans les deux sens : un secret DIFFÉRENT
+# dans ce même fichier reste détecté, et cette même valeur dans un autre fichier reste détectée.
+[[allowlists]]
+description = "Fixture SECRET base64 test-only-insecure (ExportTokenServiceTest, audit #249 §4.2)"
+condition = "AND"
+regexTarget = "line"
+regexes = ['''dGVzdC1vbmx5LWluc2VjdXJl''']
+paths = ['''(^|/)backend/src/test/java/.*/ExportTokenServiceTest\.java$''']
+
 [[allowlists]]
 description = "Armure PEM littérale, clé générée au run (JwtServiceRs256Test)"
 targetRules = ["private-key"]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,73 @@
+# Configuration gitleaks — job CI `secret-scan` (#362, sprint 60).
+#
+# POURQUOI CE FICHIER. Le dépôt est PUBLIC et l'audit #249 (sprint 50,
+# `docs/memory/audits/secret-exposure-audit.md`) a établi qu'un mot de passe DB et un secret
+# JWT y ont été lisibles ~16 mois. Aucun garde-fou n'empêchait leur réintroduction. Ce fichier
+# porte les SEULES exclusions, chacune adossée à un constat écrit de cet audit.
+#
+# RÈGLE DE MAINTENANCE. Une exclusion se justifie par un §  de l'audit, jamais par « la CI est
+# rouge ». Deux mécanismes, à ne pas confondre :
+#   - CE FICHIER : exclusions DURABLES, valables pour toute occurrence future (indépendantes du
+#     commit). Réservé aux valeurs jetables assumées et aux faux positifs de règle.
+#   - `.gitleaksignore` : empreintes `commit:fichier:règle:ligne` ÉPINGLÉES À UN COMMIT, pour
+#     l'historique déjà exposé (immuable). Ne jamais y ajouter une occurrence encore au HEAD :
+#     l'empreinte changerait au prochain commit touchant le fichier et la CI rougirait.
+#
+# CE QUE CETTE CONFIG NE COUVRE PAS (mesuré, pas supposé — cf. PIT-S58-004) : gitleaks n'a PAS
+# détecté le `DB_PASSWORD` historique de l'audit §3.1 (10 caractères alphabétiques purs, entropie
+# trop basse pour `generic-api-key`). Le job attrape les secrets de forme aléatoire ou à préfixe
+# connu (`xkeysib-`, `sk_live_`, `AKIA…`, clés privées PEM, JWT) ; il n'attrape PAS un mot de passe
+# court ressemblant à un mot du dictionnaire. Ce n'est pas un substitut à la revue.
+
+[extend]
+useDefault = true
+
+# --- 1. EXPORT_TOKEN_SECRET dev / test / CI — audit §4.2, statut « accepté, pas de suite ».
+#
+# Seul matériel HMAC encore committé au HEAD. Trois valeurs DISTINCTES (aucune réutilisation
+# croisée), chacune contenant en clair, une fois décodée, ses propres marqueurs `insecure` /
+# `only` / `change`. Elles ne peuvent pas devenir un secret de production par oubli : en profil
+# `prod`, `EXPORT_TOKEN_SECRET` est obligatoire et le boot échoue s'il manque (garde-fou #323).
+#
+# `condition = "AND"` est INDISPENSABLE : par défaut un bloc `[[allowlists]]` combine ses critères
+# en OU — le seul `regexes` suffirait alors à blanchir un `EXPORT_TOKEN_SECRET` posé N'IMPORTE OÙ,
+# y compris dans un fichier de prod. Vérifié empiriquement avant livraison (avec `AND`, la même
+# valeur dans un chemin hors liste est toujours détectée).
+[[allowlists]]
+description = "EXPORT_TOKEN_SECRET jetable dev/test/CI (audit #249 §4.2)"
+condition = "AND"
+regexTarget = "line"
+regexes = [
+  '''(?i)EXPORT_TOKEN_SECRET''',
+  '''(?i)app\.export\.token-secret''',
+]
+paths = [
+  '''(^|/)\.env\.example$''',
+  '''(^|/)\.github/workflows/ci\.yml$''',
+  '''(^|/)backend/src/test/resources/application-test\.properties$''',
+  '''(^|/)backend/src/test/java/.*/ExportTokenServiceTest\.java$''',
+]
+
+# --- 2. Faux positif de règle : littéral d'armure PEM dans un test.
+#
+# `JwtServiceRs256Test.keyMaterial_acceptsPemArmorAndLineBreaks` construit une chaîne
+# "-----BEGIN PRIVATE KEY-----\n" + <clé GÉNÉRÉE AU RUN> pour vérifier qu'un opérateur collant un
+# .pem entier n'obtient pas un boot cassé. Aucun matériel de clé n'est committé : `privateKeyBase64`
+# vient d'un `KeyPair` généré dans le test. C'est l'armure, pas la clé, que gitleaks voit.
+#
+# Triple restriction, chacune vérifiée empiriquement avant livraison :
+#   - `targetRules` : n'exclut que la règle `private-key`. Une clé d'API posée dans ce même
+#     fichier reste détectée (`generic-api-key`).
+#   - `paths` : ce seul fichier de test.
+#   - `regexes` + `condition = "AND"` : la ligne doit contenir le LITTÉRAL JAVA de l'armure,
+#     `"-----BEGIN PRIVATE KEY-----\n"` (guillemet + `\n` échappé). Sans ce 3e critère, l'exclusion
+#     couvrirait la règle `private-key` dans TOUT le fichier — donc une VRAIE clé privée collée ici
+#     passerait inaperçue. Testé : avec le critère, un bloc PEM authentique dans ce fichier est
+#     bien détecté ; sans lui, il ne l'était pas.
+[[allowlists]]
+description = "Armure PEM littérale, clé générée au run (JwtServiceRs256Test)"
+targetRules = ["private-key"]
+condition = "AND"
+regexTarget = "line"
+regexes = ['''"-----BEGIN PRIVATE KEY-----\\n"''']
+paths = ['''(^|/)backend/src/test/java/.*/JwtServiceRs256Test\.java$''']

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -37,7 +37,9 @@ e5c8ffdf26d05d8933dfe9de9fd3fe32b889f0e9:backend/src/test/java/com/matimeline/ev
 68b1bc478db36b17b8dfbeea943b293aef26d90f:backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/RegisterLoginIntegrationTest.java:generic-api-key:40
 d3a776ffee0ec45537e5ea29dc948082dcadd10c:backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/SessionRevocationIntegrationTest.java:generic-api-key:60
 
-# --- Ancien nom `SECRET` du fixture d'ExportTokenService (base64 de "test-only-insecure-jwt…").
-# Le nom actuel (`EXPORT_TOKEN_SECRET`) est couvert durablement par `.gitleaks.toml` ; cette
-# occurrence-ci porte l'ancien nom et n'entre donc pas dans l'allowlist par nom de clé.
-0d1d739532b2bacd0201ad9a3b22155aff282be9:backend/src/test/java/com/matimeline/eventmanager/infrastructure/security/ExportTokenServiceTest.java:generic-api-key:27
+# --- RETIRÉ (audit sécurité S60). Le fixture `SECRET` d'`ExportTokenServiceTest` est TOUJOURS
+# présent au HEAD (`ExportTokenServiceTest.java:40`) : l'épingler ici violait la règle énoncée
+# 25 lignes plus haut, et la violait dans le sens le plus discret — la ligne n'ayant jamais été
+# retouchée, l'empreinte restait valide indéfiniment et le masquage devenait permanent au lieu
+# de rougir. Déplacé en exclusion DURABLE dans `.gitleaks.toml` (bloc 3), ancrée sur le marqueur
+# `test-only-insecure` de la valeur elle-même et sur ce seul fichier.

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,43 @@
+# Empreintes gitleaks épinglées — historique DÉJÀ EXPOSÉ (#362, sprint 60).
+#
+# Format : commit:fichier:règle:ligne. Chaque ligne désigne UN commit précis et immuable ;
+# aucune n'accorde de blanc-seing à un fichier. Un secret réintroduit dans ces mêmes fichiers
+# produira une empreinte DIFFÉRENTE (nouveau commit) et fera rougir la CI.
+#
+# POURQUOI CES LIGNES EXISTENT. Le dépôt est PUBLIC. L'audit #249 (sprint 50,
+# `docs/memory/audits/secret-exposure-audit.md` §3.1/§3.2) a établi que ces valeurs ont été
+# lisibles ~16 mois : elles sont COMPROMISES SANS RÉSERVE et le resteront après toute purge
+# d'historique (#112, cf. §6 « les forks et clones tiers »). Les baseliner ne les protège pas
+# — c'est déjà perdu. Sans ce fichier, le scan d'historique rougirait à CHAQUE run sur des
+# constats connus et le job serait ignoré puis désactivé, ce qui est exactement le mode
+# d'échec que #362 veut éviter.
+#
+# NE PAS ajouter ici une occurrence encore présente au HEAD : son empreinte changerait au
+# prochain commit touchant le fichier. Les valeurs jetables assumées vont dans `.gitleaks.toml`.
+# NE PAS ajouter de ligne sans un § d'audit correspondant : cf. `.gitleaks.toml` en-tête.
+
+# --- `jwt.secret` (HS256, hex 128) — audit §3.2. EXPOSÉ 164 commits, 2025-03-14 -> 2026-06-25.
+# Retiré du HEAD par `ff5dca3` (#34) puis le mécanisme entier supprimé par `1758c0c` (#323, RS256).
+53175dafb8a0d9195c41031f903f42b1761b074d:backend/src/main/resources/application.properties:generic-api-key:12
+5c73971d33ffa5fa3c9841798e3b2710f84c08c8:backend/src/main/resources/application.properties:generic-api-key:12
+
+# --- `JWT_SECRET` historique hors code source — audit §4.1, les trois emplacements ont disparu
+# avec `1758c0c`. Aucun de ces fichiers n'est allowlisté durablement : seuls ces commits le sont.
+da929b6668cf9d56c5e05b3ef3aaffa1539fe482:.env.example:generic-api-key:26
+952533aa48e3b787a9ef4ac0fa48731fcf0bc3f6:.github/workflows/ci.yml:generic-api-key:158
+da929b6668cf9d56c5e05b3ef3aaffa1539fe482:backend/src/test/resources/application-test.properties:generic-api-key:28
+b0c76801f15f89691072bc025b07154053857d4b:docs/memory/sprints/sprint-47/e2e-local-runbook.md:generic-api-key:28
+
+# --- Fixtures `jwt.secret=` de tests d'intégration (@TestPropertySource), base64 de
+# "0123456789abcdef…" — matériel de test, jamais un secret réel, et la propriété `jwt.secret`
+# n'existe plus depuis #323. Historique uniquement : absent du HEAD.
+00dc7ca5480987e27e8cab6b045dd5b4bb66004f:backend/src/test/java/com/matimeline/eventmanager/application/services/ExportPurgeSchedulerIntegrationTest.java:generic-api-key:44
+e5c8ffdf26d05d8933dfe9de9fd3fe32b889f0e9:backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/AccountDeletionIntegrationTest.java:generic-api-key:55
+0d1d739532b2bacd0201ad9a3b22155aff282be9:backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/ExportEndpointsIntegrationTest.java:generic-api-key:61
+68b1bc478db36b17b8dfbeea943b293aef26d90f:backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/RegisterLoginIntegrationTest.java:generic-api-key:40
+d3a776ffee0ec45537e5ea29dc948082dcadd10c:backend/src/test/java/com/matimeline/eventmanager/infrastructure/adapters/controllers/SessionRevocationIntegrationTest.java:generic-api-key:60
+
+# --- Ancien nom `SECRET` du fixture d'ExportTokenService (base64 de "test-only-insecure-jwt…").
+# Le nom actuel (`EXPORT_TOKEN_SECRET`) est couvert durablement par `.gitleaks.toml` ; cette
+# occurrence-ci porte l'ancien nom et n'entre donc pas dans l'allowlist par nom de clé.
+0d1d739532b2bacd0201ad9a3b22155aff282be9:backend/src/test/java/com/matimeline/eventmanager/infrastructure/security/ExportTokenServiceTest.java:generic-api-key:27

--- a/README.md
+++ b/README.md
@@ -164,6 +164,29 @@ jamais silencieusement.
   compare deux identifiants différents. Rien à voir avec le code testé. (La CI est déjà en
   `workers: 1`.)
 
+### 4. `node_modules` est propre à chaque copie de travail, et son absence ment sur la cause
+
+Chaque worktree (`.claude/worktrees/…`) a **son propre** `frontend/node_modules` ; il n'est pas
+partagé avec le dépôt principal. Deux conséquences, l'une gênante, l'autre trompeuse :
+
+- Lancer `./scripts/test-quiet.sh frontend` depuis le dépôt principal **ne teste pas** le code du
+  worktree, et inversement. Le script résout ses chemins depuis sa propre position, jamais depuis
+  le répertoire courant — c'est donc le script appelé qui décide du code testé.
+- Si les dépendances n'ont jamais été installées dans la copie testée, le symptôme brut était
+  `Cannot find package 'eslint-plugin-storybook'` dans
+  `frontend/src/__tests__/console-error-guard.test.ts`. Ce test charge la configuration ESLint
+  **réelle** (`new ESLint().calculateConfigForFile`), donc exécute les imports de
+  `frontend/eslint.config.mjs`. L'erreur se lit comme une régression de la garde anti-fuite de
+  credentials `#160`/`#258` alors que seul l'environnement est en cause — le cas s'est produit
+  deux fois, dont un rapport d'agent entièrement faux mais plausible.
+
+`test-quiet.sh frontend` échoue désormais **avant** Vitest, en sortie 3, avec le répertoire testé,
+la commande de correction et le rappel ci-dessus. Correctif : `( cd frontend && npm ci )` dans la
+copie concernée.
+
+L'**approvisionnement automatique** de `node_modules` dans les worktrees n'est pas traité : c'est
+l'objet de l'issue #272. Le préflight se contente de nommer le problème au lieu de le déguiser.
+
 ## Tests
 
 Depuis la racine, [`scripts/test-quiet.sh`](scripts/test-quiet.sh) condense la sortie et ne
@@ -193,8 +216,12 @@ Avant de lancer la suite E2E, **lire** :
 - [`frontend/e2e/README.md`](frontend/e2e/README.md) — harnais de contrôle de contraste et de
   troncature des CTA.
 
+`test-quiet.sh frontend` ne lance **que** Vitest — ni `build`, ni `typecheck`, ni `lint`, qui
+s'appellent séparément (cf. équivalents directs ci-dessus). Il sort en **3**, avant Vitest, si les
+dépendances de la copie testée sont absentes ou incomplètes (cf. piège 4).
+
 La CI ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) rejoue les jobs `backend`,
-`frontend`, `e2e` et `security` à chaque push.
+`frontend`, `e2e`, `flyway-smoke`, `security`, `secret-scan` et `ai-env-packs` à chaque push.
 
 ## Mise en production
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ copie concernée.
 L'**approvisionnement automatique** de `node_modules` dans les worktrees n'est pas traité : c'est
 l'objet de l'issue #272. Le préflight se contente de nommer le problème au lieu de le déguiser.
 
+Ce que le préflight **n'attrape pas** : il ne lit que les `import` **mono-ligne** de
+`frontend/eslint.config.mjs`. Un import réparti sur plusieurs lignes, ou un `import()` dynamique,
+passerait sous son radar — et le symptôme trompeur reviendrait tel quel. À garder en tête si un
+futur plugin ESLint est ajouté autrement qu'en une ligne.
+
 ## Tests
 
 Depuis la racine, [`scripts/test-quiet.sh`](scripts/test-quiet.sh) condense la sortie et ne

--- a/docs/memory/audits/secret-exposure-audit.md
+++ b/docs/memory/audits/secret-exposure-audit.md
@@ -339,11 +339,23 @@ maintenance en en-tête. **Aucune n'a été ajoutée pour « faire passer la CI 
      littéral Java `"-----BEGIN PRIVATE KEY-----\n"`** → faux positif : le test enrobe une clé
      **générée au run** pour vérifier qu'un `.pem` collé ne casse pas le boot. Le 3ᵉ critère
      (`regexes`) est ce qui empêche l'exclusion de couvrir tout le fichier.
-- **`.gitleaksignore`** — 12 empreintes `commit:fichier:règle:ligne`, **épinglées à des commits
+  3. Fixture `SECRET` d'`ExportTokenServiceTest`, ancré sur le marqueur `test-only-insecure` de la
+     valeur (en base64) **et** sur ce seul fichier. La constante ne s'appelant pas
+     `EXPORT_TOKEN_SECRET`, l'exclusion 1 — qui filtre par nom de clé — ne la couvrait pas.
+- **`.gitleaksignore`** — **11** empreintes `commit:fichier:règle:ligne`, **épinglées à des commits
   immuables** : le `jwt.secret` de §3.2 (2), les `JWT_SECRET` hors code source de §4.1 (4), les
-  fixtures `jwt.secret=` de tests d'intégration (5), l'ancien nom `SECRET` du fixture
-  `ExportTokenService` (1). Aucun de ces fichiers n'est blanchi pour l'avenir : une réintroduction
-  produit une empreinte différente et fait rougir la CI.
+  fixtures `jwt.secret=` de tests d'intégration (5). Aucun de ces fichiers n'est blanchi pour
+  l'avenir : une réintroduction produit une empreinte différente et fait rougir la CI. **Toutes ces
+  occurrences sont absentes du HEAD**, vérifié.
+
+  > **Correction apportée par l'audit sécurité de fin de sprint.** Une 12ᵉ empreinte visait le
+  > fixture `SECRET` d'`ExportTokenServiceTest`, **encore présent au HEAD** — ce que la règle en
+  > tête de `.gitleaksignore` interdit explicitement. Le défaut était discret plutôt que bruyant :
+  > la ligne n'ayant jamais été retouchée depuis son commit d'introduction, l'empreinte restait
+  > valide indéfiniment, donc le masquage devenait **permanent** au lieu de rougir au premier
+  > reformatage. Remplacée par l'exclusion durable 3 ci-dessus, vérifiée dans les deux sens : la
+  > même valeur dans `application-prod.properties` reste détectée, et une clé Stripe placée dans
+  > `ExportTokenServiceTest.java` reste détectée.
 
 ### 9.3 Limite mesurée — ce que le job N'attrape PAS
 

--- a/docs/memory/audits/secret-exposure-audit.md
+++ b/docs/memory/audits/secret-exposure-audit.md
@@ -296,7 +296,7 @@ des **obligations différées au premier déploiement**, pas des actions exécut
 | ~~R3~~ | ~~Remplacer `.env.example:26` par un placeholder explicitement marqué~~ | **SANS OBJET** — `JWT_SECRET` supprimé par #323 (`1758c0c`), cf. §4.1 | — |
 | R4 | Ajouter `BREVO_API_KEY` à `.env.example` (absent : le fichier liste `SPRING_PROFILES_ACTIVE`, `DB_USERNAME`, `DB_PASSWORD`, `POSTGRES_DB`, `JWT_PRIVATE_KEY`, `EXPORT_TOKEN_SECRET`, `NEXT_PUBLIC_API_URL`, `APP_CANONICAL_HOST`, `AUTH_JWT_PUBLIC_KEY` — énumération ré-ancrée à la revue S50 : `JWT_SECRET` n'y figure plus depuis #323) | divergence avec `application.properties.example` | follow-up |
 | ~~R5~~ | ~~Sortir le `jwt.secret` de `application-test.properties:28`~~ | **SANS OBJET** — la clé n'existe plus ; `jwt.private-key=` est vide et la paire de test est générée au run (#323), cf. §4.1 | — |
-| R6 | Poser un scan de secrets en CI (`gitleaks`/`trufflehog`) pour empêcher toute réintroduction | aucun garde-fou automatique aujourd'hui | follow-up |
+| ~~R6~~ | ~~Poser un scan de secrets en CI (`gitleaks`/`trufflehog`)~~ | **FAIT** — job `secret-scan` (#362, sprint 60), cf. §9 | ✅ #362 |
 | R7 | Exécuter la purge d'historique #112 **après** avoir acté que R1/R2 rendent les valeurs inutiles | la purge seule ne « décompromet » rien | dev |
 
 ---
@@ -307,3 +307,65 @@ des **obligations différées au premier déploiement**, pas des actions exécut
 - `docs/memory/devops/external-services-inventory.md` — inventaire + **§3quater** procédure par service
 - `docs/memory/sprints/sprint-29/issue-112-done.md` — runbook de purge d'historique
 - Issue #249 (rotation), #323 (RS256, vague 2 S50), #250 (inventaire services), #112 (purge)
+- Issue **#362** (sprint 60) — application de R6, cf. §9
+
+---
+
+## 9. Garde-fou CI contre la réintroduction — R6 appliquée (#362, sprint 60)
+
+### 9.1 Ce qui a été posé
+
+Job **`secret-scan`** dans `.github/workflows/ci.yml`, sur `pull_request` **et** `push` (dev, main).
+
+| Choix | Décision | Pourquoi |
+|---|---|---|
+| Outil | **gitleaks** 8.30.1 | R6 laissait le choix ouvert. Retenu pour son mécanisme d'exclusion à **deux étages** (`.gitleaks.toml` durable / `.gitleaksignore` épinglé au commit), indispensable ici : l'historique exposé de §3 est **immuable** et doit être baseliné sans blanchir les fichiers concernés pour l'avenir. |
+| Intégration | **binaire épinglé + SHA-256 vérifié**, pas `gitleaks/gitleaks-action@v2` | L'action exige `GITLEAKS_LICENSE` pour les comptes **d'organisation**. `LeenVandelied` est un compte personnel, donc elle marcherait *aujourd'hui* — mais §5 établit **0 secret Actions / 0 environnement** : adosser le garde-fou à un secret à provisionner le jour d'une migration en organisation, c'est programmer sa panne. |
+| Emplacement | **job dédié**, pas une étape de `security` | `security` mêle bloquant et `continue-on-error` (chaîne eslint rouge, non corrigeable) ; et ce scan exige `fetch-depth: 0` là où `security` se contente du checkout superficiel. |
+| Portée | historique **atteignable depuis HEAD** | Contient les commits de la PR (checkout sur le commit de fusion) → le critère « échouer sur le diff » est satisfait *a fortiori*, sans plomberie `base.sha..head.sha`. Coût mesuré : **766 commits / 11,73 Mo en ~1 s**. Le scan sur `push` tient le rôle du scan périodique, à la cadence des merges, sans déclencheur `schedule` (qui rejouerait aussi backend/frontend/e2e). |
+| Redaction | `--redact=100` **obligatoire** | Les logs CI d'un dépôt public sont publics : sans redaction, le job **publierait** en clair le secret qu'il vient de détecter, hors de git donc survivant à toute purge (#112). Aucun rapport n'est uploadé en artefact, pour le même motif. |
+
+### 9.2 Exclusions (critère d'acceptation 4)
+
+Chaque exclusion est adossée à un § de cet audit ; les deux fichiers portent leur règle de
+maintenance en en-tête. **Aucune n'a été ajoutée pour « faire passer la CI ».**
+
+- **`.gitleaks.toml`** — exclusions **durables**, valables pour les occurrences futures :
+  1. `EXPORT_TOKEN_SECRET` / `app.export.token-secret` dans `.env.example`, `ci.yml`,
+     `application-test.properties`, `ExportTokenServiceTest.java` → **§4.2** (« accepté, pas de
+     suite » : valeurs jetables auto-documentées, impossibles à promouvoir en prod par oubli).
+     `condition = "AND"` (chemin **et** nom de clé) : la même valeur ailleurs reste détectée.
+  2. Règle `private-key` dans `JwtServiceRs256Test.java`, **et seulement sur la ligne portant le
+     littéral Java `"-----BEGIN PRIVATE KEY-----\n"`** → faux positif : le test enrobe une clé
+     **générée au run** pour vérifier qu'un `.pem` collé ne casse pas le boot. Le 3ᵉ critère
+     (`regexes`) est ce qui empêche l'exclusion de couvrir tout le fichier.
+- **`.gitleaksignore`** — 12 empreintes `commit:fichier:règle:ligne`, **épinglées à des commits
+  immuables** : le `jwt.secret` de §3.2 (2), les `JWT_SECRET` hors code source de §4.1 (4), les
+  fixtures `jwt.secret=` de tests d'intégration (5), l'ancien nom `SECRET` du fixture
+  `ExportTokenService` (1). Aucun de ces fichiers n'est blanchi pour l'avenir : une réintroduction
+  produit une empreinte différente et fait rougir la CI.
+
+### 9.3 Limite mesurée — ce que le job N'attrape PAS
+
+⚠️ À lire avant de considérer §3 comme « couvert ». Le scan **ne détecte pas** le `DB_PASSWORD` de
+**§3.1** : 10 caractères alphabétiques purs, entropie trop basse pour `generic-api-key`. Vérifié en
+rejouant le scan sur l'historique complet — des deux secrets de §1, seul le `jwt.secret` (hex 128)
+remonte. Le job couvre les secrets à forte entropie et les préfixes connus (`xkeysib-`, `sk_live_`,
+`AKIA…`, armures PEM, JWT) ; **un mot de passe court ressemblant à un mot du dictionnaire lui
+échappe**. Ce n'est pas un substitut à la revue, et §6 (« ce que cet audit ne couvre pas ») reste
+valable.
+
+### 9.4 Vérifications exécutées (2026-08-17)
+
+| Vérification | Résultat |
+|---|---|
+| Historique complet, config + baseline | **766 commits, 0 détection, exit 0** |
+| Historique complet, **sans** exclusions | 21 détections, exit 1 (dont 16 purement historiques) |
+| `gitleaks dir` (mode fichiers) | écarté : **+20 faux positifs**, il ignore `.gitignore` (`frontend/.next/`, `backend/target/`, `frontend/e2e/.auth/`) → le job utilise `gitleaks git`, qui ne voit que le contenu suivi |
+| Détection réelle d'un secret planté | **confirmée** : clé AWS et clé Stripe → détectées ; secret au bon nom mais **hors** chemin allowlisté → détecté ; autre nom de clé **dans** un chemin allowlisté → détecté ; vraie armure PEM dans le fichier de test → détectée |
+| Non-régression des 3 fichiers livrés | `.gitleaks.toml`, `.gitleaksignore`, `ci.yml` ne s'auto-détectent pas (exit 0) |
+| Syntaxe YAML de `ci.yml` | valide (7 jobs ; `permissions`, `concurrency` inchangés) |
+
+**Reste à faire (mainteneur)** : rendre `secret-scan` requis sur `dev` après un premier run vert
+(cf. en-tête de `ci.yml` pour le `PATCH` ciblé). Non fait ici — un check rendu requis avant son
+premier run vert bloquerait toutes les fusions, y compris la PR qui l'introduit.

--- a/docs/memory/audits/sprint-60-test-coverage.md
+++ b/docs/memory/audits/sprint-60-test-coverage.md
@@ -70,10 +70,13 @@ Aucune dette E2E créée par ce sprint. `[COVERAGE-E2E] OK`.
    l'audit §3.1 (10 caractères alphabétiques, entropie sous le seuil de `generic-api-key`). Le job
    attrape les secrets à préfixe connu ou à forte entropie ; il n'est pas un substitut à la revue.
    Documenté dans `.gitleaks.toml` plutôt que passé sous silence.
-3. **La liste réelle des checks requis sur `dev` n'a pas pu être relue** : l'endpoint
-   `branches/dev/protection` et l'API GraphQL répondent **HTTP 503** de façon persistante
-   (dégradation GitHub — le REST ordinaire fonctionne, rate limit interrogeable). Aucune
-   affirmation sur les checks requis n'est donc vérifiée dans ce sprint.
+3. ~~La liste des checks requis n'a pas pu être relue~~ — **levée.** L'endpoint
+   `branches/dev/protection` et l'API GraphQL ont répondu **HTTP 503** pendant ~2 h (dégradation
+   GitHub ; le REST ordinaire fonctionnait). Au retour du service, la liste réelle des checks
+   requis sur `dev` est : **`backend`, `frontend`, `e2e`, `ai-env-packs`** — 4 contextes.
+   `security` et `secret-scan` n'en font pas partie : conforme à ce que le sprint annonce, et
+   c'est précisément pourquoi `secret-scan` devra être promu requis après un premier run vert
+   (follow-up).
 4. **Branches non exercées du préflight #308** : `node_modules` totalement absent, et
    `node_modules` vide. Le code les traite, seul le cas « paquet manquant » a été déclenché
    réellement. Les reproduire exigeait de déplacer tout `node_modules` — écarté.

--- a/docs/memory/audits/sprint-60-test-coverage.md
+++ b/docs/memory/audits/sprint-60-test-coverage.md
@@ -63,9 +63,12 @@ Aucune dette E2E créée par ce sprint. `[COVERAGE-E2E] OK`.
 
 ## Ce qui n'est PAS couvert — à lire avant de fusionner
 
-1. **Le job `secret-scan` n'a jamais tourné sur un runner GitHub.** Le téléchargement du binaire
-   gitleaks et son `sudo install` ne sont pas exercés localement. Premier run réel à surveiller
-   sur la PR.
+1. ~~Le job `secret-scan` n'a jamais tourné sur un runner GitHub~~ — **levée par la PR #432.**
+   Les 7 jobs sont verts au premier run : `secret-scan` **pass en 8 s** (téléchargement du binaire
+   et `sudo install` donc bien exercés), `ai-env-packs` 10 s, `security` **39 s — vert**, `backend`
+   1 min 11, `flyway-smoke` 51 s, `frontend` 2 min 26, `e2e` 6 min 39.
+   Le job `security` était rouge sur **toutes** les PR du dépôt avant ce sprint : c'est la preuve
+   de l'objectif atteint, pas un détail de tableau de bord.
 2. **Angle mort mesuré du scan** : gitleaks ne détecte **pas** le `DB_PASSWORD` historique de
    l'audit §3.1 (10 caractères alphabétiques, entropie sous le seuil de `generic-api-key`). Le job
    attrape les secrets à préfixe connu ou à forte entropie ; il n'est pas un substitut à la revue.

--- a/docs/memory/audits/sprint-60-test-coverage.md
+++ b/docs/memory/audits/sprint-60-test-coverage.md
@@ -1,0 +1,118 @@
+# Audit tests — Sprint 60
+
+> Généré en fin de Phase 6. Sprint « Rendre le signal CI security exploitable » — issues #422, #362, #308.
+> Rédigé par le lead. Tous les chiffres ci-dessous ont été **mesurés depuis le worktree
+> `sprint/60`**, avec les codes de sortie réels lus via `rtk proxy` (`PIT-S45-003` : le wrapper RTK
+> a déjà affiché « PASS » sur un `exit 1`).
+
+## Couverture par issue
+
+Aucune des trois issues ne touche une règle métier (`BR-*`) : le tableau canonique par BR est donc
+sans objet ici. Le sprint est entièrement outillage / CI / dépendances. La grille est reprise par
+issue, avec la même exigence de preuve.
+
+| Issue | Nature | Cross-system flow | Test unitaire | Vérification exécutée | E2E | Preuve du cas négatif |
+|---|---|:---:|:---:|:---:|:---:|:---:|
+| #422 `nanoid` ≥ 3.3.18 | dépendance transitive | NON | ✅ suite frontend | ✅ `npm audit` avant/après | ✅ suite complète | ✅ audit rouge → vert |
+| #362 scan de secrets CI | job CI | NON | ⚠ sans objet (YAML) | ✅ scan réel + YAML validé | ⚠ sans objet | ✅ secrets plantés détectés |
+| #308 préflight `node_modules` | script shell | NON | ⚠ sans objet (shell) | ✅ 3 scopes + `bash -n` | ⚠ sans objet | ✅ garde-fou déclenché |
+
+`⚠ sans objet` = la nature du livrable exclut ce type de test, pas un manque de couverture. Chaque
+cellule est compensée par une vérification exécutée, colonne suivante.
+
+## Tests et vérifications exécutés
+
+### #422 — bump `nanoid`
+- `npm audit --omit=dev --audit-level=high` (commande exacte de l'étape bloquante `ci.yml`) :
+  **avant** `1 high severity vulnerability`, exit 1 → **après** `found 0 vulnerabilities`, **exit 0**.
+- `nanoid` : 3.3.16 → 3.3.18 dans `frontend/package-lock.json`. **Aucune cascade** :
+  1 fichier, 3 insertions / 3 suppressions.
+- `./scripts/test-quiet.sh frontend` → exit 0, 95 fichiers / 888 tests.
+- `npm run build`, `npm run typecheck`, `npm run lint` → exit 0 chacun.
+- `./scripts/test-quiet.sh e2e` → **exit 0, 169 passed / 0 failed / 8 skipped (177)**, 1,8 min.
+  Stack : backend Docker `:8086` profil e2e, frontend buildé avec `E2E_API_PROXY_TARGET=:8086`,
+  `next start -p 3000`, `CI=1 --workers=1`.
+
+### #362 — job CI `secret-scan`
+- `ci.yml` : YAML valide, 7 jobs, `on: pull_request + push` → `dev`, `main`.
+  **Validé via Ruby par le lead** — PyYAML n'est pas installé sur ce poste, donc la commande
+  `python3 -c "import yaml"` annoncée par l'agent n'a pas pu s'exécuter telle quelle.
+- Scan du dépôt avec la configuration livrée, **rejoué par le lead** :
+  **768 commits, 0 détection, exit 0**, 937 ms.
+- Preuve que le job n'est pas inerte, dans des dépôts git **jetables hors du dépôt** :
+  clé AWS + clé Stripe → **2 détections, exit 1** ; clé Brevo `xkeysib-` → **1 détection, exit 1**.
+- Deux défauts trouvés et corrigés **avant** livraison par l'agent, chacun retesté dans les deux
+  sens : allowlist combinant ses critères en OU par défaut (blanchissait `EXPORT_TOKEN_SECRET`
+  partout) ; exclusion par fichier qui laissait passer une vraie clé PEM dans le fichier de test.
+
+### #308 — préflight `node_modules`
+- Cas dégradé **réellement déclenché** (renommage réversible du plugin, restauration vérifiée) :
+  `./scripts/test-quiet.sh frontend` → **exit 3**, message actionnable, Vitest jamais lancé.
+- Cas nominal : → **exit 0**, 95 fichiers / 888 tests — identique au repère de #422.
+- Scope inconnu → **exit 2**, message inchangé. `bash -n scripts/test-quiet.sh` → exit 0.
+
+### Backend
+**Suite backend non exécutée en local.** Justification : le diff ne contient **aucun** fichier
+`backend/**` (cf. `git diff --stat origin/dev...HEAD` : 10 fichiers, aucun Java, aucun SQL, aucune
+migration). Le job CI **`backend`** est un check requis sur `dev` et rejouera la suite sur la PR.
+C'est une omission assumée et bornée, pas un oubli.
+
+## Couverture E2E des nouveaux éléments d'interface
+Heuristique Phase 8 : **aucun fichier `.tsx` modifié**, donc aucun `data-testid` introduit.
+Aucune dette E2E créée par ce sprint. `[COVERAGE-E2E] OK`.
+
+## Ce qui n'est PAS couvert — à lire avant de fusionner
+
+1. **Le job `secret-scan` n'a jamais tourné sur un runner GitHub.** Le téléchargement du binaire
+   gitleaks et son `sudo install` ne sont pas exercés localement. Premier run réel à surveiller
+   sur la PR.
+2. **Angle mort mesuré du scan** : gitleaks ne détecte **pas** le `DB_PASSWORD` historique de
+   l'audit §3.1 (10 caractères alphabétiques, entropie sous le seuil de `generic-api-key`). Le job
+   attrape les secrets à préfixe connu ou à forte entropie ; il n'est pas un substitut à la revue.
+   Documenté dans `.gitleaks.toml` plutôt que passé sous silence.
+3. **La liste réelle des checks requis sur `dev` n'a pas pu être relue** : l'endpoint
+   `branches/dev/protection` et l'API GraphQL répondent **HTTP 503** de façon persistante
+   (dégradation GitHub — le REST ordinaire fonctionne, rate limit interrogeable). Aucune
+   affirmation sur les checks requis n'est donc vérifiée dans ce sprint.
+4. **Branches non exercées du préflight #308** : `node_modules` totalement absent, et
+   `node_modules` vide. Le code les traite, seul le cas « paquet manquant » a été déclenché
+   réellement. Les reproduire exigeait de déplacer tout `node_modules` — écarté.
+5. **Préflight sous un `node_modules` en symlink** vers le dépôt principal (contournement décrit
+   par #272) : non testé.
+6. `npm ci` from scratch non rejoué côté #422 (arbre mis à jour en place par `npm update`).
+
+## Review batch et audit sécurité (Phases 5 et 7)
+
+**Reviewer** — aucun `[CRITIQUE]`. Un `[MAJEUR]` qui demandait une contre-épreuve plutôt qu'il ne
+constatait un défaut (portée réelle de l'exclusion PEM). Tranché par le lead, dans des dépôts
+jetables : littéral d'armure Java seul → **0 détection, exit 0** ; vraie clé PEM RSA-2048 dans ce
+**même** fichier exclu → **détectée, exit 1** ; clé PEM dans un fichier quelconque → détectée.
+L'exclusion est bien restreinte à la ligne, dans les deux sens. **Aucun défaut.**
+Deux `[MINEUR]` : la limite « imports mono-ligne » du préflight est désormais écrite dans le
+README ; rendre `secret-scan` requis reste un follow-up dépendant d'un premier run CI vert.
+
+**Audit sécurité** — un `[MAJEUR]` **réel, corrigé** (`bdf6671`).
+`.gitleaksignore` épinglait une empreinte sur le fixture `SECRET` d'`ExportTokenServiceTest`,
+**encore présent au HEAD** (`ExportTokenServiceTest.java:40`), ce que la règle en tête du fichier
+interdit explicitement. La constante s'appelle `SECRET` et non `EXPORT_TOKEN_SECRET` : l'allowlist
+par nom de clé ne la couvrait pas. Mode d'échec discret : la ligne n'ayant jamais été retouchée,
+l'empreinte restait valide indéfiniment — masquage **permanent** au lieu d'un rougissement au
+premier reformatage. Remplacée par une exclusion durable ancrée sur le marqueur
+`test-only-insecure` de la valeur **et** sur ce seul fichier.
+Vérifié après correction : dépôt complet **772 commits, 0 détection, exit 0** ; même valeur dans
+`application-prod.properties` → **détectée** ; clé Stripe dans `ExportTokenServiceTest.java` →
+**détectée**.
+
+Le reste de l'audit est `[OK]`, avec tests exécutés : `condition = "AND"` prouvé indispensable (la
+variante `"OR"` rejouée rend le secret hors-chemin invisible), somme SHA-256 du binaire gitleaks
+recalculée depuis GitHub et **conforme** au workflow, `permissions` non élargies, pas de
+`pull_request_target`, aucun `secrets.*` référencé, aucun `upload-artifact` dans `secret-scan`,
+`--redact` présent, angle mort `DB_PASSWORD` confirmé par test et correctement documenté.
+Un point `[NON TESTÉ]` assumé : l'épinglage SHA des actions tierces (`checkout`, `setup-java`,
+`setup-node`, `trivy-action`) n'a pas été confronté aux tags officiels.
+
+## Conclusion
+Prêt pour PR. Aucune couverture attendue ne fait défaut : les trois issues ont chacune une
+vérification exécutée **et** une preuve de cas négatif. Les six réserves ci-dessus sont des limites
+d'environnement local, pas des trous de test — la plus matérielle est la n° 1, que la PR lèvera
+d'elle-même.

--- a/docs/memory/decisions.md
+++ b/docs/memory/decisions.md
@@ -461,3 +461,28 @@ Retenu : **ramener le h1** (`text-xl md:text-2xl lg:text-3xl` = 35/45/57), `typo
 Motif décisif : créer 2 tokens pour 1 seul usage est disproportionné, tandis que supprimer ce site rend
 l'invariant « never Tailwind-default » de l'en-tête du fichier **vrai à l'échelle du dépôt**. Cf.
 [[PIT-S59-003]].
+
+## Sprint 60 — gitleaks plutôt que trufflehog, et binaire épinglé plutôt qu'action officielle
+
+`docs/memory/audits/secret-exposure-audit.md` §R6 laissait les deux outils ouverts. Retenu :
+**gitleaks 8.30.1**. Motif décisif : son **mécanisme d'exclusion à deux étages** —
+`.gitleaksignore` (empreinte incluant le SHA du commit, donc ne couvre qu'un commit immuable) pour
+l'historique déjà exposé, et `.gitleaks.toml` (scopé chemin + nom de clé) pour les valeurs jetables
+encore au HEAD. C'est exactement ce qu'exige la situation : l'historique compromis doit être
+baseliné **sans** blanchir les fichiers pour l'avenir.
+
+**Binaire téléchargé et vérifié par SHA-256**, pas `gitleaks/gitleaks-action@v2` : l'action exige
+`GITLEAKS_LICENSE` pour les organisations, et ce dépôt n'a **aucun secret GitHub Actions**. Une
+solution dépendant d'un secret aurait été inapplicable ici.
+
+**Job dédié, pas une étape de `security`** : ce dernier mêle du bloquant et du `continue-on-error`,
+et le scan exige `fetch-depth: 0`. Garder le signal lisible séparément était tout l'objet du sprint.
+
+## Sprint 60 — un garde-fou de diagnostic ne doit jamais devenir une cause d'échec
+
+Le préflight `node_modules` de `scripts/test-quiet.sh` (#308) **ne bloque pas sur son propre
+échec** : si la sonde Node sort en erreur, il avertit sur `stderr` et laisse Vitest tourner. Il
+n'échoue (exit 3) que sur un diagnostic **positif** — répertoire absent, vide, ou paquet non
+résolvable. Motif : un outil ajouté pour rendre un échec lisible qui deviendrait lui-même une
+nouvelle source de rouge serait désactivé au premier faux positif, et emporterait le bénéfice avec
+lui.

--- a/docs/memory/patterns.md
+++ b/docs/memory/patterns.md
@@ -542,3 +542,24 @@ contrôle ponctuel** (1 palier, 1 locale) qui asserte l'égalité des métriques
 mesure, pas par l'opinion** : injection d'une règle `.dark h1{font-size:33px}` → 10 passed / 1 failed, seul
 le contrôle ponctuel la voit. Le contrôle doit asserter la présence de `.dark` avant de re-mesurer, sinon il
 compare clair à clair et devient lui-même vacuous.
+
+## Baseliner un historique compromis sans créer d'angle mort futur (Sprint 60, #362)
+
+Problème : sur un dépôt **public**, l'historique contient des secrets définitivement compromis
+(audit #249). Un scan qui rougit à chaque run sur ces constats connus sera ignoré puis désactivé —
+exactement le mode d'échec que le garde-fou veut éviter. Mais tout mécanisme d'exclusion risque de
+blanchir aussi l'avenir.
+
+Solution retenue, **deux étages qu'il ne faut pas confondre** :
+- `.gitleaksignore` — empreintes `commit:fichier:règle:ligne`. Le SHA rend l'exclusion **inerte pour
+  tout commit futur** : une réintroduction produit une empreinte différente et rougit. Réservé aux
+  occurrences **absentes du HEAD** — le vérifier une par une, cf. [[PIT-S60-002]].
+- `.gitleaks.toml` — exclusions **durables** pour les valeurs jetables encore au HEAD, scopées
+  chemin **+** marqueur de la valeur, `condition = "AND"` obligatoire, cf. [[PIT-S60-001]].
+
+Anti-pattern écarté : `--baseline-path` avec un rapport JSON committé — le rapport **contient les
+valeurs en clair**, donc committer la baseline reviendrait à recommitter les secrets.
+
+Règle de maintenance qui fait tenir l'ensemble : **une exclusion se justifie par un § d'audit,
+jamais par « la CI est rouge »**. Et chaque exclusion se teste **dans les deux sens** avant
+livraison.

--- a/docs/memory/pitfalls.md
+++ b/docs/memory/pitfalls.md
@@ -866,3 +866,79 @@ Après édition de `globals.css`, la première passe du test d'injection `.dark`
 règle injectée n'était simplement pas dans le CSS servi. `touch` et rechargement n'ont rien changé ; **seul
 un redémarrage du serveur dev** a compilé la règle. Prévention : avant de conclure « le défaut injecté n'est
 pas vu », `curl` le chunk CSS servi et vérifier que l'injection y figure. (Corollaire de [[PIT-S52-002]].)
+
+## PIT-S60-001 — Une allowlist de scanner combine ses critères en OU : elle blanchit plus large qu'elle n'en a l'air
+Un bloc `[[allowlists]]` gitleaks avec `paths` **et** `regexes` mais **sans `condition = "AND"`** blanchit la
+valeur **partout dans le dépôt**, pas seulement dans le chemin visé. La lecture du bloc suggère l'inverse : les
+deux critères juxtaposés se lisent comme un ET. Trouvé à l'écriture de `.gitleaks.toml` (#362), la première
+version blanchissait `EXPORT_TOKEN_SECRET` y compris dans un fichier de prod. **Prévention : toute allowlist de
+scanner se teste dans les DEUX sens** — le cas attendu est tu, ET un cas voisin (même valeur hors chemin, autre
+secret dans le chemin) reste détecté. Rejouer la variante buggée pour voir le trou est ce qui l'a prouvé.
+
+## PIT-S60-002 — Une empreinte de baseline épinglée sur une ligne encore au HEAD masque à VIE, sans jamais rougir
+`.gitleaksignore` (format `commit:fichier:règle:ligne`) épinglait le fixture `SECRET` d'`ExportTokenServiceTest`,
+**toujours présent au HEAD**. La règle écrite en tête du fichier l'interdit — au motif que l'empreinte
+changerait au prochain commit touchant le fichier. Le mode d'échec réel est **l'inverse et bien plus discret** :
+la ligne n'ayant jamais été retouchée depuis son commit d'introduction, l'empreinte reste valide indéfiniment,
+donc le masquage devient **permanent** au lieu de rougir. Trouvé par l'audit sécurité de fin de sprint, pas à
+l'écriture. Remède : exclusion **durable** ancrée sur un marqueur de la VALEUR (`test-only-insecure`) + le
+chemin, `condition = "AND"` ; `.gitleaksignore` réservé aux occurrences **absentes du HEAD**, à vérifier une
+par une. Cf. [[PIT-S60-001]].
+
+## PIT-S60-003 — `gitleaks dir` ignore `.gitignore` : un gate CI doit être en mode `git`
+Mesuré : `gitleaks dir` scanne 214 Mo et remonte 25 détections, dont **20 dans `frontend/.next/`,
+`backend/target/`, `frontend/e2e/.auth/`** — des artefacts de build non versionnés. `gitleaks git` ne voit que
+le contenu suivi (21 détections). Un job bâti sur `dir` rougit donc pour des fichiers qui ne sont pas dans le
+dépôt, et sera désactivé après deux faux positifs. **Mode `git` pour tout gate CI.**
+
+## PIT-S60-004 — Un scan vert AVANT le commit ne prouve rien sur l'état APRÈS (le scanner peut se détecter lui-même)
+Un fichier de baseline listant des empreintes `commit:fichier:generic-api-key:ligne` aligne un SHA 40-hex à
+forte entropie et le mot « api-key » sur la même ligne : le scanner peut se déclencher **sur sa propre
+configuration**. Vérifié négatif ici, mais le piège général demeure — un scan pré-commit ne voit pas les
+fichiers non encore committés. **Rejouer le scan dans un dépôt jetable contenant les fichiers committés** avant
+de conclure. Corollaire : `--baseline-path` avec rapport JSON committé est un anti-pattern sur dépôt public —
+le rapport **contient les valeurs en clair**.
+
+## PIT-S60-005 — Un sous-agent qui casse l'environnement pour reproduire un cas dégradé peut caler avant de le restaurer
+Sprint 60 #308 : l'agent a renommé `frontend/node_modules/eslint-plugin-storybook` en
+`.eslint-plugin-storybook.S60-308-bak` pour prouver son garde-fou, puis a calé (watchdog 600 s) **avant la
+restauration**. Le worktree est resté dans l'état dégradé — et **`git status` était propre**, `node_modules`
+n'étant pas suivi. Un lead qui vérifie l'état d'un sprint sur le seul `git status` ne le voit pas ; l'échec
+suivant accuserait le code. **Après tout arrêt anormal d'un sous-agent, vérifier l'ENVIRONNEMENT** (résolution
+des paquets, processus laissés, ports tenus), pas seulement l'arbre git. Ici :
+`node -e "require.resolve('eslint-plugin-storybook')"`. Le répertoire de sauvegarde se retrouve par
+`find node_modules -maxdepth 2 -iname '*<paquet>*'` — le préfixe `.` le cache d'un `ls` ordinaire.
+
+## PIT-S60-006 — `npm audit fix` échoue tant qu'un `overrides` auto-référentiel existe
+`frontend/package.json` déclare `overrides: { "postcss": "$postcss" }` ; l'arbre virtuel d'`audit fix` ne résout
+pas la référence → `npm error Unable to resolve reference $postcss`, sur **toute** invocation. L'issue #422
+affirmait pourtant que `npm audit fix` était « confirmé suffisant ». Solution retenue : `npm update <transitif>`
+quand la version corrigée tient dans la plage semver du parent (lire la plage **dans le lock** avant). **Ne pas
+glisser vers `--force`** : il accepte les bumps majeurs. Prévention : ne jamais écrire dans une issue qu'une
+commande est confirmée sans l'avoir lancée.
+
+## PIT-S60-007 — `npm run typecheck` rouge sur une route FANTÔME : `.next/types` d'un build antérieur
+`tsconfig.json:26` inclut `.next/types/**/*.ts`, donc `tsc` type-checke les artefacts d'un build précédent —
+au S60, une erreur citant `app/[locale]/settings/page.js`, route disparue au passage en route group. Solution :
+rebuild puis re-typecheck. **Prévention : une erreur `tsc` qui ne cite QUE `.next/**` n'est pas imputable à son
+propre diff.**
+
+## PIT-S60-008 — Le squatteur de port peut être un AUTRE worktree DU MÊME projet
+Variante de [[PIT-S56-004]] : `:3100` était tenu par un `next-server` de
+`worktrees/new-feature-2347-14cb9a/frontend` (up 21 h), rendant **500 sur `/fr/register`**. Le réflexe « c'est
+un autre projet du poste » ne suffit donc pas — même nom de projet, même app, mais **code d'une autre branche**.
+`lsof -a -p <pid> -d cwd` identifie le propriétaire réel. Prendre un port libre plutôt que tuer le process d'une
+autre session.
+
+## PIT-S60-009 — `test-quiet.sh frontend` ne lance QUE Vitest, contrairement à ce que disent le README et les briefings
+`run_frontend` exécute un seul `npm test --silent` : ni `build`, ni `typecheck`, ni `lint`. La description
+« vitest + build + typecheck + lint » circulait dans les briefings de sprint et le README. **Anti-pattern :
+conclure « frontend vert » sur ce seul scope.** Corrigé au S60 (README §Tests + piège 4). Voisin de
+[[PIT-S58-004]] : une garantie décrite mais inexistante dissuade d'en écrire une vraie.
+
+## PIT-S60-010 — Un commentaire de test peut annoncer une isolation que le test ne respecte pas
+`console-error-guard.test.ts:20-21` annonce que son lint de fixtures reste « isolé des plugins next/storybook ».
+Vrai pour le volet 2 (config minimale), **faux pour le volet 1**, qui appelle
+`new ESLint().calculateConfigForFile(...)` — donc charge `eslint.config.mjs` et **tous** ses imports. C'est ce
+qui rend ce fichier, et lui seul, sensible à un `node_modules` incomplet. Le commentaire a probablement orienté
+#308 vers la déclaration de dépendance plutôt que vers le cwd. Cf. [[PIT-S41-004]], [[PIT-S53-006]].

--- a/docs/memory/sprint-history.md
+++ b/docs/memory/sprint-history.md
@@ -2723,9 +2723,22 @@ sprint depuis S57 — cf. note S57 ; ne pas « corriger » ce décalage.)
    install` non exercés). Premier run réel à surveiller.
 2. Gitleaks ne détecte **pas** le `DB_PASSWORD` historique (§3.1, 10 caractères alphabétiques,
    entropie trop basse). Documenté dans `.gitleaks.toml`, pas dissimulé.
-3. **La liste réelle des checks requis sur `dev` n'a pas pu être relue** : `branches/dev/protection`
-   **et** l'API GraphQL répondent HTTP 503 de façon persistante (dégradation GitHub ; le REST
-   ordinaire fonctionne). Aucune affirmation sur les checks requis n'est vérifiée dans ce sprint.
+3. ~~Checks requis non relisibles~~ — **levée en fin de sprint.** `branches/dev/protection` et
+   l'API GraphQL ont répondu HTTP 503 pendant ~2 h (dégradation GitHub, le REST ordinaire
+   fonctionnait), puis le service est revenu. **Checks requis réels sur `dev` :
+   `backend`, `frontend`, `e2e`, `ai-env-packs`** (4 contextes) — ni `security`, ni `secret-scan`.
+   À noter pour la mémoire projet : l'entrée qui parlait de « 5 jobs requis » est à corriger.
+
+### Défaut trouvé et corrigé par l'audit sécurité de fin de sprint
+
+`.gitleaksignore` épinglait une empreinte sur le fixture `SECRET` d'`ExportTokenServiceTest`,
+**encore présent au HEAD**, ce que la règle en tête de ce même fichier interdit explicitement.
+La constante s'appelle `SECRET` et non `EXPORT_TOKEN_SECRET` : l'allowlist par nom de clé ne la
+couvrait pas. Le mode d'échec était discret plutôt que bruyant — la ligne n'ayant jamais été
+retouchée depuis son commit d'introduction, l'empreinte restait valide indéfiniment, donc le
+masquage devenait **permanent** au lieu de rougir au premier reformatage. Remplacée (`bdf6671`)
+par une exclusion durable ancrée sur le marqueur `test-only-insecure` de la valeur **et** sur ce
+seul fichier, vérifiée dans les deux sens.
 
 ### ⚠ Rappel de clôture — régénérer les packs dérivés du Layer B
 

--- a/docs/memory/sprint-history.md
+++ b/docs/memory/sprint-history.md
@@ -2645,3 +2645,93 @@ Les 13 issues de « Mise en ligne (GELÉ) » supposent toutes un serveur, un dom
 
 > **Pas de branche `sprint/55` créée** (étape 4 du skill volontairement sautée, leçon S43/S44
 > reconduite depuis S45) : `/sprint start` crée son worktree lui-même.
+
+---
+
+## Sprint 60 — 2026-08-17 (En cours — PR à ouvrir depuis `sprint/60`)
+
+**Objectif :** Rendre le signal CI `security` exploitable.
+**Milestone GitHub :** #61 (le numéro de milestone est décalé de +1 par rapport au numéro de
+sprint depuis S57 — cf. note S57 ; ne pas « corriger » ce décalage.)
+**Issues livrées (3) :** #422, #362, #308
+**Vagues exécutées :** V1 = #422 + #362 en parallèle | V2 = #308
+**Branche :** `sprint/60`, créée depuis `origin/dev` @ `e18e5c1`.
+**Commits (5) :**
+- `c68591d` #362 — job CI `secret-scan` (gitleaks 8.30.1, binaire épinglé + SHA-256), `.gitleaks.toml`,
+  `.gitleaksignore`, §9 de l'audit d'exposition
+- `da0f0a3` #422 — `nanoid` 3.3.16 → 3.3.18 (GHSA-2v37-7h3g-55p8, HIGH)
+- `1b477c8` #422 — artefact
+- `79d4a5b` #308 — préflight `node_modules` dans `test-quiet.sh` + piège 4 du README
+- `647f45f` #308 — correction du SHA dans l'artefact
+
+**BR impactées :** aucune. Sprint entièrement outillage / CI / dépendances.
+**Tests :** frontend 95 fichiers / 888 tests exit 0 · E2E 169 passed / 0 failed / 8 skipped exit 0 ·
+`npm audit --omit=dev --audit-level=high` exit 0 · backend **non rejoué en local** (zéro fichier
+`backend/**` au diff ; le job CI requis le couvre). Détail :
+`docs/memory/audits/sprint-60-test-coverage.md`.
+**Status :** En cours
+
+### Ce qui n'a PAS suivi le protocole, et pourquoi
+
+- **Sprint jamais passé par `/sprint plan`.** Aucune entrée d'historique préalable, aucun
+  `architect-plans.md`, donc **aucun mini-plan architecte** — les plans d'implémentation ont été
+  écrits par le lead depuis les pistes techniques des issues, et la matrice de conflits de fichiers
+  vérifiée à la main. Le label `sprint-60` et le milestone préexistaient (posés par l'audit de
+  clôtures du 2026-08-16).
+- **Context-pack réduit délibérément.** `inject-pack.sh unknown frontend` produisait 77 Ko par
+  briefing, dont 44 Ko de pièges de mise en page sans rapport avec des issues de dépendances et de
+  CI. Remplacé par un pack `tooling` de 23 Ko (même logique de classification que
+  `gen-pit-packs.sh` : entrées `tooling` + `both` + non classées). Briefings finaux ~33 Ko, le
+  garde-fou `pre-spawn-fullstack.sh` (≥ 8 Ko + marqueur) reste satisfait.
+- **Le lead a terminé #308 à la place du fullstack-dev.** L'agent a calé (watchdog, 600 s sans
+  progression) après avoir écrit et câblé le préflight, avant la doc, la preuve, l'artefact et le
+  commit. Le lead a repris son diff non committé sans en réécrire une ligne, et a ajouté
+  `README.md` + l'artefact. Consigné en tête de `issue-308-done.md`.
+- **Deux erreurs du lead dans les briefings**, corrigées en cours de sprint :
+  (1) les briefings annonçaient que `test-quiet.sh frontend` lance vitest + build + typecheck +
+  lint — il ne lance **que** vitest ; l'agent de #422 l'a repéré et a lancé les trois autres
+  séparément, donc sans perte de couverture ;
+  (2) la consigne d'isolation des commits disait « `git add` ciblé » — `PIT-S57-001` établit que
+  c'est insuffisant. Corrigée en `git commit -m … -- <pathspec>` **avant** le premier spawn.
+
+### Vérifications refaites par le lead, sans croire les rapports
+
+- `ci.yml` revalidé via **Ruby** : la validation YAML annoncée par l'agent
+  (`python3 -c "import yaml"`) **ne pouvait pas s'exécuter** — PyYAML n'est pas installé sur ce
+  poste. Résultat : YAML valide, 7 jobs, `on: pull_request + push` vers `dev`/`main`.
+- Scan gitleaks rejoué : 768 commits, 0 détection, exit 0.
+- Détection prouvée hors dépôt : clé AWS + clé Stripe → 2 détections exit 1 ; clé Brevo
+  `xkeysib-` → 1 détection exit 1. **Piège rencontré** : `AKIAIOSFODNN7EXAMPLE` est la clé
+  d'exemple canonique d'AWS, allowlistée par défaut par gitleaks — un premier test de détection a
+  donc échoué à tort. Le test était mauvais, pas le job.
+- Préflight #308 déclenché réellement (exit 3), suite nominale revérifiée (95/888 exit 0), scope
+  inconnu toujours exit 2.
+- **État de l'environnement vérifié après l'arrêt de l'agent #308**, pas seulement `git status` :
+  celui-ci était propre alors que `frontend/node_modules/eslint-plugin-storybook` avait été
+  renommé et jamais restauré. Le worktree était dans l'état dégradé.
+
+### Écart de piste technique (issue #422)
+
+`npm audit fix` — commande prescrite par l'issue et annoncée comme « confirmée suffisante » —
+**échoue sur ce dépôt** : `Unable to resolve reference $postcss`, dû à
+`overrides: { "postcss": "$postcss" }`. Bump obtenu par `npm update nanoid`, dans la plage
+`^3.3.16` exigée par postcss 8.5.23, donc sans majeur et **sans aucune cascade**.
+
+### Réserves connues au moment d'ouvrir la PR
+
+1. Le job `secret-scan` n'a **jamais tourné sur un runner GitHub** (binaire téléchargé + `sudo
+   install` non exercés). Premier run réel à surveiller.
+2. Gitleaks ne détecte **pas** le `DB_PASSWORD` historique (§3.1, 10 caractères alphabétiques,
+   entropie trop basse). Documenté dans `.gitleaks.toml`, pas dissimulé.
+3. **La liste réelle des checks requis sur `dev` n'a pas pu être relue** : `branches/dev/protection`
+   **et** l'API GraphQL répondent HTTP 503 de façon persistante (dégradation GitHub ; le REST
+   ordinaire fonctionne). Aucune affirmation sur les checks requis n'est vérifiée dans ce sprint.
+
+### ⚠ Rappel de clôture — régénérer les packs dérivés du Layer B
+
+Reconduit du S59, toujours absent du skill : la Phase 2 de `/sprint end` écrit dans
+`pitfalls.md`, ce qui **périme par construction** `pit-backend.md` / `pit-frontend.md`, et le job
+CI requis `ai-env-packs` rougit. Recette : classer chaque nouvelle entrée dans
+`.ai-env/tools/pit-classification.tsv`, puis `bash .ai-env/tools/gen-pit-packs.sh`, puis
+`--check` avant de pousser. Ce sprint apporte plusieurs `[MEMORY:pitfall]` à classer, dont
+plusieurs de catégorie `tooling`.

--- a/docs/memory/sprint-history.md
+++ b/docs/memory/sprint-history.md
@@ -2719,8 +2719,10 @@ sprint depuis S57 — cf. note S57 ; ne pas « corriger » ce décalage.)
 
 ### Réserves connues au moment d'ouvrir la PR
 
-1. Le job `secret-scan` n'a **jamais tourné sur un runner GitHub** (binaire téléchargé + `sudo
-   install` non exercés). Premier run réel à surveiller.
+1. ~~`secret-scan` jamais exécuté sur un runner~~ — **levée : PR #432, 7/7 jobs verts au premier
+   run.** `secret-scan` pass en 8 s, `security` **pass en 39 s** — il était rouge sur *toutes* les
+   PR du dépôt avant ce sprint, c'est l'objectif atteint. `backend` 1 min 11, `frontend` 2 min 26,
+   `e2e` 6 min 39, `flyway-smoke` 51 s, `ai-env-packs` 10 s.
 2. Gitleaks ne détecte **pas** le `DB_PASSWORD` historique (§3.1, 10 caractères alphabétiques,
    entropie trop basse). Documenté dans `.gitleaks.toml`, pas dissimulé.
 3. ~~Checks requis non relisibles~~ — **levée en fin de sprint.** `branches/dev/protection` et

--- a/docs/memory/sprint-history.md
+++ b/docs/memory/sprint-history.md
@@ -2648,7 +2648,7 @@ Les 13 issues de « Mise en ligne (GELÉ) » supposent toutes un serveur, un dom
 
 ---
 
-## Sprint 60 — 2026-08-17 (En cours — PR à ouvrir depuis `sprint/60`)
+## Sprint 60 — 2026-08-17 (Terminé — merge PR #432 dans `dev`)
 
 **Objectif :** Rendre le signal CI `security` exploitable.
 **Milestone GitHub :** #61 (le numéro de milestone est décalé de +1 par rapport au numéro de
@@ -2669,7 +2669,9 @@ sprint depuis S57 — cf. note S57 ; ne pas « corriger » ce décalage.)
 `npm audit --omit=dev --audit-level=high` exit 0 · backend **non rejoué en local** (zéro fichier
 `backend/**` au diff ; le job CI requis le couvre). Détail :
 `docs/memory/audits/sprint-60-test-coverage.md`.
-**Status :** En cours
+**Status :** **Terminé** — PR **#432** (`sprint/60` → `dev`) **mergée le 2026-08-17**, milestone #61
+fermé. Titre et ligne `Status` sont volontairement redondants : `PIT-S56-006` montre que grepper l'un
+sans l'autre rate les entrées où les deux se contredisent.
 
 ### Ce qui n'a PAS suivi le protocole, et pourquoi
 
@@ -2723,6 +2725,43 @@ sprint depuis S57 — cf. note S57 ; ne pas « corriger » ce décalage.)
    run.** `secret-scan` pass en 8 s, `security` **pass en 39 s** — il était rouge sur *toutes* les
    PR du dépôt avant ce sprint, c'est l'objectif atteint. `backend` 1 min 11, `frontend` 2 min 26,
    `e2e` 6 min 39, `flyway-smoke` 51 s, `ai-env-packs` 10 s.
+
+### Clôture (`/sprint end 60`)
+
+**Merge :** PR #432 (`sprint/60` → `dev`), merge commit, autorisé explicitement par le dev.
+**Milestone GitHub :** #61, fermé après le merge.
+**Issues fermées :** #422, #362, #308.
+**Commits :** 10.
+**Reviews :** reviewer batch — 0 CRITIQUE / 1 MAJEUR (contre-épreuve exécutée, **aucun défaut**) /
+2 MINEURS (1 traité, 1 en follow-up). Audit sécurité — **1 MAJEUR réel, corrigé** (`bdf6671`).
+**Tests :** frontend 95 fichiers / 888 tests · E2E 169 passed / 8 skipped · backend via CI ·
+CI finale **7/7 verte**.
+
+**Consolidation mémoire :** 10 pitfalls (`PIT-S60-001` → `010`), 2 décisions, 1 pattern.
+Les 10 pitfalls ont été **classés** dans `.ai-env/tools/pit-classification.tsv` (7 `tooling`,
+3 `frontend`) et les packs régénérés — `gen-pit-packs.sh --check` vert, et le job requis
+`ai-env-packs` confirmé vert en CI. Le rappel du S59 a donc été tenu cette fois.
+
+**Absorbé en cours (XS) :** 2 — exclusion PEM écrite au plus étroit après qualification du faux
+positif (#362) ; inventaire des jobs CI du README remis à jour, il en annonçait 4 sur 7 (#308).
+
+**Follow-ups arbitrés (Phase 4 triage) — 6 items, 6 créés, 0 discardé, backlog libre :**
+  - Rendre `secret-scan` **requis** sur `dev` [XS | devops] → **#433**
+  - Aligner `scripts/test-quiet.sh frontend` sur ce qu'annoncent les docs [S | tooling] → **#434**
+  - Réparer `npm audit fix` (override `$postcss` auto-référentiel) [S | frontend] → **#435**
+  - Règle gitleaks pour les mots de passe à basse entropie [S | devops] → **#436**
+  - Préflight : imports mono-ligne seulement [XS | tooling] → **#437**
+  - 6 HIGH résiduelles dev+prod (chaîne eslint/brace-expansion) [M | tooling] → **#438**
+
+> **Ratio discard 0/6 — deuxième sprint consécutif à 0 %** (S59 : 0/5). Le skill signale qu'un
+> discard nul récurrent indique soit que le lead filtre en amont, soit que le critère de
+> `RECOMMAND_FOLLOWUP` est trop large. À trancher au prochain sprint plutôt qu'à laisser filer :
+> ici les 6 items étaient tous des limites **mesurées** du travail livré, pas des intuitions — ce
+> qui plaide pour le filtrage amont, mais deux points ne font pas une tendance.
+
+> **#433 est le follow-up qui conditionne la valeur de tout ce sprint.** Tant que `secret-scan`
+> n'est pas un check requis, une PR qui le ferait rougir reste fusionnable, et le garde-fou est
+> décoratif. Sa précondition (premier run vert) est levée depuis la PR #432.
 2. Gitleaks ne détecte **pas** le `DB_PASSWORD` historique (§3.1, 10 caractères alphabétiques,
    entropie trop basse). Documenté dans `.gitleaks.toml`, pas dissimulé.
 3. ~~Checks requis non relisibles~~ — **levée en fin de sprint.** `branches/dev/protection` et

--- a/docs/memory/sprints/sprint-60/issue-308-done.md
+++ b/docs/memory/sprints/sprint-60/issue-308-done.md
@@ -1,0 +1,90 @@
+# Issue #308 — Régulariser la dev-dep eslint-plugin-storybook
+
+> ⚠ **Artefact rédigé par le LEAD, pas par le fullstack-dev.** L'agent a calé
+> (watchdog, 600 s sans progression) après avoir écrit le préflight et l'avoir câblé dans
+> `run_frontend`, mais avant la documentation, la preuve, l'artefact et le commit.
+> Le lead a repris à partir de son diff non committé. Détail en fin de fichier.
+
+- commits: [ee0b1ea]
+
+- resume:
+  **Diagnostic** — la prémisse de l'issue est fausse : `eslint-plugin-storybook` **est** déclaré
+  (`frontend/package.json:72`) **et** installé. Chaîne réelle : `frontend/eslint.config.mjs:2`
+  importe le plugin au chargement du module ; `console-error-guard.test.ts:26-30` instancie
+  `new ESLint().calculateConfigForFile(...)`, ce qui charge la config **réelle** et déclenche cet
+  import. `node_modules` absent/incomplet dans la copie testée ⇒ ce seul fichier tombe en
+  « Cannot find package », lu à tort comme une régression de la garde `#160`/`#258`.
+  Cause profonde = worktree sans `node_modules` (**#272, encore ouverte**) + cwd sur le mauvais
+  dépôt (`PIT-S41-004`, `PIT-S53-006`).
+
+  **Solution retenue** — préflight dans `scripts/test-quiet.sh`, exécuté avant Vitest dans
+  `run_frontend`. Il extrait les specs d'import de `eslint.config.mjs`, teste leur résolvabilité
+  via `createRequire` ancré sur `frontend/`, et sort en **3** avec un message nommant le
+  répertoire réellement testé, la commande de correction (`npm ci`), le rappel « un worktree =
+  son propre `node_modules` » et le renvoi à #272.
+  Écarté : `skip` du test (la garde est une protection anti-fuite de credentials — un skip la
+  neutraliserait sans bruit) ; auto-provisionnement de `node_modules` (périmètre de #272).
+
+  **Fichiers** — `scripts/test-quiet.sh` (+112 l. : `frontend_env_hint`, `frontend_preflight`,
+  câblage dans `run_frontend`) · `README.md` (piège 4 + précisions §Tests).
+
+  **Doc** — `README.md` §« Pièges connus » entrée 4, à côté des pièges CORS/`workers` existants.
+
+  **Preuve du cas dégradé (exécutée, pas supposée — `PIT-S58-004`)** : renommage réversible de
+  `frontend/node_modules/eslint-plugin-storybook`, puis `./scripts/test-quiet.sh frontend` →
+  **exit 3**, message complet affiché, Vitest jamais lancé. Répertoire restauré et résolution
+  revérifiée (`require.resolve` OK).
+
+  **Tests (exit codes réels, via `rtk proxy`, cwd = worktree `sprint/60`)**
+  - `./scripts/test-quiet.sh frontend` → **exit 0**, 95 fichiers / 888 tests passed
+    (identique au repère mesuré par #422 une heure plus tôt : 95/888).
+  - `bash -n scripts/test-quiet.sh` → exit 0.
+  - `./scripts/test-quiet.sh bogus` (scope inconnu) → **exit 2**, message inchangé.
+
+- [MEMORY:pitfall] Un sous-agent qui reproduit un cas dégradé en déplaçant un répertoire de
+  `node_modules` peut caler **entre** le déplacement et la restauration : le worktree reste cassé
+  et l'échec suivant accuse le code. Le lead doit vérifier l'état de l'environnement, pas
+  seulement `git status`, après tout arrêt anormal — `git status` était propre alors que
+  `frontend/node_modules/eslint-plugin-storybook` avait disparu.
+- [MEMORY:pitfall] `console-error-guard.test.ts` annonce en commentaire (`:20-21`) que son lint de
+  fixtures reste « isolé des plugins next/storybook ». Vrai pour le volet 2 (config minimale),
+  **faux pour le volet 1**, qui charge la config réelle exprès. Le commentaire a probablement
+  contribué à faire chercher la cause du côté de la déclaration de dépendance.
+- [MEMORY:decision] Le préflight ne bloque jamais sur son propre échec : si la sonde Node sort en
+  erreur, il avertit et laisse Vitest tourner. Un garde-fou de diagnostic ne doit pas devenir une
+  nouvelle cause d'échec.
+
+- recommandations suite:
+  - RECOMMAND_FOLLOWUP: le préflight ne couvre que les imports **mono-ligne** de
+    `eslint.config.mjs` ; un import multi-ligne ou un `require()` dynamique passe sous le radar
+    [triage XS | domaine tooling]
+  - Pas de RECOMMAND_DB_EXPERT (aucune migration, aucun SQL touché).
+  - Pas de RECOMMAND_SECURITY (aucun code d'auth, de PII ni d'API externe).
+  - Pas de RECOMMAND_UI_DESIGN (aucun changement visuel).
+  - Pas de RECOMMAND_TEST_RUNNER (suite frontend 888 tests, ~20 s — sous les seuils).
+
+- ABSORBED: correction d'une affirmation périmée du README — il annonçait les jobs CI
+  `backend`/`frontend`/`e2e`/`security` ; la liste réelle en compte sept depuis #362
+  (`flyway-smoke`, `secret-scan`, `ai-env-packs` manquaient).
+
+- NON VERIFIE:
+  - Le préflight n'a **pas** été exercé en CI (rien n'est poussé au moment de l'écriture). En CI
+    `npm ci` précède les tests, donc le chemin dégradé ne devrait jamais s'y déclencher — non
+    prouvé.
+  - Cas `node_modules` **totalement absent** et cas `node_modules` **vide** : les deux branches
+    existent dans le code mais seul le cas « paquet manquant » a été déclenché réellement. Les
+    reproduire exigeait de déplacer tout `node_modules`, écarté pour ne pas bloquer le sprint.
+  - Comportement sous un `frontend/node_modules` en **symlink** vers le dépôt principal (le
+    contournement décrit par #272) : non testé.
+
+## Reprise après arrêt de l'agent
+
+L'agent `fullstack-dev` a calé (watchdog : 600 s sans progression), dernier message
+« Now wire the preflight into `run_frontend` » — édition en réalité déjà appliquée. Il avait
+laissé `frontend/node_modules/eslint-plugin-storybook` renommé en
+`.eslint-plugin-storybook.S60-308-bak` : **le worktree était dans l'état dégradé**, invisible à
+`git status`. Le lead a restauré le répertoire, vérifié la résolution, relu le diff, complété la
+documentation manquante, produit la preuve et committé. Aucune ligne du préflight n'a été
+réécrite par le lead — seuls `README.md` et cet artefact ont été ajoutés.
+
+STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-60/issue-308-done.md
+++ b/docs/memory/sprints/sprint-60/issue-308-done.md
@@ -5,7 +5,8 @@
 > `run_frontend`, mais avant la documentation, la preuve, l'artefact et le commit.
 > Le lead a repris à partir de son diff non committé. Détail en fin de fichier.
 
-- commits: [ee0b1ea]
+- commits: [79d4a5b] — plus le commit immédiatement suivant, qui ne fait que corriger ce champ
+  (écrit en placeholder avant d'avoir le SHA). Un 2ᵉ commit plutôt qu'un `--amend` : `PIT-S55-002`.
 
 - resume:
   **Diagnostic** — la prémisse de l'issue est fausse : `eslint-plugin-storybook` **est** déclaré

--- a/docs/memory/sprints/sprint-60/issue-362-done.md
+++ b/docs/memory/sprints/sprint-60/issue-362-done.md
@@ -1,0 +1,87 @@
+- commits: [SHA à relire par le lead]
+- resume: gitleaks 8.30.1, **binaire épinglé + SHA-256 vérifié** (PAS `gitleaks-action@v2` : exige
+  `GITLEAKS_LICENSE` en organisation ; dépôt a 0 secret Actions — contrainte respectée).
+  **Job dédié `secret-scan`** et non étape de `security` : `security` mêle bloquant et
+  `continue-on-error` (chaîne eslint rouge connue) → signal illisible ; et ce scan exige
+  `fetch-depth: 0` là où `security` prend le checkout superficiel. Portée : `gitleaks git`
+  (historique atteignable depuis HEAD) sur **pull_request ET push** — contient les commits de la PR
+  (checkout = commit de fusion) donc couvre le diff *a fortiori*, sans plomberie `base..head` ;
+  le scan sur `push` tient le rôle du scan périodique sans déclencheur `schedule` (qui rejouerait
+  backend/frontend/e2e). `--redact=100` obligatoire : logs CI publics, sinon le job publierait
+  lui-même le secret détecté. `gitleaks dir` écarté (ignore `.gitignore` → +20 faux positifs
+  `.next/`, `target/`, `e2e/.auth/`).
+  Exclusions 2 étages, chacune adossée à un § de l'audit #249 : `.gitleaks.toml` (durable —
+  EXPORT_TOKEN_SECRET §4.2 avec `condition="AND"` chemin+nom de clé ; faux positif `private-key`
+  de `JwtServiceRs256Test` restreint à la ligne portant le littéral `"-----BEGIN PRIVATE KEY-----\n"`)
+  + `.gitleaksignore` (12 empreintes épinglées au commit pour l'historique immuable §3.2/§4.1).
+  Aucun fichier n'est blanchi pour l'avenir.
+  **Verdict scan local chiffré** : sans exclusions 21 détections / exit 1 ; avec exclusions
+  **766 commits, 0 détection, exit 0** (~1 s, 11,73 Mo). 4/4 des détections HEAD couvertes par
+  allowlist durable, 16 purement historiques par empreinte.
+  **Preuve de détection (exigée)** : secrets plantés dans dépôts git jetables HORS dépôt
+  (scratchpad, rien créé dans le repo — `git status` vérifié) → clé AWS **détectée**, clé Stripe
+  **détectée**, secret au bon nom hors chemin allowlisté **détecté**, autre nom de clé dans un
+  chemin allowlisté **détecté**, vraie armure PEM multi-ligne dans le fichier de test **détectée**
+  (le littéral Java reste exempté). Exit codes réels lus via `rtk proxy` (PIT-S45-003).
+  YAML `ci.yml` validé (parseur YAML : 7 jobs ; `permissions`/`concurrency` inchangés ; aucune
+  permission élargie). Les 3 fichiers livrés ne s'auto-détectent pas (exit 0) — piège écarté :
+  `.gitleaksignore` contient des SHA 40-hex sur des lignes portant le texte « api-key ».
+  Doc : audit §9 (choix, exclusions, limite mesurée, vérifications) + R6 passée à FAIT.
+
+- [MEMORY:*] signaux:
+  - `[MEMORY:pitfall]` Contexte : `[[allowlists]]` gitleaks combine ses critères en **OU par
+    défaut**. Un bloc `paths` + `regexes` sans `condition = "AND"` blanchit la valeur PARTOUT dans
+    le dépôt, pas seulement dans le chemin visé — une exclusion qui paraît étroite à la lecture est
+    en fait globale. Solution : `condition = "AND"` systématique, et le vérifier en plantant la même
+    valeur hors du chemin allowlisté. Prévention : toute allowlist de scanner doit être testée dans
+    les DEUX sens (le cas attendu est tu, un cas voisin est toujours détecté).
+  - `[MEMORY:pitfall]` Contexte : `gitleaks dir` **ne respecte pas `.gitignore`** (mesuré : 214 Mo
+    scannés, 25 détections dont 20 dans `frontend/.next/`, `backend/target/`, `frontend/e2e/.auth/`)
+    alors que `gitleaks git` ne voit que le contenu suivi (21 détections). Un job bâti sur `dir`
+    rougit pour des artefacts de build non versionnés. Prévention : mode `git` pour un gate CI.
+  - `[MEMORY:pitfall]` Contexte : un scanner de secrets peut **se détecter lui-même** — un fichier
+    de baseline listant des empreintes `commit:fichier:generic-api-key:ligne` aligne un SHA 40-hex
+    à forte entropie et le mot « api-key » sur la même ligne. Vérifié négatif ici, mais à tester
+    avant commit : le scan pré-commit ne voit pas les fichiers non encore committés, donc un scan
+    vert AVANT le commit ne prouve rien sur l'état APRÈS. Solution : rejouer le scan dans un dépôt
+    jetable contenant les fichiers committés.
+  - `[MEMORY:decision]` Contexte : R6 laissait gitleaks/trufflehog ouverts. Décision : gitleaks.
+    Pourquoi : mécanisme d'exclusion à deux étages (durable vs épinglé au commit) — requis parce que
+    l'historique exposé est immuable et doit être baseliné SANS blanchir les fichiers pour l'avenir.
+  - `[MEMORY:pattern]` Problème : baseliner un historique compromis sans créer d'angle mort futur.
+    Solution : `.gitleaksignore` (empreinte incluant le SHA → ne couvre qu'un commit immuable) pour
+    l'historique + `.gitleaks.toml` scopé chemin+nom de clé pour les valeurs jetables encore au HEAD.
+    Anti-pattern : `--baseline-path` avec un rapport JSON committé — le rapport **contient les
+    valeurs en clair**, donc committer la baseline reviendrait à recommitter les secrets sur un
+    dépôt public.
+
+- recommandations suite:
+  - `RECOMMAND_FOLLOWUP: rendre le check `secret-scan` requis sur `dev` après un premier run vert
+    (PATCH ciblé documenté en en-tête de ci.yml ; réénumérer backend/frontend/e2e/ai-env-packs car
+    la liste est REMPLACÉE, pas fusionnée)` [triage XS | domaine devops]
+  - `RECOMMAND_FOLLOWUP: le scan ne couvre pas le `DB_PASSWORD` de l'audit §3.1 (10 car.
+    alphabétiques, entropie trop basse pour `generic-api-key`) — évaluer une règle gitleaks maison
+    sur les clés `*password*` à valeur littérale non-`${...}` dans `**/application*.properties`,
+    avec mesure du bruit avant adoption` [triage S | domaine devops]
+  - Pas de `RECOMMAND_DB_EXPERT` : aucune migration, aucun schéma touché.
+  - Pas de `RECOMMAND_SECURITY` : le périmètre EST la sécurité et les exclusions sont adossées à
+    l'audit #249 existant ; un second avis n'apporterait rien sans nouveau constat.
+  - Pas de `RECOMMAND_TEST_RUNNER` : aucune suite de tests touchée (job CI uniquement) ; la
+    vérification exigée était l'exécution réelle du scanner, faite ici.
+  - Pas de `RECOMMAND_UI_DESIGN` : aucun changement visuel.
+
+- ABSORBED:
+  - Faux positif `private-key` sur `JwtServiceRs256Test.java:100` identifié et qualifié (armure PEM
+    littérale autour d'une clé générée au run) — exclusion écrite au plus étroit plutôt que par
+    fichier, après constat qu'une exclusion par fichier laissait passer une vraie clé PEM.
+  - `.github/workflows/ci.yml` en-tête : `secret-scan` ajouté à l'inventaire des checks NON requis,
+    pour que l'état documenté reste vrai.
+  - NON VÉRIFIÉ (à assumer) : la liste réelle des checks requis sur `dev` n'a pas pu être relue —
+    `gh api .../branches/dev/protection` a répondu **HTTP 503**. Les affirmations préexistantes de
+    l'en-tête de `ci.yml` n'ont donc pas été corrigées, seulement complétées.
+  - NON VÉRIFIÉ (à assumer) : le job n'a pas été exécuté sur un runner GitHub. Sont prouvés en
+    local le verdict du scanner, ses exclusions, sa détection et la validité YAML ; ne sont PAS
+    prouvés le téléchargement du binaire depuis le runner ni `sudo install` (étapes standard, mais
+    non exercées). Premier run réel à surveiller par le lead.
+
+STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-60/issue-422-done.md
+++ b/docs/memory/sprints/sprint-60/issue-422-done.md
@@ -1,0 +1,61 @@
+# Issue #422 — nanoid < 3.3.18 (GHSA-2v37-7h3g-55p8, HIGH)
+
+- commits: [da0f0a3] (lockfile) + commit de ce rapport (2e commit, pas d'amend — PIT-S55-002)
+- resume:
+  - Fichier modifie : `frontend/package-lock.json` SEUL, 3 lignes. `package.json` NON touche.
+  - AUDIT AVANT : `npm audit --omit=dev --audit-level=high` -> `1 high severity vulnerability` (nanoid <3.3.18), exit 1.
+  - AUDIT APRES : meme commande -> `found 0 vulnerabilities`, **exit 0**.
+  - nanoid `3.3.16` -> `3.3.18` (lock l.11121-11124). Chaine : `postcss@8.5.23 (overridden) > nanoid`.
+  - CASCADE : **aucun autre paquet**. `diff --stat` = `1 file changed, 3 insertions(+), 3 deletions(-)`.
+  - ECART PISTE ISSUE : `npm audit fix` **ECHOUE** ici -> `npm error Unable to resolve reference $postcss`
+    (npm 10.9.7 / node 22.22.2), du a `overrides: {"postcss": "$postcss"}`. Pas de `--force`.
+    Contournement : `npm update nanoid` (reste dans `nanoid: ^3.3.16` exige par postcss -> aucun majeur).
+  - TESTS (codes de sortie reels, `rtk proxy`, cwd worktree verifie) :
+    - `./scripts/test-quiet.sh frontend` : **exit 0**, 95 fichiers / **888 tests passed**.
+      (Ce scope ne lance QUE vitest — script l.96-103 : ni build, ni typecheck, ni lint.)
+    - `npm run lint` **exit 0** ; `npm run build` **exit 0** (Next 15.5.22).
+    - `npm run typecheck` : exit 2 au 1er essai (artefact PERIME `.next/types/validator.ts` citant
+      `app/[locale]/settings/page.js`, chemin disparu au passage en route group) -> **exit 0** apres build.
+      Pre-existant, sans lien avec nanoid.
+    - **E2E complet : exit 0 — 169 passed / 0 failed / 8 skipped (177 total), 1.8 min.**
+      Stack : backend Docker `mytimeline-e2e` `:8086` (profil e2e verifie, test-support -> 404) ; frontend
+      builde AVEC `NEXT_PUBLIC_API_URL=/api E2E_API_PROXY_TARGET=http://localhost:8086` puis `next start -p 3000`
+      (oracles : `/api/auth/me` 401, `/fr/register` 200) ; `CI=1 --workers=1` ; `PLAYWRIGHT_BASE_URL` pose
+      (webServer Playwright desactive, PIT-S56-005). Serveur `:3000` arrete apres le run.
+      Les `[setup] ... e2e-500-persistant ... 500` du log = self-test `e2e/auth-setup-render-retry.spec.ts:53`, pas un echec.
+
+- [MEMORY:*] signaux:
+  - [MEMORY:pitfall] `npm audit fix` echoue sur `frontend/` (`Unable to resolve reference $postcss`) : l'arbre
+    virtuel d'audit fix ne resout pas l'override `"postcss": "$postcss"`. Solution : `npm update <transitif>` si la
+    version corrigee tient dans la plage semver du parent (lire la plage dans le lock AVANT). Prevention : ne jamais
+    ecrire dans une issue que `npm audit fix` « est confirme suffisant » sans l'avoir lance ; ne pas glisser vers `--force`.
+  - [MEMORY:pitfall] `npm run typecheck` rouge sur une route FANTOME : `tsconfig.json:26` inclut `.next/types/**/*.ts`,
+    donc tsc type-checke les artefacts d'un build anterieur. Solution : rebuild puis re-typecheck. Prevention : une
+    erreur tsc qui ne cite QUE `.next/**` n'est pas imputable a son propre diff.
+  - [MEMORY:pitfall] `:3100` etait tenu par un `next-server` d'un AUTRE WORKTREE MyTimeline
+    (`worktrees/new-feature-2347-14cb9a/frontend`, up 21 h) rendant **500 sur /fr/register** — variante de
+    PIT-S56-004 ou le squatteur est le meme projet. Solution : `lsof -a -p <pid> -d cwd` pour identifier le
+    proprietaire, puis prendre un port libre plutot que tuer le process d'une autre session.
+  - [MEMORY:pattern] `test-quiet.sh frontend` est decrit partout comme « vitest + build + typecheck + lint » : il ne
+    lance QUE vitest. Anti-pattern : conclure « frontend vert » sur ce seul scope.
+
+- recommandations suite:
+  - Pas de RECOMMAND_DB_EXPERT (aucune migration), ni RECOMMAND_UI_DESIGN (aucun changement visuel),
+    ni RECOMMAND_TEST_RUNNER (suites jouees ici avec exit codes), ni RECOMMAND_SECURITY (advisory purge,
+    verifie par la commande exacte du job CI).
+  - RECOMMAND_FOLLOWUP: reparer `npm audit fix` sur `frontend/` (evaluer `"postcss": "^8.5.23"` litteral dans
+    `overrides`, re-tester audit fix ET le build Tailwind v4). [triage S | domaine frontend]
+  - RECOMMAND_FOLLOWUP: aligner `scripts/test-quiet.sh frontend` sur ce qu'annoncent les briefings
+    (ajouter typecheck+lint+build, ou renommer le scope `frontend-unit`). [triage S | domaine tooling]
+  - RECOMMAND_FOLLOWUP: 6 HIGH subsistent en dev+prod (etape CI INFORMATIVE, chaine eslint/brace-expansion
+    documentee incorrigible `ci.yml:498-515`) — hors perimetre #422. [triage M | domaine tooling]
+
+- ABSORBED: aucune (`.github/**` et `docs/memory/audits/**` laisses intacts — perimetre #362).
+
+## Non verifie / limites assumees
+- Job CI `security` PAS observe vert (rien n'est pousse) ; preuve locale = commande exacte de l'etape bloquante
+  (`ci.yml:517-519`) en exit 0.
+- Backend E2E `:8086` up depuis 21 h, non rebuild : peut preceder `sprint/60`. Sans impact attendu (diff 100 % frontend).
+- `npm ci` from scratch non rejoue (arbre mis a jour en place par `npm update`).
+
+STATUS: COMPLETED

--- a/docs/memory/sprints/sprint-60/specialists-review-security-test-runner.md
+++ b/docs/memory/sprints/sprint-60/specialists-review-security-test-runner.md
@@ -1,0 +1,92 @@
+# Spécialistes Sprint 60 — review batch, audit sécurité, exécution des suites
+
+> Artefact de traçabilité (Phases 5-7). Les rapports des spécialistes n'étaient consignés que dans
+> le contexte du lead ; ils sont fixés ici pour que la clôture soit vérifiable après coup.
+
+## Audit sécurité — `security-expert`, sur le job `secret-scan` (#362)
+
+Spawné par le lead (profondeur 1). Portée : `.github/workflows/ci.yml`, `.gitleaks.toml`,
+`.gitleaksignore`, §9 de `docs/memory/audits/secret-exposure-audit.md`.
+
+### `[MAJEUR]` — corrigé pendant le sprint (`bdf6671`)
+
+`.gitleaksignore` épinglait une empreinte
+(`0d1d7395…:…/ExportTokenServiceTest.java:generic-api-key:27`) sur le fixture `SECRET`
+**toujours présent au HEAD** (`ExportTokenServiceTest.java:40`, `git blame` : ligne jamais modifiée
+depuis son commit d'introduction). Cela contredit la règle écrite en tête de `.gitleaksignore`
+lui-même : « NE PAS ajouter ici une occurrence encore présente au HEAD ».
+
+La constante s'appelle `SECRET`, pas `EXPORT_TOKEN_SECRET` : l'allowlist durable, qui filtre par
+**nom de clé**, ne la couvrait pas. Mode d'échec **discret plutôt que bruyant** — la ligne n'ayant
+jamais été retouchée, l'empreinte restait valide indéfiniment, donc le masquage devenait
+**permanent** au lieu de rougir au premier reformatage. Risque intrinsèque faible ici (valeur
+auto-marquée `test-only-insecure`), mais le **mécanisme** était démontré cassé.
+
+Correction : exclusion durable dans `.gitleaks.toml` (bloc 3), ancrée sur le marqueur
+`test-only-insecure` de la valeur (en base64) **et** sur ce seul fichier, `condition = "AND"`.
+Vérifié par le lead dans les deux sens après correction :
+- dépôt complet → **772 commits, 0 détection, exit 0**
+- même valeur dans `application-prod.properties` → **détectée** (`generic-api-key`)
+- clé Stripe dans `ExportTokenServiceTest.java` → **détectée** (`stripe-access-token`)
+
+Les 5 autres empreintes du groupe `jwt.secret=` ont été vérifiées **absentes du HEAD**.
+
+### `[OK]` — chacun appuyé sur un test exécuté
+
+- `condition = "AND"` prouvé indispensable : la variante `"OR"` rejouée rend **invisible** un secret
+  posé hors des chemins listés (0 leak au lieu de 1).
+- Blanchiment scopé par nom, pas par fichier : une clé Stripe dans `.env.example` (chemin
+  allowlisté) reste détectée.
+- Exclusion PEM : une vraie clé privée collée dans `JwtServiceRs256Test.java` — le fichier même de
+  l'exclusion — reste détectée. Seul le littéral d'armure Java est blanchi.
+- Somme SHA-256 du binaire gitleaks 8.30.1 **recalculée depuis GitHub** et conforme à
+  `GITLEAKS_SHA256` du workflow : ce n'est pas un hash auto-référentiel.
+- Angle mort `DB_PASSWORD` confirmé par test (`10 caractères alpha` → 0 détection) et correctement
+  documenté, pas dissimulé.
+- Sûreté du job : `permissions: contents: read` hérité, pas de `pull_request_target`, aucun
+  `secrets.*` référencé, aucun `upload-artifact`, `--redact` présent, `persist-credentials: false`.
+
+### `[NON TESTÉ]` assumé
+Épinglage SHA des actions tierces (`checkout`, `setup-java`, `setup-node`, `trivy-action`) non
+confronté aux tags officiels. Priorité faible en l'absence totale de secrets Actions.
+
+## Review batch — `reviewer`, sur le diff complet
+
+Spawné par le lead. **Aucun `[CRITIQUE]`.**
+
+- `[MAJEUR]` sur la portée de l'exclusion PEM : demandait une contre-épreuve plutôt qu'il ne
+  constatait un défaut. **Tranché par le lead**, dans des dépôts jetables — littéral d'armure seul
+  → 0 détection exit 0 ; vraie clé PEM RSA-2048 dans ce **même** fichier exclu → détectée exit 1 ;
+  clé PEM dans un fichier quelconque → détectée. **Aucun défaut.**
+- `[MINEUR]` limite « imports mono-ligne » du préflight #308 → **traité**, écrit dans le README.
+- `[MINEUR]` `secret-scan` pas encore requis → **follow-up**, dépend d'un premier run CI vert
+  (désormais obtenu).
+- `[OK]` : job `secret-scan`, empreintes `.gitleaksignore`, bump `nanoid`, préflight #308,
+  cohérence README/code.
+
+## Exécution des suites — pas de `test-runner`, écart assumé
+
+**Aucun subagent `test-runner` n'a été spawné pour ce sprint.** Les suites ont été exécutées
+directement, avec lecture des **codes de sortie réels** via `rtk proxy` (`PIT-S45-003`) :
+
+- par l'agent de #422 : frontend 95 fichiers / 888 tests exit 0 · `build`/`typecheck`/`lint` exit 0
+  · **E2E 169 passed / 0 failed / 8 skipped exit 0**
+- re-mesuré par le lead après la reprise de #308 : frontend **95 fichiers / 888 tests exit 0**,
+  chiffre identique — c'est ce qui permet d'affirmer que #308 n'a rien régressé.
+
+Justification de l'écart : la suite frontend tient en ~20 s et 888 tests, sous les seuils qui
+motivent l'isolation d'un `test-runner` (>500 tests **et** sortie volumineuse). Le risque que le
+protocole veut couvrir — un rapport de test faux mais plausible, `PIT-S53-006` — a été traité
+autrement : chaque chiffre a été re-mesuré depuis le worktree, et le cwd vérifié.
+
+La suite **backend n'a pas été rejouée en local** : zéro fichier `backend/**` au diff. Le job CI
+requis `backend` l'a couverte sur la PR #432 (**pass en 1 min 11**).
+
+## Résultat CI final — PR #432, 7/7 verts au premier run
+
+`secret-scan` 8 s · `ai-env-packs` 10 s · **`security` 39 s** · `flyway-smoke` 51 s ·
+`backend` 1 min 11 · `frontend` 2 min 26 · `e2e` 6 min 39.
+
+Le job `security` était rouge sur **toutes** les PR du dépôt avant ce sprint.
+
+STATUS: COMPLETED

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11119,9 +11119,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/scripts/test-quiet.sh
+++ b/scripts/test-quiet.sh
@@ -86,6 +86,111 @@ run_backend() {
   return 0
 }
 
+# --- Préflight frontend (#308) -----------------------------------------------
+# Mode d'échec visé : `node_modules` absent ou incomplet dans le répertoire
+# RÉELLEMENT testé. Le symptôme brut est trompeur — la suite
+# src/__tests__/console-error-guard.test.ts charge la config ESLint réelle
+# (`new ESLint().calculateConfigForFile`), donc exécute les imports de
+# frontend/eslint.config.mjs ; un plugin manquant y produit
+#   Error: Cannot find package 'eslint-plugin-storybook' imported from …
+# qui se lit comme une régression de la garde anti-fuite credentials #160/#258
+# alors que seul l'environnement est en cause. Cas déjà survenu deux fois
+# (PIT-S41-004, PIT-S53-006 : rapport d'agent entièrement faux mais plausible).
+# On échoue donc AVANT vitest, avec le diagnostic et le correctif.
+frontend_env_hint() {
+  cat >&2 <<EOF
+  ─────────────────────────────────────────────────────────────────────────────
+  Ce n'est PAS une régression du code testé : l'environnement Node du
+  répertoire ci-dessous est absent ou incomplet.
+    répertoire testé : ${FRONTEND_DIR}
+    script exécuté   : ${SCRIPT_DIR}/test-quiet.sh  (les chemins sont résolus
+                       depuis la position du script, jamais depuis le cwd)
+  Correctif :
+    ( cd "${FRONTEND_DIR}" && npm ci )
+  Chaque worktree de sprint (.claude/worktrees/…) a son PROPRE node_modules :
+  lancer ce script depuis le dépôt principal ne teste PAS le code du worktree,
+  et inversement. Vérifier le dépôt visé :
+    /usr/bin/git -C "${REPO_ROOT}" rev-parse --show-toplevel
+    /usr/bin/git -C "${REPO_ROOT}" branch --show-current
+  Approvisionnement automatique de node_modules dans les worktrees : issue #272
+  (hors périmètre de ce préflight, qui se contente de nommer le problème).
+  ─────────────────────────────────────────────────────────────────────────────
+EOF
+}
+
+frontend_preflight() {
+  if [ ! -d "${FRONTEND_DIR}/node_modules" ]; then
+    echo "✗ Frontend : ${FRONTEND_DIR}/node_modules est absent — dépendances jamais installées ici." >&2
+    frontend_env_hint
+    return 3
+  fi
+  # Répertoire présent mais vide (symlink cassé, install interrompue) : même cause.
+  if [ -z "$(ls -A "${FRONTEND_DIR}/node_modules" 2>/dev/null)" ]; then
+    echo "✗ Frontend : ${FRONTEND_DIR}/node_modules existe mais est VIDE." >&2
+    frontend_env_hint
+    return 3
+  fi
+
+  if ! command -v node >/dev/null 2>&1; then
+    echo "✗ Frontend : 'node' introuvable dans le PATH — impossible de lancer Vitest." >&2
+    return 127
+  fi
+
+  # Résolvabilité des paquets importés par eslint.config.mjs. Limites assumées :
+  # ne couvre QUE les imports mono-ligne de ce seul fichier (un import multi-ligne
+  # ou un `require()` dynamique passe sous le radar), et ne valide pas le reste de
+  # l'arbre de dépendances — c'est un détecteur du cas de figure documenté
+  # ci-dessus, pas une vérification d'intégrité de node_modules.
+  local missing=""
+  local probe_status=0
+  missing="$(PREFLIGHT_FRONTEND_DIR="${FRONTEND_DIR}" node - <<'PREFLIGHT_JS'
+const fs = require('fs')
+const path = require('path')
+const { createRequire } = require('module')
+
+const dir = process.env.PREFLIGHT_FRONTEND_DIR
+const cfgPath = path.join(dir, 'eslint.config.mjs')
+if (!fs.existsSync(cfgPath)) process.exit(0)
+
+const src = fs.readFileSync(cfgPath, 'utf8')
+const specs = new Set()
+const importRe = /^\s*import\s[^'"]*['"]([^'"]+)['"]/gm
+let m
+while ((m = importRe.exec(src)) !== null) specs.add(m[1])
+
+const req = createRequire(path.join(dir, '__preflight__.cjs'))
+const missing = []
+for (const spec of specs) {
+  if (spec.startsWith('.') || spec.startsWith('/') || spec.startsWith('node:')) continue
+  try {
+    req.resolve(spec)
+  } catch (err) {
+    // Seul un paquet INTROUVABLE compte. Un paquet présent mais non exposé en
+    // CJS échoue avec ERR_PACKAGE_PATH_NOT_EXPORTED : ce n'est pas un manque.
+    if (err.code === 'MODULE_NOT_FOUND' || err.code === 'ERR_MODULE_NOT_FOUND') missing.push(spec)
+  }
+}
+process.stdout.write(missing.join(' '))
+PREFLIGHT_JS
+  )" || probe_status=$?
+
+  if [ "${probe_status}" -ne 0 ]; then
+    # Le préflight ne doit jamais empêcher de lancer les tests : on prévient et on passe.
+    echo "⚠ Frontend : préflight de résolution non concluant (exit ${probe_status}) — poursuite vers Vitest." >&2
+    return 0
+  fi
+
+  if [ -n "${missing}" ]; then
+    echo "✗ Frontend : paquet(s) importé(s) par eslint.config.mjs non résolvable(s) : ${missing}" >&2
+    echo "  Sans ce préflight, le symptôme est \"Cannot find package …\" dans" >&2
+    echo "  src/__tests__/console-error-guard.test.ts (il charge la config ESLint réelle)," >&2
+    echo "  ce qui se lit à tort comme une régression de la garde console.error #160/#258." >&2
+    frontend_env_hint
+    return 3
+  fi
+  return 0
+}
+
 # --- Frontend unitaires : Vitest ("test" = "vitest run") ---------------------
 run_frontend() {
   # Suite unitaire Vitest. Skip explicite si aucun script "test" (plutôt qu'un
@@ -93,6 +198,13 @@ run_frontend() {
   # (critère #133).
   if [ -f "${FRONTEND_DIR}/package.json" ] \
      && grep -qE '"test"[[:space:]]*:' "${FRONTEND_DIR}/package.json"; then
+    # #308 — échouer avec un diagnostic actionnable plutôt que de laisser Vitest
+    # cracher un « Cannot find package » qui accuse le code.
+    local pre=0
+    frontend_preflight || pre=$?
+    if [ "${pre}" -ne 0 ]; then
+      return "${pre}"
+    fi
     echo "▶ Frontend (unitaires) : npm test  (vitest run, cwd=frontend)"
     local status=0
     ( cd "${FRONTEND_DIR}" && npm test --silent ) || status=$?


### PR DESCRIPTION
## Objectif

Rendre le signal CI `security` exploitable — et, tant qu'à toucher à la CI, poser le garde-fou qui
manquait sur un dépôt public, et rendre lisible un faux échec de tests qui a déjà produit un
rapport entièrement faux.

Milestone **Sprint 60** (#61). Trois issues, huit commits.

## Issues traitées

| # | Titre | Résultat |
|---|---|---|
| #422 | `nanoid` < 3.3.18, vulnérabilité HIGH en dépendance de production | `nanoid` 3.3.16 → 3.3.18, `npm audit --omit=dev --audit-level=high` passe de exit 1 à **exit 0** |
| #362 | Scan de secrets en CI | job dédié `secret-scan` (gitleaks 8.30.1, binaire épinglé + SHA-256 vérifié), sans aucune dépendance à un secret Actions |
| #308 | Régulariser la dev-dep `eslint-plugin-storybook` | préflight `node_modules` dans `test-quiet.sh` : échec en **exit 3** avec diagnostic actionnable, avant Vitest |

## Changements clés

- **`.github/workflows/ci.yml`** — job `secret-scan` sur `pull_request` **et** `push`, scan de
  l'historique atteignable depuis `HEAD` (le checkout PR étant le commit de fusion, le diff est
  couvert *a fortiori* — pas de plomberie `base..head` ni son échec silencieux). Binaire téléchargé
  et vérifié par SHA-256, `permissions` non élargies, aucun `secrets.*`, aucun artefact uploadé.
- **`.gitleaks.toml` / `.gitleaksignore`** — exclusions à deux étages : durables pour les valeurs
  jetables assumées, empreintes épinglées au commit pour l'historique déjà exposé (immuable).
  Chaque exclusion est adossée à un § de `docs/memory/audits/secret-exposure-audit.md`.
- **`frontend/package-lock.json`** — bump minimal, **aucune cascade** (3 insertions / 3 suppressions).
- **`scripts/test-quiet.sh`** — préflight de résolution des imports de `eslint.config.mjs`.
- **`README.md`** — piège 4 (« `node_modules` est propre à chaque copie de travail, et son absence
  ment sur la cause ») + inventaire des jobs CI remis à jour.

## Règles métier impactées

**Aucune.** Sprint entièrement outillage / CI / dépendances. Zéro fichier `backend/**`, zéro
migration, zéro `.tsx`.

## Tests

Chiffres mesurés depuis le worktree `sprint/60`, codes de sortie réels lus via `rtk proxy`.

- Frontend : **95 fichiers / 888 tests, exit 0**
- E2E Playwright : **169 passed / 0 failed / 8 skipped (177), exit 0**, 1,8 min
- `npm run build` · `npm run typecheck` · `npm run lint` : exit 0 chacun
- `npm audit --omit=dev --audit-level=high` : **exit 0**
- `scripts/test-quiet.sh` : scope nominal exit 0, scope inconnu exit 2, `bash -n` exit 0
- Gitleaks sur le dépôt complet : **772 commits, 0 détection, exit 0** (937 ms)

**Backend non rejoué en local** : aucun fichier `backend/**` au diff. Le job requis `backend` le
couvre sur cette PR. Omission assumée et bornée.

Audit détaillé : `docs/memory/audits/sprint-60-test-coverage.md`.

## Preuves que les garde-fous ne sont pas décoratifs

Un job de sécurité qui ne détecte rien est pire qu'aucun job. Chaque garde-fou a été déclenché pour
de vrai, dans des dépôts jetables **hors du dépôt** :

- clé AWS + clé Stripe plantées → **2 détections, exit 1** ; clé Brevo `xkeysib-` → **1 détection**
- vraie clé PEM RSA-2048 dans le fichier de test **explicitement exclu** → **détectée** ; le seul
  littéral d'armure Java dans ce même fichier → non détecté. L'exclusion est bien restreinte à la ligne
- `condition = "AND"` prouvé indispensable : la variante `"OR"` rejouée rend invisible un secret
  posé hors des chemins listés
- préflight #308 : plugin rendu non résolvable → **exit 3**, message actionnable, Vitest jamais lancé

## Défaut trouvé et corrigé pendant la revue

`.gitleaksignore` épinglait une empreinte sur un fixture **encore présent au `HEAD`**, ce que la
règle écrite en tête de ce même fichier interdit. Le mode d'échec était discret : la ligne n'ayant
jamais été retouchée, l'empreinte restait valide indéfiniment — le masquage devenait **permanent**
au lieu de rougir au premier reformatage. Remplacée (`bdf6671`) par une exclusion durable ancrée sur
le marqueur `test-only-insecure` de la valeur *et* sur ce seul fichier, vérifiée dans les deux sens.

Review batch : aucun `[CRITIQUE]`. Le `[MAJEUR]` du reviewer demandait une contre-épreuve, exécutée
ci-dessus, sans défaut.

## Limites connues — à lire avant de fusionner

1. **Le job `secret-scan` n'a jamais tourné sur un runner GitHub.** Téléchargement du binaire et
   `sudo install` non exercés localement. **Premier run réel à surveiller sur cette PR.**
2. **Angle mort mesuré** : gitleaks ne détecte **pas** le `DB_PASSWORD` historique (§3.1 de l'audit,
   10 caractères alphabétiques, entropie sous le seuil). Documenté dans `.gitleaks.toml`, pas
   dissimulé. Le job n'est pas un substitut à la revue.
3. **`secret-scan` n'est pas un check requis** — les requis sur `dev` sont `backend`, `frontend`,
   `e2e`, `ai-env-packs`. Le promouvoir après un premier run vert fait l'objet d'un follow-up ;
   sans cela le garde-fou reste décoratif.
4. Le préflight #308 ne lit que les `import` **mono-ligne** de `eslint.config.mjs` ; un import
   multi-ligne ou dynamique le contournerait. Écrit dans le README.
5. Branches non exercées du préflight : `node_modules` totalement absent, et `node_modules` vide.
   Le code les traite, seul le cas « paquet manquant » a été déclenché réellement.

## Écart de piste technique (#422)

`npm audit fix` — commande prescrite par l'issue et annoncée comme « confirmée suffisante » —
**échoue sur ce dépôt** : `Unable to resolve reference $postcss`, dû à
`overrides: { "postcss": "$postcss" }`. Le bump a été obtenu par `npm update nanoid`, dans la plage
`^3.3.16` exigée par postcss 8.5.23 : ni majeur, ni cascade.

## Écarts au protocole `/sprint`, assumés

- Sprint **jamais passé par `/sprint plan`** : aucun mini-plan architecte, plans d'implémentation
  écrits par le lead depuis les pistes techniques des issues, matrice de conflits vérifiée à la main.
- **Context-pack réduit délibérément** : `inject-pack.sh` produisait 77 Ko par briefing dont 44 Ko
  de pièges de mise en page sans rapport ; remplacé par un pack `tooling` de 23 Ko, même logique de
  classification que `gen-pit-packs.sh`.
- **#308 terminée par le lead** : l'agent a calé (watchdog 600 s) après avoir écrit et câblé le
  préflight, mais **avant de restaurer** `frontend/node_modules/eslint-plugin-storybook` qu'il avait
  déplacé pour son test — le worktree était cassé alors que `git status` était propre. Le lead a
  restauré, repris son diff sans en réécrire une ligne, et produit la preuve, la doc et l'artefact.
  Consigné en tête de `issue-308-done.md`.

Cohésion : les trois issues partagent le même domaine (outillage / CI / dépendances) et des
périmètres de fichiers disjoints, ce qui a permis d'exécuter #422 et #362 en parallèle.
